### PR TITLE
feat(bfdr): add support for BFDR mother and father education level plus property helpers

### DIFF
--- a/projects/BFDR.CLI/Program.cs
+++ b/projects/BFDR.CLI/Program.cs
@@ -119,6 +119,11 @@ namespace BFDR.CLI
                 birthRecord.FatherBirthYear = 1990;
                 birthRecord.FatherDateOfBirth = "1990-09-21";
 
+                birthRecord.MotherEducationLevelHelper = VR.ValueSets.EducationLevel.Doctoral_Or_Post_Graduate_Education;
+                birthRecord.MotherEducationLevelEditFlagHelper = VR.ValueSets.EditBypass01234.Edit_Passed;
+                birthRecord.FatherEducationLevelHelper = VR.ValueSets.EducationLevel.Bachelors_Degree;
+                birthRecord.FatherEducationLevelEditFlagHelper = VR.ValueSets.EditBypass01234.Edit_Failed_Data_Queried_But_Not_Verified;
+
                 // TODO: add these back once correct codesystems are used for the component 
                 // Ethnicity
                 // birthRecord.MotherEthnicity3Helper = VR.ValueSets.HispanicNoUnknown.Yes;

--- a/projects/BFDR.Tests/BirthRecord_Should.cs
+++ b/projects/BFDR.Tests/BirthRecord_Should.cs
@@ -1374,6 +1374,47 @@ namespace BFDR.Tests
       Assert.False(FakeBirthRecord.ArtificialInsemination);
     }
 
+        [Fact]
+        public void TestPropertiesWithHelpers()
+        {
+            // Test all properties that have helpers
+            // TODO: Move some existing property tests here
+            TestCodedPropertyWithHelper("MotherEducationLevel", VR.ValueSets.EducationLevel.Codes);
+            TestCodedPropertyWithHelper("MotherEducationLevelEditFlag", VR.ValueSets.EditBypass01234.Codes);
+            TestCodedPropertyWithHelper("FatherEducationLevel", VR.ValueSets.EducationLevel.Codes);
+            TestCodedPropertyWithHelper("FatherEducationLevelEditFlag", VR.ValueSets.EditBypass01234.Codes);
+        }
+
+        // Given a property name that takes a code and has a helper property, and a list of codes to test,
+        // test setting and getting all the valid codes
+        private void TestCodedPropertyWithHelper(string propertyName, string[,] codes)
+        {
+            // Helper name is just an extension of the property name
+            string helperName = propertyName + "Helper";
+            BirthRecord record = new BirthRecord();
+            // Default should be null
+            Assert.Equal("", ((Dictionary<string, string>)record.GetType().GetProperty(propertyName).GetValue(record))["code"]);
+            Assert.Null(record.GetType().GetProperty(helperName).GetValue(record));
+            for (int i = 0; i < codes.GetLength(0); i++)
+            {
+                // Set to the code via the helper and make sure the get returns the same code for both the helper and the base
+                // property along with the appropriate system and display values
+                record.GetType().GetProperty(helperName).SetValue(record, codes[i, 0]);
+                Assert.Equal(codes[i, 0], record.GetType().GetProperty(helperName).GetValue(record));
+                Assert.Equal(codes[i, 0], ((Dictionary<string, string>)record.GetType().GetProperty(propertyName).GetValue(record))["code"]);
+                Assert.Equal(codes[i, 1], ((Dictionary<string, string>)record.GetType().GetProperty(propertyName).GetValue(record))["display"]);
+                Assert.Equal(codes[i, 2], ((Dictionary<string, string>)record.GetType().GetProperty(propertyName).GetValue(record))["system"]);
+                // Reset it and then set the value via the base property coded value and make sure the correct values are present
+                record.GetType().GetProperty(propertyName).SetValue(record, null);
+                Assert.Null(record.GetType().GetProperty(helperName).GetValue(record));
+                Dictionary<string, string> dict = new Dictionary<string, string>();
+                dict.Add("code", codes[i, 0]);
+                record.GetType().GetProperty(propertyName).SetValue(record, dict);
+                Assert.Equal(codes[i, 0], record.GetType().GetProperty(helperName).GetValue(record));
+                Assert.Equal(codes[i, 0], ((Dictionary<string, string>)record.GetType().GetProperty(propertyName).GetValue(record))["code"]);
+            }
+        }
+
     private string FixturePath(string filePath)
         {
             if (Path.IsPathRooted(filePath))

--- a/projects/BFDR/BirthRecord.xml
+++ b/projects/BFDR/BirthRecord.xml
@@ -974,7 +974,7 @@
             <para>ethnicity.Add("display", "Yes");</para>
             <para>ExampleBirthRecord.MotherEthnicity1 = ethnicity;</para>
             <para>// Getter:</para>
-            <para>Console.WriteLine($"Mother Ethnicity: {ExampleBirthRecord.MotherEthnicity1['display']}");</para>
+            <para>Console.WriteLine($"Mother Ethnicity: {ExampleBirthRecord.MotherEthnicity1["display"]}");</para>
             </example>
         </member>
         <member name="P:BFDR.BirthRecord.MotherEthnicity1Helper">
@@ -1002,7 +1002,7 @@
             <para>ethnicity.Add("display", "Yes");</para>
             <para>ExampleBirthRecord.MotherEthnicity2 = ethnicity;</para>
             <para>// Getter:</para>
-            <para>Console.WriteLine($"Mother Ethnicity: {ExampleBirthRecord.MotherEthnicity2['display']}");</para>
+            <para>Console.WriteLine($"Mother Ethnicity: {ExampleBirthRecord.MotherEthnicity2["display"]}");</para>
             </example>
         </member>
         <member name="P:BFDR.BirthRecord.MotherEthnicity2Helper">
@@ -1030,7 +1030,7 @@
             <para>ethnicity.Add("display", "Yes");</para>
             <para>ExampleBirthRecord.MotherEthnicity3 = ethnicity;</para>
             <para>// Getter:</para>
-            <para>Console.WriteLine($"Mother Ethnicity: {ExampleBirthRecord.MotherEthnicity3['display']}");</para>
+            <para>Console.WriteLine($"Mother Ethnicity: {ExampleBirthRecord.MotherEthnicity3["display"]}");</para>
             </example>
         </member>
         <member name="P:BFDR.BirthRecord.MotherEthnicity3Helper">
@@ -1058,7 +1058,7 @@
             <para>ethnicity.Add("display", "Yes");</para>
             <para>ExampleBirthRecord.MotherEthnicity3 = ethnicity;</para>
             <para>// Getter:</para>
-            <para>Console.WriteLine($"Mother Ethnicity: {ExampleBirthRecord.MotherEthnicity4['display']}");</para>
+            <para>Console.WriteLine($"Mother Ethnicity: {ExampleBirthRecord.MotherEthnicity4["display"]}");</para>
             </example>
         </member>
         <member name="P:BFDR.BirthRecord.MotherEthnicity4Helper">
@@ -1082,7 +1082,7 @@
             <para>// Setter:</para>
             <para>ExampleBirthRecord.MotherEthnicityLiteral = ethnicity;</para>
             <para>// Getter:</para>
-            <para>Console.WriteLine($"Ethnicity: {ExampleBirthRecord.MotherEthnicityLiteral['display']}");</para>
+            <para>Console.WriteLine($"Ethnicity: {ExampleBirthRecord.MotherEthnicityLiteral["display"]}");</para>
             </example>
         </member>
         <member name="P:BFDR.BirthRecord.MotherRace">
@@ -1111,7 +1111,7 @@
             <para>ethnicity.Add("display", "Yes");</para>
             <para>ExampleBirthRecord.FatherEthnicity1 = ethnicity;</para>
             <para>// Getter:</para>
-            <para>Console.WriteLine($"Father Ethnicity: {ExampleBirthRecord.FatherEthnicity1['display']}");</para>
+            <para>Console.WriteLine($"Father Ethnicity: {ExampleBirthRecord.FatherEthnicity1["display"]}");</para>
             </example>
         </member>
         <member name="P:BFDR.BirthRecord.FatherEthnicity1Helper">
@@ -1139,7 +1139,7 @@
             <para>ethnicity.Add("display", "Yes");</para>
             <para>ExampleBirthRecord.FatherEthnicity1 = ethnicity;</para>
             <para>// Getter:</para>
-            <para>Console.WriteLine($"Father Ethnicity: {ExampleBirthRecord.FatherEthnicity2['display']}");</para>
+            <para>Console.WriteLine($"Father Ethnicity: {ExampleBirthRecord.FatherEthnicity2["display"]}");</para>
             </example>
         </member>
         <member name="P:BFDR.BirthRecord.FatherEthnicity2Helper">
@@ -1167,7 +1167,7 @@
             <para>ethnicity.Add("display", "Yes");</para>
             <para>ExampleBirthRecord.FatherEthnicity3 = ethnicity;</para>
             <para>// Getter:</para>
-            <para>Console.WriteLine($"Father Ethnicity: {ExampleBirthRecord.FatherEthnicity3['display']}");</para>
+            <para>Console.WriteLine($"Father Ethnicity: {ExampleBirthRecord.FatherEthnicity3["display"]}");</para>
             </example>
         </member>
         <member name="P:BFDR.BirthRecord.FatherEthnicity3Helper">
@@ -1195,7 +1195,7 @@
             <para>ethnicity.Add("display", "Yes");</para>
             <para>ExampleBirthRecord.FatherEthnicity4 = ethnicity;</para>
             <para>// Getter:</para>
-            <para>Console.WriteLine($"Father Ethnicity: {ExampleBirthRecord.FatherEthnicity4['display']}");</para>
+            <para>Console.WriteLine($"Father Ethnicity: {ExampleBirthRecord.FatherEthnicity4["display"]}");</para>
             </example>
         </member>
         <member name="P:BFDR.BirthRecord.FatherEthnicity4Helper">
@@ -1219,7 +1219,7 @@
             <para>// Setter:</para>
             <para>ExampleBirthRecord.EthnicityLiteral = ethnicity;</para>
             <para>// Getter:</para>
-            <para>Console.WriteLine($"Ethnicity: {ExampleBirthRecord.EthnicityLiteral['display']}");</para>
+            <para>Console.WriteLine($"Ethnicity: {ExampleBirthRecord.EthnicityLiteral["display"]}");</para>
             </example>
         </member>
         <member name="P:BFDR.BirthRecord.FatherRace">
@@ -1486,6 +1486,101 @@
             <para>ExampleBirthRecord.FatherIndustry = "public health";</para>
             <para>// Getter:</para>
             <para>Console.WriteLine($"Father's Industry: {ExampleBirthRecord.FatherIndustry}");</para>
+            </example>
+        </member>
+        <!-- Badly formed XML comment ignored for member "P:BFDR.BirthRecord.MotherEducationLevel" -->
+        <member name="P:BFDR.BirthRecord.MotherEducationLevelHelper">
+            <summary>Mother's Education Level Helper</summary>
+            <value>Mother's Education Level.</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.MotherEducationLevelHelper = VR.ValueSets.EducationLevel.Bachelors_Degree;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Mother's Education Level: {ExampleBirthRecord.EducationLevelHelper}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.MotherEducationLevelEditFlag">
+            <summary>Mother's Education Level Edit Flag.</summary>
+            <value>the mother's education level edit flag. A Dictionary representing a code, containing the following key/value pairs:
+            <para>"code" - the code</para>
+            <para>"system" - the code system this code belongs to</para>
+            <para>"display" - a human readable meaning of the code</para>
+            </value>
+            <example>
+            <para>// Setter:</para>
+            <para>Dictionary&lt;string, string&gt; elevel = new Dictionary&lt;string, string&gt;();</para>
+            <para>elevel.Add("code", "0");</para>
+            <para>elevel.Add("system", VR.CodeSystems.BypassEditFlag);</para>
+            <para>elevel.Add("display", "Edit Passed");</para>
+            <para>ExampleBirthRecord.MotherEducationLevelEditFlag = elevel;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Mother's Education Level Edit Flag: {ExampleBirthRecord.EducationLevelEditFlag["display"]}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.MotherEducationLevelEditFlagHelper">
+            <summary>Mother's Education Level Edit Flag Helper</summary>
+            <value>Mother's Education Level Edit Flag.</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.MotherEducationLevelEditFlag = VRDR.ValueSets.EditBypass01234.EditPassed;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Mother's Education Level Edit Flag: {ExampleBirthRecord.EducationLevelHelperEditFlag}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.FatherEducationLevel">
+            <summary>Father's Education Level.</summary>
+            <value>the father's education level. A Dictionary representing a code, containing the following key/value pairs:
+            <para>"code" - the code</para>
+            <para>"system" - the code system this code belongs to</para>
+            <para>"display" - a human readable meaning of the code</para>
+            </value>
+            <example>
+            <para>// Setter:</para>
+            <para>Dictionary&lt;string, string&gt; elevel = new Dictionary&lt;string, string&gt;();</para>
+            <para>elevel.Add("code", "BA");</para>
+            <para>elevel.Add("system", VR.CodeSystems.EducationLevel);</para>
+            <para>elevel.Add("display", "Bachelor’s Degree");</para>
+            <para>ExampleBirthRecord.FatherEducationLevel = elevel;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Father's Education Level: {ExampleBirthRecord.FatherEducationLevel["display"]}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.FatherEducationLevelHelper">
+            <summary>Father's Education Level Helper</summary>
+            <value>Father's Education Level.</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.FatherEducationLevelHelper = VR.ValueSets.EducationLevel.Bachelors_Degree;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Father's Education Level: {ExampleBirthRecord.EducationLevelHelper}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.FatherEducationLevelEditFlag">
+            <summary>Father's Education Level Edit Flag.</summary>
+            <value>the father's education level edit flag. A Dictionary representing a code, containing the following key/value pairs:
+            <para>"code" - the code</para>
+            <para>"system" - the code system this code belongs to</para>
+            <para>"display" - a human readable meaning of the code</para>
+            </value>
+            <example>
+            <para>// Setter:</para>
+            <para>Dictionary&lt;string, string&gt; elevel = new Dictionary&lt;string, string&gt;();</para>
+            <para>elevel.Add("code", "0");</para>
+            <para>elevel.Add("system", VR.CodeSystems.BypassEditFlag);</para>
+            <para>elevel.Add("display", "Edit Passed");</para>
+            <para>ExampleBirthRecord.FatherEducationLevelEditFlag = elevel;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Father's Education Level Edit Flag: {ExampleBirthRecord.EducationLevelEditFlag["display"]}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.FatherEducationLevelEditFlagHelper">
+            <summary>Father's Education Level Edit Flag Helper</summary>
+            <value>Father's Education Level Edit Flag.</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.FatherEducationLevelEditFlag = VRDR.ValueSets.EditBypass01234.EditPassed;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Father's Education Level Edit Flag: {ExampleBirthRecord.EducationLevelHelperEditFlag}");</para>
             </example>
         </member>
         <member name="T:BFDR.FHIRSubject">

--- a/projects/BFDR/BirthRecord_constructors.cs
+++ b/projects/BFDR/BirthRecord_constructors.cs
@@ -142,6 +142,8 @@ namespace BFDR
             // Make sure to include the base identifiers, including certificate number and auxiliary state IDs
             dccBundle.Identifier = Bundle.Identifier;
             // TODO: Here we'd determine what resources to add to this particular bundle, see VRDR for example
+            // NOTE: If we want to put observations in the coded content bundle that don't have references we'll
+            // need to move them over by grabbing them by the observation code
             return dccBundle;
         }
 

--- a/projects/BFDR/BirthRecord_submissionProperties.cs
+++ b/projects/BFDR/BirthRecord_submissionProperties.cs
@@ -4721,7 +4721,7 @@ namespace BFDR
         public Dictionary<string, string> MotherEducationLevel
         {
             get => GetObservationValue("57712-2");
-            set => SetObservationValue(value, "57712-2", CodeSystems.LOINC, "Highest level of education Mother", VR.ProfileURL.EducationLevel, NEWBORN_INFORMATION_SECTION);
+            set => SetObservationValue(value, "57712-2", CodeSystems.LOINC, "Highest level of education Mother", VR.ProfileURL.EducationLevel, MOTHER_INFORMATION_SECTION);
         }
 
         /// <summary>Mother's Education Level Helper</summary>
@@ -4764,9 +4764,8 @@ namespace BFDR
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='57712-2')", "")]
         public Dictionary<string, string> MotherEducationLevelEditFlag
         {
-            // TODO: Replace URL string with VR.ExtensionURL.BypassEditFlag once VR.ExtensionURLs are static again
-            get => GetObservationValue("57712-2", "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag");
-            set => SetObservationValue(value, "57712-2", CodeSystems.LOINC, "Highest level of education Mother", VR.ProfileURL.EducationLevel, NEWBORN_INFORMATION_SECTION, "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag");
+            get => GetObservationValue("57712-2", VRExtensionURLs.BypassEditFlag);
+            set => SetObservationValue(value, "57712-2", CodeSystems.LOINC, "Highest level of education Mother", VR.ProfileURL.EducationLevel, MOTHER_INFORMATION_SECTION, "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag");
         }
 
         /// <summary>Mother's Education Level Edit Flag Helper</summary>
@@ -4810,7 +4809,7 @@ namespace BFDR
         public Dictionary<string, string> FatherEducationLevel
         {
             get => GetObservationValue("87300-0");
-            set => SetObservationValue(value, "87300-0", CodeSystems.LOINC, "Highest level of education Father", VR.ProfileURL.EducationLevel, NEWBORN_INFORMATION_SECTION);
+            set => SetObservationValue(value, "87300-0", CodeSystems.LOINC, "Highest level of education Father", VR.ProfileURL.EducationLevel, FATHER_INFORMATION_SECTION);
         }
 
         /// <summary>Father's Education Level Helper</summary>
@@ -4853,9 +4852,8 @@ namespace BFDR
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='87300-0')", "")]
         public Dictionary<string, string> FatherEducationLevelEditFlag
         {
-            // TODO: Replace URL string with VR.ExtensionURL.BypassEditFlag once VR.ExtensionURLs are static again
-            get => GetObservationValue("87300-0", "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag");
-            set => SetObservationValue(value, "87300-0", CodeSystems.LOINC, "Highest level of education Father", VR.ProfileURL.EducationLevel, NEWBORN_INFORMATION_SECTION, "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag");
+            get => GetObservationValue("87300-0", VRExtensionURLs.BypassEditFlag);
+            set => SetObservationValue(value, "87300-0", CodeSystems.LOINC, "Highest level of education Father", VR.ProfileURL.EducationLevel, FATHER_INFORMATION_SECTION, "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag");
         }
 
         /// <summary>Father's Education Level Edit Flag Helper</summary>

--- a/projects/BFDR/BirthRecord_submissionProperties.cs
+++ b/projects/BFDR/BirthRecord_submissionProperties.cs
@@ -2989,7 +2989,7 @@ namespace BFDR
         /// <para>ethnicity.Add("display", "Yes");</para>
         /// <para>ExampleBirthRecord.MotherEthnicity1 = ethnicity;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Mother Ethnicity: {ExampleBirthRecord.MotherEthnicity1['display']}");</para>
+        /// <para>Console.WriteLine($"Mother Ethnicity: {ExampleBirthRecord.MotherEthnicity1["display"]}");</para>
         /// </example>
         [Property("MotherEthnicity1", Property.Types.Dictionary, "Race and Ethnicity Profiles", "Mother's Ethnicity Hispanic Mexican.", true, VR.IGURL.InputRaceAndEthnicity, false, 34)]
         [PropertyParam("code", "The code used to describe this concept.")]
@@ -3068,7 +3068,7 @@ namespace BFDR
         /// <para>ethnicity.Add("display", "Yes");</para>
         /// <para>ExampleBirthRecord.MotherEthnicity2 = ethnicity;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Mother Ethnicity: {ExampleBirthRecord.MotherEthnicity2['display']}");</para>
+        /// <para>Console.WriteLine($"Mother Ethnicity: {ExampleBirthRecord.MotherEthnicity2["display"]}");</para>
         /// </example>
         [Property("MotherEthnicity2", Property.Types.Dictionary, "Race and Ethnicity Profiles", "Mother's Ethnicity Hispanic Puerto Rican.", true, VR.IGURL.InputRaceAndEthnicity, false, 34)]
         [PropertyParam("code", "The code used to describe this concept.")]
@@ -3147,7 +3147,7 @@ namespace BFDR
         /// <para>ethnicity.Add("display", "Yes");</para>
         /// <para>ExampleBirthRecord.MotherEthnicity3 = ethnicity;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Mother Ethnicity: {ExampleBirthRecord.MotherEthnicity3['display']}");</para>
+        /// <para>Console.WriteLine($"Mother Ethnicity: {ExampleBirthRecord.MotherEthnicity3["display"]}");</para>
         /// </example>
         [Property("MotherEthnicity3", Property.Types.Dictionary, "Race and Ethnicity Profiles", "Mother's Ethnicity Hispanic Cuban.", true, VR.IGURL.InputRaceAndEthnicity, false, 34)]
         [PropertyParam("code", "The code used to describe this concept.")]
@@ -3227,7 +3227,7 @@ namespace BFDR
         /// <para>ethnicity.Add("display", "Yes");</para>
         /// <para>ExampleBirthRecord.MotherEthnicity3 = ethnicity;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Mother Ethnicity: {ExampleBirthRecord.MotherEthnicity4['display']}");</para>
+        /// <para>Console.WriteLine($"Mother Ethnicity: {ExampleBirthRecord.MotherEthnicity4["display"]}");</para>
         /// </example>
         [Property("MotherEthnicity4", Property.Types.Dictionary, "Race and Ethnicity Profiles", "Mother's Ethnicity Hispanic Other.", true, VR.IGURL.InputRaceAndEthnicity, false, 34)]
         [PropertyParam("code", "The code used to describe this concept.")]
@@ -3302,7 +3302,7 @@ namespace BFDR
         /// <para>// Setter:</para>
         /// <para>ExampleBirthRecord.MotherEthnicityLiteral = ethnicity;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Ethnicity: {ExampleBirthRecord.MotherEthnicityLiteral['display']}");</para>
+        /// <para>Console.WriteLine($"Ethnicity: {ExampleBirthRecord.MotherEthnicityLiteral["display"]}");</para>
         /// </example>
         [Property("MotherEthnicityLiteral", Property.Types.String, "Race and Ethnicity Profiles", "Mother's Ethnicity Literal.", true, VR.IGURL.InputRaceAndEthnicity, false, 34)]
         [PropertyParam("ethnicity", "The literal string to describe ethnicity.")]
@@ -3460,7 +3460,7 @@ namespace BFDR
         /// <para>ethnicity.Add("display", "Yes");</para>
         /// <para>ExampleBirthRecord.FatherEthnicity1 = ethnicity;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Father Ethnicity: {ExampleBirthRecord.FatherEthnicity1['display']}");</para>
+        /// <para>Console.WriteLine($"Father Ethnicity: {ExampleBirthRecord.FatherEthnicity1["display"]}");</para>
         /// </example>
         [Property("FatherEthnicity1", Property.Types.Dictionary, "Race and Ethnicity Profiles", "Father's Ethnicity Hispanic Mexican.", true, VR.IGURL.InputRaceAndEthnicity, false, 34)]
         [PropertyParam("code", "The code used to describe this concept.")]
@@ -3539,7 +3539,7 @@ namespace BFDR
         /// <para>ethnicity.Add("display", "Yes");</para>
         /// <para>ExampleBirthRecord.FatherEthnicity1 = ethnicity;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Father Ethnicity: {ExampleBirthRecord.FatherEthnicity2['display']}");</para>
+        /// <para>Console.WriteLine($"Father Ethnicity: {ExampleBirthRecord.FatherEthnicity2["display"]}");</para>
         /// </example>
         [Property("FatherEthnicity2", Property.Types.Dictionary, "Race and Ethnicity Profiles", "Father's Ethnicity Hispanic PuertoRican.", true, VR.IGURL.InputRaceAndEthnicity, false, 34)]
         [PropertyParam("code", "The code used to describe this concept.")]
@@ -3618,7 +3618,7 @@ namespace BFDR
         /// <para>ethnicity.Add("display", "Yes");</para>
         /// <para>ExampleBirthRecord.FatherEthnicity3 = ethnicity;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Father Ethnicity: {ExampleBirthRecord.FatherEthnicity3['display']}");</para>
+        /// <para>Console.WriteLine($"Father Ethnicity: {ExampleBirthRecord.FatherEthnicity3["display"]}");</para>
         /// </example>
         [Property("FatherEthnicity3", Property.Types.Dictionary, "Race and Ethnicity Profiles", "Father's Ethnicity Hispanic Cuban.", true, VR.IGURL.InputRaceAndEthnicity, false, 34)]
         [PropertyParam("code", "The code used to describe this concept.")]
@@ -3698,7 +3698,7 @@ namespace BFDR
         /// <para>ethnicity.Add("display", "Yes");</para>
         /// <para>ExampleBirthRecord.FatherEthnicity4 = ethnicity;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Father Ethnicity: {ExampleBirthRecord.FatherEthnicity4['display']}");</para>
+        /// <para>Console.WriteLine($"Father Ethnicity: {ExampleBirthRecord.FatherEthnicity4["display"]}");</para>
         /// </example>
         [Property("FatherEthnicity4", Property.Types.Dictionary, "Race and Ethnicity Profiles", "Father's Ethnicity Hispanic Other.", true, VR.IGURL.InputRaceAndEthnicity, false, 34)]
         [PropertyParam("code", "The code used to describe this concept.")]
@@ -3773,7 +3773,7 @@ namespace BFDR
         /// <para>// Setter:</para>
         /// <para>ExampleBirthRecord.EthnicityLiteral = ethnicity;</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Ethnicity: {ExampleBirthRecord.EthnicityLiteral['display']}");</para>
+        /// <para>Console.WriteLine($"Ethnicity: {ExampleBirthRecord.EthnicityLiteral["display"]}");</para>
         /// </example>
         [Property("FatherEthnicityLiteral", Property.Types.String, "Race and Ethnicity Profiles", "Father's Ethnicity Literal.", true, VR.IGURL.InputRaceAndEthnicity, false, 34)]
         [PropertyParam("ethnicity", "The literal string to describe ethnicity.")]
@@ -3913,7 +3913,6 @@ namespace BFDR
                     }
                     InputRaceAndEthnicityObsFather.Component.Add(component);
                 }
-
             }
         }
 
@@ -4701,6 +4700,179 @@ namespace BFDR
         {
             get => GetIndustry("FTH");
             set => SetIndustry("FTH", value);
+        }
+
+        /// <summary>Mother's Education Level.</summary>
+        /// <value>the mother's education level. A Dictionary representing a code, containing the following key/value pairs:
+        /// <para>Dictionary&lt;string, string&gt; elevel = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>elevel.Add("code", "BA");</para>
+        /// <para>elevel.Add("system", VR.CodeSystems.EducationLevel);</para>
+        /// <para>elevel.Add("display", "Bachelor’s Degree");</para>
+        /// <para>ExampleBirthRecord.MotherEducationLevel = elevel;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Mother's Education Level: {ExampleBirthRecord.MotherEducationLevel["display"]}");</para>
+        /// </example>
+        [Property("Mother's Education Level", Property.Types.Dictionary, "Education Profiles", "Mother's Education Level.", true, VR.IGURL.EducationLevel, false, 32)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='57712-2').value.coding", "")]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
+        public Dictionary<string, string> MotherEducationLevel
+        {
+            get => GetObservationValue("57712-2");
+            set => SetObservationValue(value, "57712-2", CodeSystems.LOINC, "Highest level of education Mother", VR.ProfileURL.EducationLevel, NEWBORN_INFORMATION_SECTION);
+        }
+
+        /// <summary>Mother's Education Level Helper</summary>
+        /// <value>Mother's Education Level.</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.MotherEducationLevelHelper = VR.ValueSets.EducationLevel.Bachelors_Degree;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Mother's Education Level: {ExampleBirthRecord.EducationLevelHelper}");</para>
+        /// </example>
+        [Property("Mother's Education Level Helper", Property.Types.String, "Education Profiles", "Mother's Education Level.", false, VR.IGURL.EducationLevel, false, 32)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='57712-2').value.coding", "")]
+        public string MotherEducationLevelHelper
+        {
+            get => GetObservationValueHelper();
+            set => SetObservationValueHelper(value, VR.ValueSets.EducationLevel.Codes);
+        }
+
+        /// <summary>Mother's Education Level Edit Flag.</summary>
+        /// <value>the mother's education level edit flag. A Dictionary representing a code, containing the following key/value pairs:
+        /// <para>"code" - the code</para>
+        /// <para>"system" - the code system this code belongs to</para>
+        /// <para>"display" - a human readable meaning of the code</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>Dictionary&lt;string, string&gt; elevel = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>elevel.Add("code", "0");</para>
+        /// <para>elevel.Add("system", VR.CodeSystems.BypassEditFlag);</para>
+        /// <para>elevel.Add("display", "Edit Passed");</para>
+        /// <para>ExampleBirthRecord.MotherEducationLevelEditFlag = elevel;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Mother's Education Level Edit Flag: {ExampleBirthRecord.EducationLevelEditFlag["display"]}");</para>
+        /// </example>
+        [Property("Mother's Education Level Edit Flag", Property.Types.Dictionary, "Education Profiles", "Mother's Education Level Edit Flag.", true, VR.IGURL.EducationLevel, false, 33)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='57712-2')", "")]
+        public Dictionary<string, string> MotherEducationLevelEditFlag
+        {
+            // TODO: Replace URL string with VR.ExtensionURL.BypassEditFlag once VR.ExtensionURLs are static again
+            get => GetObservationValue("57712-2", "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag");
+            set => SetObservationValue(value, "57712-2", CodeSystems.LOINC, "Highest level of education Mother", VR.ProfileURL.EducationLevel, NEWBORN_INFORMATION_SECTION, "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag");
+        }
+
+        /// <summary>Mother's Education Level Edit Flag Helper</summary>
+        /// <value>Mother's Education Level Edit Flag.</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.MotherEducationLevelEditFlag = VRDR.ValueSets.EditBypass01234.EditPassed;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Mother's Education Level Edit Flag: {ExampleBirthRecord.EducationLevelHelperEditFlag}");</para>
+        /// </example>
+        [Property("Education Level Edit Flag Helper", Property.Types.String, "Decedent Demographics", "Mother's Education Level Edit Flag Helper.", false, VR.IGURL.EducationLevel, false, 34)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='57712-2')", "")]
+        public string MotherEducationLevelEditFlagHelper
+        {
+            get => GetObservationValueHelper();
+            set => SetObservationValueHelper(value, VR.ValueSets.EditBypass01234.Codes);
+        }
+
+        /// <summary>Father's Education Level.</summary>
+        /// <value>the father's education level. A Dictionary representing a code, containing the following key/value pairs:
+        /// <para>"code" - the code</para>
+        /// <para>"system" - the code system this code belongs to</para>
+        /// <para>"display" - a human readable meaning of the code</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>Dictionary&lt;string, string&gt; elevel = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>elevel.Add("code", "BA");</para>
+        /// <para>elevel.Add("system", VR.CodeSystems.EducationLevel);</para>
+        /// <para>elevel.Add("display", "Bachelor’s Degree");</para>
+        /// <para>ExampleBirthRecord.FatherEducationLevel = elevel;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Father's Education Level: {ExampleBirthRecord.FatherEducationLevel["display"]}");</para>
+        /// </example>
+        [Property("Father's Education Level", Property.Types.Dictionary, "Education Profiles", "Father's Education Level.", true, VR.IGURL.EducationLevel, false, 78)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='87300-0').value.coding", "")]
+        public Dictionary<string, string> FatherEducationLevel
+        {
+            get => GetObservationValue("87300-0");
+            set => SetObservationValue(value, "87300-0", CodeSystems.LOINC, "Highest level of education Father", VR.ProfileURL.EducationLevel, NEWBORN_INFORMATION_SECTION);
+        }
+
+        /// <summary>Father's Education Level Helper</summary>
+        /// <value>Father's Education Level.</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.FatherEducationLevelHelper = VR.ValueSets.EducationLevel.Bachelors_Degree;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Father's Education Level: {ExampleBirthRecord.EducationLevelHelper}");</para>
+        /// </example>
+        [Property("Father's Education Level Helper", Property.Types.String, "Education Profiles", "Father's Education Level.", false, VR.IGURL.EducationLevel, false, 32)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='87300-0').value.coding", "")]
+        public string FatherEducationLevelHelper
+        {
+            get => GetObservationValueHelper();
+            set => SetObservationValueHelper(value, VR.ValueSets.EducationLevel.Codes);
+        }
+
+        /// <summary>Father's Education Level Edit Flag.</summary>
+        /// <value>the father's education level edit flag. A Dictionary representing a code, containing the following key/value pairs:
+        /// <para>"code" - the code</para>
+        /// <para>"system" - the code system this code belongs to</para>
+        /// <para>"display" - a human readable meaning of the code</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>Dictionary&lt;string, string&gt; elevel = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>elevel.Add("code", "0");</para>
+        /// <para>elevel.Add("system", VR.CodeSystems.BypassEditFlag);</para>
+        /// <para>elevel.Add("display", "Edit Passed");</para>
+        /// <para>ExampleBirthRecord.FatherEducationLevelEditFlag = elevel;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Father's Education Level Edit Flag: {ExampleBirthRecord.EducationLevelEditFlag["display"]}");</para>
+        /// </example>
+        [Property("Father's Education Level Edit Flag", Property.Types.Dictionary, "Education Profiles", "Father's Education Level Edit Flag.", true, VR.IGURL.EducationLevel, false, 33)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='87300-0')", "")]
+        public Dictionary<string, string> FatherEducationLevelEditFlag
+        {
+            // TODO: Replace URL string with VR.ExtensionURL.BypassEditFlag once VR.ExtensionURLs are static again
+            get => GetObservationValue("87300-0", "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag");
+            set => SetObservationValue(value, "87300-0", CodeSystems.LOINC, "Highest level of education Father", VR.ProfileURL.EducationLevel, NEWBORN_INFORMATION_SECTION, "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag");
+        }
+
+        /// <summary>Father's Education Level Edit Flag Helper</summary>
+        /// <value>Father's Education Level Edit Flag.</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.FatherEducationLevelEditFlag = VRDR.ValueSets.EditBypass01234.EditPassed;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Father's Education Level Edit Flag: {ExampleBirthRecord.EducationLevelHelperEditFlag}");</para>
+        /// </example>
+        [Property("Education Level Edit Flag Helper", Property.Types.String, "Decedent Demographics", "Father's Education Level Edit Flag Helper.", false, VR.IGURL.EducationLevel, false, 34)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='87300-0')", "")]
+        public string FatherEducationLevelEditFlagHelper
+        {
+            get => GetObservationValueHelper();
+            set => SetObservationValueHelper(value, VR.ValueSets.EditBypass01234.Codes);
         }
     }
 }

--- a/projects/BFDR/IJENatality.cs
+++ b/projects/BFDR/IJENatality.cs
@@ -668,12 +668,14 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
+                return Get_MappingFHIRToIJE(VR.Mappings.ConceptMapEducationLevelVitalRecords.FHIRToIJE, "MotherEducationLevel", "MEDUC");
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location:
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    Set_MappingIJEToFHIR(VR.Mappings.ConceptMapEducationLevelVitalRecords.IJEToFHIR, "MEDUC", "MotherEducationLevel", value);
+                }
             }
         }
 
@@ -683,12 +685,14 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
+                return Get_MappingFHIRToIJE(VR.Mappings.ConceptMapEditBypass01234VitalRecords.FHIRToIJE, "MotherEducationLevelEditFlag", "MEDUC_BYPASS");
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location:
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    Set_MappingIJEToFHIR(VR.Mappings.ConceptMapEditBypass01234VitalRecords.IJEToFHIR, "MEDUC_BYPASS", "MotherEducationLevelEditFlag", value);
+                }
             }
         }
 
@@ -1443,12 +1447,14 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
+                return Get_MappingFHIRToIJE(VR.Mappings.ConceptMapEducationLevelVitalRecords.FHIRToIJE, "FatherEducationLevel", "FEDUC");
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location:
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    Set_MappingIJEToFHIR(VR.Mappings.ConceptMapEducationLevelVitalRecords.IJEToFHIR, "FEDUC", "FatherEducationLevel", value);
+                }
             }
         }
 
@@ -1458,12 +1464,14 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
+                return Get_MappingFHIRToIJE(VR.Mappings.ConceptMapEditBypass01234VitalRecords.FHIRToIJE, "FatherEducationLevelEditFlag", "FEDUC_BYPASS");
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location:
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    Set_MappingIJEToFHIR(VR.Mappings.ConceptMapEditBypass01234VitalRecords.IJEToFHIR, "FEDUC_BYPASS", "FatherEducationLevelEditFlag", value);
+                }
             }
         }
 

--- a/projects/VitalRecord/VitalRecord.xml
+++ b/projects/VitalRecord/VitalRecord.xml
@@ -5170,6 +5170,46 @@
             <param name="shouldExist">if true the entry will be created unless it already exists, if false the entry will be removed if it exists</param>
             <param name="propertyName">the name of the C# property, must have a FHIRPath annotation, will default to the name of the calling property</param>
         </member>
+        <member name="M:VR.VitalRecord.GetObservationValue(System.String,System.String)">
+            <summary>Helper to support vital record property getter helper methods for values stored in Observations.</summary>
+            <param name="code">the code to identify the type of Observation</param>
+            <param name="extensionURL">if present, specifies that the value should be set on an extension with the provided URL instead</param>
+        </member>
+        <member name="M:VR.VitalRecord.SetObservationValue(System.Collections.Generic.Dictionary{System.String,System.String},System.String,System.String,System.String,System.String,System.String,System.String,System.String)">
+            <summary>Helper to support vital record property setter helper methods for values stored in Observations.</summary>
+            <param name="value">the coded value to set as the value of the property</param>
+            <param name="code">the code to specify the type of Observation</param>
+            <param name="codeSystem">the code system of the code specifying the type of Observation</param>
+            <param name="text">the text for the code specifying the type of Observation</param>
+            <param name="profileURL">the profile URL to include in the meta of the Observation</param>
+            <param name="section">the section of the composition the Observation should be added to</param>
+            <param name="extensionURL">if present, specifies that the value should be set on an extension with the provided URL instead</param>
+            <param name="propertyName">the name of the C# property, used to determine the subject ID</param>
+        </member>
+        <member name="M:VR.VitalRecord.GetObservationValueHelper(System.String)">
+            <summary>Helper to support vital record property getter helper methods for getting and setting coded values.</summary>
+            <param name="propertyName">the name of the C# helper property, used to determine which underlying property to call</param>
+            <example>
+            <para>// Given a property named MotherEducationLevel, the getter for MotherEducationLevelHelper can be defined using:</para>
+            <para>public string MotherEducationLevelHelper</para>
+            <para>{</para>
+            <para>    get => GetObservationValueHelper();</para>
+            <para>}</para>
+            </example>
+        </member>
+        <member name="M:VR.VitalRecord.SetObservationValueHelper(System.String,System.String[0:,0:],System.String)">
+            <summary>Helper to support vital record property setter helper methods for getting and setting coded values.</summary>
+            <param name="value">the coded value to set as the code in the underlying property value</param>
+            <param name="codes">the list of allowed codes</param>
+            <param name="propertyName">the name of the C# helper property, used to determine which underlying property to call</param>
+            <example>
+            <para>// Given a property named MotherEducationLevel, the setter for MotherEducationLevelHelper can be defined using:</para>
+            <para>public string MotherEducationLevelHelper</para>
+            <para>{</para>
+            <para>    set => SetObservationValueHelper(value, VR.ValueSets.EducationLevel.Codes);</para>
+            <para>}</para>
+            </example>
+        </member>
         <member name="M:VR.VitalRecord.RemoveAllEntries(VR.FHIRPath)">
             <summary>Remove all of the entries for the supplied category</summary>
             <param name="fhirPath">the FHIRPath of a none-of-the-above entry</param>

--- a/projects/VitalRecord/VitalRecord_util.cs
+++ b/projects/VitalRecord/VitalRecord_util.cs
@@ -94,6 +94,143 @@ namespace VR
             }
         }
 
+        // TODO: How can we make this flexible to support more types?
+        /// <summary>Helper to support vital record property getter helper methods for values stored in Observations.</summary>
+        /// <param name="code">the code to identify the type of Observation</param>
+        /// <param name="extensionURL">if present, specifies that the value should be set on an extension with the provided URL instead</param>
+        protected Dictionary<string, string> GetObservationValue(string code, string extensionURL = null)
+        {
+            var entry = Bundle.Entry.Where(e => e.Resource is Observation obs && CodeableConceptToDict(obs.Code)["code"] == code).FirstOrDefault();
+            if (entry != null)
+            {
+                Observation observation = (Observation)entry.Resource;
+                if (extensionURL != null)
+                {
+                    Extension extension = observation?.Value?.Extension.FirstOrDefault(ext => ext.Url == extensionURL);
+                    if (extension != null && extension.Value != null && extension.Value.GetType() == typeof(CodeableConcept))
+                    {
+                        return CodeableConceptToDict((CodeableConcept)extension.Value);
+                    }
+                }
+                else
+                {
+                    return CodeableConceptToDict((CodeableConcept)observation.Value);
+                }
+            }
+            return EmptyCodeableDict();
+        }
+
+        /// <summary>Helper to support vital record property setter helper methods for values stored in Observations.</summary>
+        /// <param name="value">the coded value to set as the value of the property</param>
+        /// <param name="code">the code to specify the type of Observation</param>
+        /// <param name="codeSystem">the code system of the code specifying the type of Observation</param>
+        /// <param name="text">the text for the code specifying the type of Observation</param>
+        /// <param name="profileURL">the profile URL to include in the meta of the Observation</param>
+        /// <param name="section">the section of the composition the Observation should be added to</param>
+        /// <param name="extensionURL">if present, specifies that the value should be set on an extension with the provided URL instead</param>
+        /// <param name="propertyName">the name of the C# property, used to determine the subject ID</param>
+        protected void SetObservationValue(Dictionary<string, string> value, string code, string codeSystem, string text, string profileURL, string section, string extensionURL = null, [CallerMemberName] string propertyName = null)
+        {
+            var entry = Bundle.Entry.Where(e => e.Resource is Observation obs && CodeableConceptToDict(obs.Code)["code"] == code).FirstOrDefault();
+            Observation observation;
+            // If the observation is there we use it, otherwise create it
+            if (entry != null)
+            {
+                observation = (Observation)entry.Resource;
+            }
+            else
+            {
+                observation = new Observation();
+                observation.Id = Guid.NewGuid().ToString();
+                observation.Meta = new Meta();
+                string[] profile = { profileURL };
+                observation.Meta.Profile = profile;
+                observation.Code = new CodeableConcept(codeSystem, code, text, null);
+                observation.Subject = new ResourceReference($"urn:uuid:{SubjectId(propertyName)}");
+                observation.Status = ObservationStatus.Final; // TODO: is this correct?
+                // TODO: We need to set the focus to something sane
+                AddReferenceToComposition(observation.Id, section);
+                Bundle.AddResourceEntry(observation, "urn:uuid:" + observation.Id);
+            }
+
+            // Set the value or the extension, depending on what's desired
+            if (extensionURL != null)
+            {
+                // If there's a value clear this extension in case it's previously set, otherwise set an empty value
+                if (observation.Value == null)
+                {
+                    observation.Value = new CodeableConcept();
+                }
+                else
+                {
+                    observation.Value.Extension.RemoveAll(ext => ext.Url == extensionURL);
+                }
+                Extension extension = new Extension(extensionURL, DictToCodeableConcept(value));
+                observation.Value.Extension.Add(extension);
+            }
+            else
+            {
+                // Need to keep any existing extension that could be there
+                List<Extension> extensions = observation.Value?.Extension?.FindAll(e => true);
+                observation.Value = DictToCodeableConcept(value);
+                if (extensions != null)
+                {
+                    observation.Value.Extension.AddRange(extensions);
+                }
+            }
+        }
+
+        /// <summary>Helper to support vital record property getter helper methods for getting and setting coded values.</summary>
+        /// <param name="propertyName">the name of the C# helper property, used to determine which underlying property to call</param>
+        /// <example>
+        /// <para>// Given a property named MotherEducationLevel, the getter for MotherEducationLevelHelper can be defined using:</para>
+        /// <para>public string MotherEducationLevelHelper</para>
+        /// <para>{</para>
+        /// <para>    get => GetObservationValueHelper();</para>
+        /// <para>}</para>
+        /// </example>
+        protected string GetObservationValueHelper([CallerMemberName] string propertyName = null)
+        {
+            // Find the base property name by stripping off the "Helper" from the calling property
+            if (!propertyName.EndsWith("Helper"))
+            {
+                throw new ArgumentException("GetObservationValueHelper called with a non-helper property");
+            }
+            string basePropertyName = propertyName.Replace("Helper", "");
+            Dictionary<string, string> value = (Dictionary<string, string>)this.GetType().GetProperty(basePropertyName).GetValue(this);
+            if (value.ContainsKey("code") && !string.IsNullOrWhiteSpace(value["code"]))
+            {
+                return value["code"];
+            }
+            return null;
+        }
+
+        /// <summary>Helper to support vital record property setter helper methods for getting and setting coded values.</summary>
+        /// <param name="value">the coded value to set as the code in the underlying property value</param>
+        /// <param name="codes">the list of allowed codes</param>
+        /// <param name="propertyName">the name of the C# helper property, used to determine which underlying property to call</param>
+        /// <example>
+        /// <para>// Given a property named MotherEducationLevel, the setter for MotherEducationLevelHelper can be defined using:</para>
+        /// <para>public string MotherEducationLevelHelper</para>
+        /// <para>{</para>
+        /// <para>    set => SetObservationValueHelper(value, VR.ValueSets.EducationLevel.Codes);</para>
+        /// <para>}</para>
+        /// </example>
+        protected void SetObservationValueHelper(string value, string[,] codes, [CallerMemberName] string propertyName = null)
+        {
+            // Find the base property name by stripping off the "Helper" from the calling property
+            // Find the base property name by stripping off the "Helper" from the calling property
+            if (!propertyName.EndsWith("Helper"))
+            {
+                throw new ArgumentException("GetObservationValueHelper called with a non-helper property");
+            }
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                string basePropertyName = propertyName.Replace("Helper", "");
+                SetCodeValue(basePropertyName, value, codes);
+            }
+        }
+
         /// <summary>Remove all of the entries for the supplied category</summary>
         /// <param name="fhirPath">the FHIRPath of a none-of-the-above entry</param>
         protected void RemoveAllEntries(FHIRPath fhirPath)
@@ -1811,7 +1948,7 @@ namespace VR
         }
 
         /// <summary>Constructor.</summary>
-        public FHIRPath(FhirType fhirType, string categoryCode = "", string code = "", string section = "", string codeSystem = null)
+        public FHIRPath(FhirType fhirType, string categoryCode = "", string code = null, string section = null, string codeSystem = null)
         {
             if (fhirType == FhirType.Observation)
             {

--- a/projects/VitalRecord/VitalRecord_util.cs
+++ b/projects/VitalRecord/VitalRecord_util.cs
@@ -97,7 +97,7 @@ namespace VR
         // TODO: How can we make this flexible to support more types?
         /// <summary>Helper to support vital record property getter helper methods for values stored in Observations.</summary>
         /// <param name="code">the code to identify the type of Observation</param>
-        /// <param name="extensionURL">if present, specifies that the value should be set on an extension with the provided URL instead</param>
+        /// <param name="extensionURL">if present, specifies that the value should be get from an extension with the provided URL instead</param>
         protected Dictionary<string, string> GetObservationValue(string code, string extensionURL = null)
         {
             var entry = Bundle.Entry.Where(e => e.Resource is Observation obs && CodeableConceptToDict(obs.Code)["code"] == code).FirstOrDefault();


### PR DESCRIPTION
This pull request:

1) Adds GetObservationValueHelper and SetObservationValueHelper methods to make it easier to implement property helpers for records
2) Adds GetObservationValue and SetObservationValue methods to make it easier to implement properties that set coded values in observations; useful feedback would be on whether generalizing this to other observation value types makes sense, and if so what a good approach would be
3) Implements support for BFDR mother and father education level and education level edit flag properties
4) Adds some generalized support for testing properties that take coded values based on value sets along with their helper functions
