### PR TITLE
Nvss 579 cli feature updates

### DIFF
--- a/projects/BFDR.CLI/BirthRecord.CLI.csproj
+++ b/projects/BFDR.CLI/BirthRecord.CLI.csproj
@@ -7,5 +7,6 @@
   <ItemGroup>
     <ProjectReference Include="..\BFDR\BirthRecord.csproj" />
     <ProjectReference Include="..\BFDR.Messaging\BFDRMessaging.csproj" />
+    <ProjectReference Include="..\VitalRecord\VitalRecord.csproj" />
   </ItemGroup>
 </Project>

--- a/projects/BFDR.CLI/Program.cs
+++ b/projects/BFDR.CLI/Program.cs
@@ -471,6 +471,246 @@ namespace BFDR.CLI
                 }
                 return 0;
             }
+            else if (args.Length == 2 && args[0] == "json2xml")
+            {
+                BirthRecord b = new BirthRecord(File.ReadAllText(args[1]));
+                Console.WriteLine(XDocument.Parse(b.ToXML()).ToString());
+                return 0;
+            }
+            else if (args.Length == 2 && args[0] == "checkXml")
+            {
+                BirthRecord b = new BirthRecord(File.ReadAllText(args[1]), true);
+                Console.WriteLine(XDocument.Parse(b.ToXML()).ToString());
+                return 0;
+            }
+            else if (args.Length == 2 && args[0] == "checkJson")
+            {
+                BirthRecord b = new BirthRecord(File.ReadAllText(args[1]), true);
+                Console.WriteLine(b.ToJSON());
+                return 0;
+            }
+            else if (args.Length == 2 && args[0] == "xml2json")
+            {
+                BirthRecord b = new BirthRecord(File.ReadAllText(args[1]));
+                Console.WriteLine(b.ToJSON());
+                return 0;
+            }
+            else if (args.Length == 2 && args[0] == "xml2xml")
+            {
+                // Forces record through getters and then setters, prints as xml
+                BirthRecord indr = new BirthRecord(File.ReadAllText(args[1]));
+                BirthRecord outdr = new BirthRecord();
+                List<PropertyInfo> properties = typeof(BirthRecord).GetProperties().ToList();
+                foreach (PropertyInfo property in properties)
+                {
+                    if (property.GetCustomAttribute<Property>() != null)
+                    {
+                        property.SetValue(outdr, property.GetValue(indr));
+                    }
+                }
+                Console.WriteLine(XDocument.Parse(outdr.ToXML()).ToString());
+                return 0;
+            }
+            else if (args.Length == 2 && args[0] == "json2json")
+            {
+                // Forces record through getters and then setters, prints as JSON
+                BirthRecord indr = new BirthRecord(File.ReadAllText(args[1]));
+                BirthRecord outdr = new BirthRecord();
+                List<PropertyInfo> properties = typeof(BirthRecord).GetProperties().ToList();
+                foreach (PropertyInfo property in properties)
+                {
+                    if (property.GetCustomAttribute<Property>() != null)
+                    {
+                        property.SetValue(outdr, property.GetValue(indr));
+                    }
+                }
+                Console.WriteLine(outdr.ToJSON());
+                return 0;
+            }
+            else if (args.Length == 2 && args[0] == "roundtrip-ije")
+            {
+                // Console.WriteLine("Converting FHIR to IJE...\n");
+                BirthRecord b = new BirthRecord(File.ReadAllText(args[1]));
+                IJENatality ije1, ije2, ije3;
+                try
+                {
+                    ije1 = new IJENatality(b);
+                    ije2 = new IJENatality(ije1.ToString());
+                    ije3 = new IJENatality(new BirthRecord(ije2.ToRecord().ToXML()));
+                }
+                catch (Exception e)
+                {
+                    Console.Error.WriteLine(e.Message);
+                    return (1);
+                }
+
+                int issues = 0;
+                int total = 0;
+                foreach (PropertyInfo property in typeof(IJENatality).GetProperties())
+                {
+                    string val1 = Convert.ToString(property.GetValue(ije1, null));
+                    string val2 = Convert.ToString(property.GetValue(ije2, null));
+                    string val3 = Convert.ToString(property.GetValue(ije3, null));
+
+                    IJEField info = property.GetCustomAttribute<IJEField>();
+
+                    if (val1.ToUpper() != val2.ToUpper() || val1.ToUpper() != val3.ToUpper() || val2.ToUpper() != val3.ToUpper())
+                    {
+                        issues++;
+                        Console.WriteLine($"[***** MISMATCH *****]\t{info.Name}: {info.Contents} \t\t\"{val1}\" != \"{val2}\" != \"{val3}\"");
+                    }
+                    total++;
+                }
+                Console.WriteLine($"\n{issues} issues out of {total} total fields.");
+                return issues;
+            }
+            else if (args.Length == 2 && args[0] == "roundtrip-all")
+            {
+                BirthRecord b1 = new BirthRecord(File.ReadAllText(args[1]));
+                BirthRecord b2 = new BirthRecord(d1.ToJSON());
+                BirthRecord b3 = new BirthRecord();
+                List<PropertyInfo> properties = typeof(BirthRecord).GetProperties().ToList();
+                // HashSet<string> skipPropertyNames = new HashSet<string>() { "CausesOfDeath", "AgeAtDeathYears", "AgeAtDeathMonths", "AgeAtDeathDays", "AgeAtDeathHours", "AgeAtDeathMinutes" };
+                foreach (PropertyInfo property in properties)
+                {
+                    // if (skipPropertyNames.Contains(property.Name))
+                    // {
+                    //     continue;
+                    // }
+                    if (property.GetCustomAttribute<Property>() != null)
+                    {
+                        property.SetValue(d3, property.GetValue(d2));
+                    }
+                }
+
+                int good = 0;
+                int bad = 0;
+
+                foreach (PropertyInfo property in properties)
+                {
+                    if (skipPropertyNames.Contains(property.Name))
+                    {
+                        continue;
+                    }
+                    // Console.WriteLine($"Property: Name: {property.Name.ToString()} Type: {property.PropertyType.ToString()}");
+                    string one;
+                    string two;
+                    string three;
+                    if (property.PropertyType.ToString() == "System.Collections.Generic.Dictionary`2[System.String,System.String]")
+                    {
+                        Dictionary<string, string> oneDict = (Dictionary<string, string>)property.GetValue(d1);
+                        Dictionary<string, string> twoDict = (Dictionary<string, string>)property.GetValue(d2);
+                        Dictionary<string, string> threeDict = (Dictionary<string, string>)property.GetValue(d3);
+                        // Ignore empty entries in the dictionary so they don't throw off comparisons.
+                        one = String.Join(", ", oneDict.Select(x => (x.Value != "") ? (x.Key + "=" + x.Value) : ("")).ToArray()).Replace(" ,", "");
+                        two = String.Join(", ", twoDict.Select(x => (x.Value != "") ? (x.Key + "=" + x.Value) : ("")).ToArray()).Replace(" ,", "");
+                        three = String.Join(", ", threeDict.Select(x => (x.Value != "") ? (x.Key + "=" + x.Value) : ("")).ToArray()).Replace(" ,", "");
+                    }
+                    else if (property.PropertyType.ToString() == "System.String[]")
+                    {
+                        one = String.Join(", ", (string[])property.GetValue(d1));
+                        two = String.Join(", ", (string[])property.GetValue(d2));
+                        three = String.Join(", ", (string[])property.GetValue(d3));
+                    }
+                    else
+                    {
+                        one = Convert.ToString(property.GetValue(d1));
+                        two = Convert.ToString(property.GetValue(d2));
+                        three = Convert.ToString(property.GetValue(d3));
+                    }
+                    if (one.ToLower() != three.ToLower())
+                    {
+                        Console.WriteLine("[***** MISMATCH *****]\t" + $"\"{one}\" (property: {property.Name}) does not equal \"{three}\"" + $"      1:\"{one}\" 2:\"{two}\" 3:\"{three}\"");
+                        bad++;
+                    }
+                    else
+                    {
+                        // We don't actually need to see all the matches and it makes it hard to see the mismatches
+                        // Console.WriteLine("[MATCH]\t" + $"\"{one}\" (property: {property.Name}) equals \"{three}\"" + $"      1:\"{one}\" 2:\"{two}\" 3:\"{three}\"");
+                        good++;
+                    }
+                }
+                Console.WriteLine($"\n{bad} mismatches out of {good + bad} total properties checked.");
+                if (bad > 0)
+                {
+                    return 1;
+                }
+                else
+                {
+                    return 0;
+                }
+            }
+            else if (args.Length == 2 && args[0] == "ije")
+            {
+                string ijeString = File.ReadAllText(args[1]);
+                List<PropertyInfo> properties = typeof(IJEMortality).GetProperties().ToList().OrderBy(p => p.GetCustomAttribute<IJEField>().Field).ToList();
+
+                foreach (PropertyInfo property in properties)
+                {
+                    IJEField info = property.GetCustomAttribute<IJEField>();
+                    string field = ijeString.Substring(info.Location - 1, info.Length);
+                    Console.WriteLine($"{info.Field,-5} {info.Name,-15} {Truncate(info.Contents, 75),-75}: \"{field + "\"",-80}");
+                }
+            }
+            else if (args[0] == "ijebuilder")
+            {
+                IJENatality ije = new IJENatality();
+                foreach (string arg in args)
+                {
+                    string[] keyAndValue = arg.Split('=');
+                    if (keyAndValue.Length == 2)
+                    {
+                        typeof(IJENatality).GetProperty(keyAndValue[0]).SetValue(ije, keyAndValue[1]);
+                    }
+                }
+                BirthRecord b = ije.ToRecord();
+                Console.WriteLine(b.ToJson());
+            }
+            else if (args.Length == 3 && args[0] == "compare")
+            {
+                string ijeString1 = File.ReadAllText(args[1]);
+
+                BirthRecord record2 = new BirthRecord(File.ReadAllText(args[2]));
+                IJENatality ije2 = new IJENatality(record2);
+                string ijeString2 = ije2.ToString();
+
+                List<PropertyInfo> properties = typeof(IJEMortality).GetProperties().ToList().OrderBy(p => p.GetCustomAttribute<IJEField>().Field).ToList();
+
+                int differences = 0;
+
+                foreach (PropertyInfo property in properties)
+                {
+                    IJEField info = property.GetCustomAttribute<IJEField>();
+                    string field1 = ijeString1.Substring(info.Location - 1, info.Length);
+                    string field2 = ijeString2.Substring(info.Location - 1, info.Length);
+                    if (field1 != field2)
+                    {
+                        differences += 1;
+                        Console.WriteLine($" IJE: {info.Field,-5} {info.Name,-15} {Truncate(info.Contents, 75),-75}: \"{field1 + "\"",-80}");
+                        Console.WriteLine($"FHIR: {info.Field,-5} {info.Name,-15} {Truncate(info.Contents, 75),-75}: \"{field2 + "\"",-80}");
+                        Console.WriteLine();
+                    }
+                }
+                Console.WriteLine($"Differences detected: {differences}");
+                return differences;
+            }
+            else if (args.Length == 2 && args[0] == "extract")
+            {
+                BaseMessage message = BaseMessage.Parse(File.ReadAllText(args[1]));
+                BirthRecord record;
+                switch (message)
+                {
+                    case BirthRecordSubmissionMessage submission:
+                        record = submission.BirthRecord;
+                        Console.WriteLine(record.ToJSON());
+                        break;
+                    case BirthRecordDemographicsCodingMessage coding:
+                        record = coding.BirthRecord;
+                        Console.WriteLine(record.ToJSON());
+                        break;
+                }
+                return 0;
+            }
             return 0;
         }
 

--- a/projects/BFDR.CLI/Program.cs
+++ b/projects/BFDR.CLI/Program.cs
@@ -37,10 +37,20 @@ namespace BFDR.CLI
   - resubmit: Create a submission update FHIR message wrapping a FHIR birth record (1 argument: FHIR birth record)
   - void: Creates a Void message for a Birth Record (1 argument: FHIR birth record; one optional argument: number of records to void)
   - ack: Create an acknowledgement FHIR message for a submission FHIR message (1 argument: submission FHIR message; many arguments: output directory and FHIR messages)
-";
-  //- batch: Read in IJE messages and create a batch submission bundle (2+ arguments: submission URL (for inside bundle) and one or more messages)
-  //- filter: Read in the FHIR birth record and filter based on filter array (1 argument: path to birth record to filter)
-
+  - ije2json: Creates an IJE birth record and prints out as JSON
+  - json2xml: Read in the FHIR JSON birth record, completely disassemble then reassemble, and print as FHIR XML (1 argument: FHIR JSON Birth Record)
+  - checkXml: Read in the given FHIR xml (being permissive) and print out the same; useful for doing validation diffs (1 argument: FHIR XML file)
+  - checkJson: Read in the given FHIR json (being permissive) and print out the same; useful for doing validation diffs (1 argument: FHIR JSon file)
+  - xml2json: Read in the IJE birth record and print out as JSON (1 argument: path to death record in XML format)
+  - xml2xml: Read in the IJE birth record and print out as XML (1 argument: path to death record in XML format)
+  - json2json: Read in the FHIR JSON birth record, completely disassemble then reassemble, and print as FHIR JSON (1 argument: FHIR JSON Birth Record)
+  - roundtrip-ije: Convert a record to IJE and back and check field by field to identify any conversion issues (1 argument: FHIR Birth Record)
+  - roundtrip-all: Convert a record to JSON and back and check field by field to identify any conversion issues (1 argument: FHIR Birth Record)
+  - ije: Read in and parse an IJE death record and print out the values for every (supported) field (1 argument: path to death record in IJE format)
+  - ijebuilder: Create json birth record using IJE (natality) mapped fields
+  - compare: Compare an IJE record with a FHIR record by each IJE field (2 arguments:  IJE record, FHIR Record)
+  - extract: Extract a FHIR record from a FHIR message (1 argument: FHIR message)
+    ";
 
         static int Main(string[] args)
         {
@@ -58,6 +68,65 @@ namespace BFDR.CLI
                 birthRecord.BirthDay = 1;
                 birthRecord.Identifier = "100";
                 birthRecord.StateLocalIdentifier1 = "123";
+                birthRecord.DateOfBirth = "2023-01-01";
+                birthRecord.BirthSex = "M";
+
+                string[] childNames = { "Alexander", "Arlo" };
+                birthRecord.ChildGivenNames = childNames;
+                string[] motherName = { "Xenia" };
+                birthRecord.MotherGivenNames = motherName;
+                string lastName = "Adkins";
+                birthRecord.ChildFamilyName = lastName;
+                birthRecord.MotherFamilyName = lastName;
+
+                birthRecord.BirthLocationJurisdiction = "MA";
+                Dictionary<string, string> birthAddress = new Dictionary<string, string>();
+                birthAddress.Add("addressLine1", "123 Fake Street");
+                birthAddress.Add("addressCity", "Springfield");
+                birthAddress.Add("addressCounty", "Hampden");
+                birthAddress.Add("addressState", "MA");
+                birthAddress.Add("addressZip", "01101");
+                birthAddress.Add("addressCountry", "US");
+                birthRecord.PlaceOfBirth = birthAddress;
+
+                birthRecord.InfantMedicalRecordNumber = "7134703";
+                birthRecord.MotherMedicalRecordNumber = "2286144";
+                birthRecord.MotherSocialSecurityNumber = "133756482";
+
+                birthRecord.SetOrder = null;
+                birthRecord.Plurality = null;
+                birthRecord.NoCongenitalAnomaliesOfTheNewborn = true;
+                birthRecord.EpiduralOrSpinalAnesthesia = true;
+                birthRecord.AugmentationOfLabor = true;
+                birthRecord.NoSpecifiedAbnormalConditionsOfNewborn = true;
+                birthRecord.NoInfectionsPresentDuringPregnancy = true;
+                birthRecord.GestationalHypertension = true;
+
+                Dictionary<string, string> route = new Dictionary<string, string>();
+                route.Add("code", "700000006");
+                route.Add("system", "http://snomed.info/sct");
+                route.Add("display", "Vaginal delivery of fetus (procedure)");
+                birthRecord.FinalRouteAndMethodOfDelivery = route;
+
+                birthRecord.NoObstetricProcedures = true;
+
+                birthRecord.MotherBirthDay = 12;
+                birthRecord.MotherBirthMonth = 1;
+                birthRecord.MotherBirthYear = 1992;
+                birthRecord.MotherDateOfBirth = "1992-01-12";
+                birthRecord.FatherBirthDay = 21;
+                birthRecord.FatherBirthMonth = 9;
+                birthRecord.FatherBirthYear = 1990;
+                birthRecord.FatherDateOfBirth = "1990-09-21";
+
+                // TODO: add these back once correct codesystems are used for the component 
+                // Ethnicity
+                // birthRecord.MotherEthnicity3Helper = VR.ValueSets.HispanicNoUnknown.Yes;
+                // // Race
+                // Tuple<string, string>[] motherRace = { Tuple.Create(NvssRace.BlackOrAfricanAmerican, "Y")};
+                // birthRecord.MotherRace = motherRace;
+                // Tuple<string, string>[] fatherRace = { Tuple.Create(NvssRace.White, "Y")};
+                // birthRecord.FatherRace = fatherRace;
 
                 // 1. Write out the Record
                 Console.WriteLine(birthRecord.ToJSON());
@@ -249,19 +318,172 @@ namespace BFDR.CLI
                 
            //     FilterService FilterService = new FilterService("./BFDR.Filter/NCHSIJEFilter.json", "./BFDR.Filter/IJEToFHIRMapping.json");
 
-           //     var filteredFile = FilterService.filterMessage(baseMessage).ToJson();
-           //     BirthRecordBaseMessage.Parse(filteredFile);
-           //     Console.WriteLine($"File successfully filtered and saved to {args[2]}");
-                    
-           //     File.WriteAllText(args[2], filteredFile);
-                
-           //     return 0;
-          //  }
-            else
+                    if (val1.ToUpper() != val2.ToUpper() || val1.ToUpper() != val3.ToUpper() || val2.ToUpper() != val3.ToUpper())
+                    {
+                        issues++;
+                        Console.WriteLine($"[***** MISMATCH *****]\t{info.Name}: {info.Contents} \t\t\"{val1}\" != \"{val2}\" != \"{val3}\"");
+                    }
+                    total++;
+                }
+                Console.WriteLine($"\n{issues} issues out of {total} total fields.");
+                return issues;
+            }
+            else if (args.Length == 2 && args[0] == "roundtrip-all")
             {
-                Console.WriteLine($"**** No such command {args[0]} with the number of arguments supplied");
+                BirthRecord b1 = new BirthRecord(File.ReadAllText(args[1]));
+                BirthRecord b2 = new BirthRecord(b1.ToJSON());
+                BirthRecord b3 = new BirthRecord();
+                List<PropertyInfo> properties = typeof(BirthRecord).GetProperties().ToList();
+                // HashSet<string> skipPropertyNames = new HashSet<string>() { "CausesOfDeath", "AgeAtDeathYears", "AgeAtDeathMonths", "AgeAtDeathDays", "AgeAtDeathHours", "AgeAtDeathMinutes" };
+                foreach (PropertyInfo property in properties)
+                {
+                    // if (skipPropertyNames.Contains(property.Name))
+                    // {
+                    //     continue;
+                    // }
+                    if (property.GetCustomAttribute<Property>() != null)
+                    {
+                        property.SetValue(b3, property.GetValue(b2));
+                    }
+                }
+
+                int good = 0;
+                int bad = 0;
+
+                foreach (PropertyInfo property in properties)
+                {
+                    // Console.WriteLine($"Property: Name: {property.Name.ToString()} Type: {property.PropertyType.ToString()}");
+                    string one;
+                    string two;
+                    string three;
+                    if (property.PropertyType.ToString() == "System.Collections.Generic.Dictionary`2[System.String,System.String]")
+                    {
+                        Dictionary<string, string> oneDict = (Dictionary<string, string>)property.GetValue(b1);
+                        Dictionary<string, string> twoDict = (Dictionary<string, string>)property.GetValue(b2);
+                        Dictionary<string, string> threeDict = (Dictionary<string, string>)property.GetValue(b3);
+                        // Ignore empty entries in the dictionary so they don't throw off comparisons.
+                        one = String.Join(", ", oneDict.Select(x => (x.Value != "") ? (x.Key + "=" + x.Value) : ("")).ToArray()).Replace(" ,", "");
+                        two = String.Join(", ", twoDict.Select(x => (x.Value != "") ? (x.Key + "=" + x.Value) : ("")).ToArray()).Replace(" ,", "");
+                        three = String.Join(", ", threeDict.Select(x => (x.Value != "") ? (x.Key + "=" + x.Value) : ("")).ToArray()).Replace(" ,", "");
+                    }
+                    else if (property.PropertyType.ToString() == "System.String[]")
+                    {
+                        one = String.Join(", ", (string[])property.GetValue(b1));
+                        two = String.Join(", ", (string[])property.GetValue(b2));
+                        three = String.Join(", ", (string[])property.GetValue(b3));
+                    }
+                    else
+                    {
+                        one = Convert.ToString(property.GetValue(b1));
+                        two = Convert.ToString(property.GetValue(b2));
+                        three = Convert.ToString(property.GetValue(b3));
+                    }
+                    if (one.ToLower() != three.ToLower())
+                    {
+                        Console.WriteLine("[***** MISMATCH *****]\t" + $"\"{one}\" (property: {property.Name}) does not equal \"{three}\"" + $"      1:\"{one}\" 2:\"{two}\" 3:\"{three}\"");
+                        bad++;
+                    }
+                    else
+                    {
+                        // We don't actually need to see all the matches and it makes it hard to see the mismatches
+                        // Console.WriteLine("[MATCH]\t" + $"\"{one}\" (property: {property.Name}) equals \"{three}\"" + $"      1:\"{one}\" 2:\"{two}\" 3:\"{three}\"");
+                        good++;
+                    }
+                }
+                Console.WriteLine($"\n{bad} mismatches out of {good + bad} total properties checked.");
+                if (bad > 0)
+                {
+                    return 1;
+                }
+                else
+                {
+                    return 0;
+                }
+            }
+            else if (args.Length == 2 && args[0] == "ije")
+            {
+                string ijeString = File.ReadAllText(args[1]);
+                List<PropertyInfo> properties = typeof(IJENatality).GetProperties().ToList().OrderBy(p => p.GetCustomAttribute<IJEField>().Field).ToList();
+
+                foreach (PropertyInfo property in properties)
+                {
+                    IJEField info = property.GetCustomAttribute<IJEField>();
+                    string field = ijeString.Substring(info.Location - 1, info.Length);
+                    Console.WriteLine($"{info.Field,-5} {info.Name,-15} {Truncate(info.Contents, 75),-75}: \"{field + "\"",-80}");
+                }
+            }
+            else if (args[0] == "ijebuilder")
+            {
+                IJENatality ije = new IJENatality();
+                foreach (string arg in args)
+                {
+                    string[] keyAndValue = arg.Split('=');
+                    if (keyAndValue.Length == 2)
+                    {
+                        typeof(IJENatality).GetProperty(keyAndValue[0]).SetValue(ije, keyAndValue[1]);
+                    }
+                }
+                BirthRecord b = ije.ToRecord();
+                Console.WriteLine(b.ToJson());
+            }
+            else if (args.Length == 3 && args[0] == "compare")
+            {
+                string ijeString1 = File.ReadAllText(args[1]);
+
+                BirthRecord record2 = new BirthRecord(File.ReadAllText(args[2]));
+                IJENatality ije2 = new IJENatality(record2);
+                string ijeString2 = ije2.ToString();
+
+                List<PropertyInfo> properties = typeof(IJENatality).GetProperties().ToList().OrderBy(p => p.GetCustomAttribute<IJEField>().Field).ToList();
+
+                int differences = 0;
+
+                foreach (PropertyInfo property in properties)
+                {
+                    IJEField info = property.GetCustomAttribute<IJEField>();
+                    string field1 = ijeString1.Substring(info.Location - 1, info.Length);
+                    string field2 = ijeString2.Substring(info.Location - 1, info.Length);
+                    if (field1 != field2)
+                    {
+                        differences += 1;
+                        Console.WriteLine($" IJE: {info.Field,-5} {info.Name,-15} {Truncate(info.Contents, 75),-75}: \"{field1 + "\"",-80}");
+                        Console.WriteLine($"FHIR: {info.Field,-5} {info.Name,-15} {Truncate(info.Contents, 75),-75}: \"{field2 + "\"",-80}");
+                        Console.WriteLine();
+                    }
+                }
+                Console.WriteLine($"Differences detected: {differences}");
+                return differences;
+            }
+            else if (args.Length == 2 && args[0] == "extract")
+            {
+                BirthRecordBaseMessage message = BirthRecordBaseMessage.Parse(File.ReadAllText(args[1]));
+                BirthRecord record;
+                switch (message)
+                {
+                    case BirthRecordSubmissionMessage submission:
+                        record = submission.BirthRecord;
+                        Console.WriteLine(record.ToJSON());
+                        break;
+                    case BirthRecordDemographicsCodingMessage coding:
+                        record = coding.BirthRecord;
+                        Console.WriteLine(record.ToJSON());
+                        break;
+                }
+                return 0;
             }
             return 0;
+        }
+
+         private static string Truncate(string value, int length)
+        {
+            if (String.IsNullOrWhiteSpace(value) || value.Length <= length)
+            {
+                return value;
+            }
+            else
+            {
+                return value.Substring(0, length);
+            }
         }
     }
 }

--- a/projects/BFDR.CLI/Program.cs
+++ b/projects/BFDR.CLI/Program.cs
@@ -69,7 +69,7 @@ namespace BFDR.CLI
                 birthRecord.Identifier = "100";
                 birthRecord.StateLocalIdentifier1 = "123";
                 birthRecord.DateOfBirth = "2023-01-01";
-                birthRecord.BirthSex = "M";
+                birthRecord.BirthSexHelper = "M";
 
                 string[] childNames = { "Alexander", "Arlo" };
                 birthRecord.ChildGivenNames = childNames;
@@ -318,88 +318,14 @@ namespace BFDR.CLI
                 
            //     FilterService FilterService = new FilterService("./BFDR.Filter/NCHSIJEFilter.json", "./BFDR.Filter/IJEToFHIRMapping.json");
 
-                    if (val1.ToUpper() != val2.ToUpper() || val1.ToUpper() != val3.ToUpper() || val2.ToUpper() != val3.ToUpper())
-                    {
-                        issues++;
-                        Console.WriteLine($"[***** MISMATCH *****]\t{info.Name}: {info.Contents} \t\t\"{val1}\" != \"{val2}\" != \"{val3}\"");
-                    }
-                    total++;
-                }
-                Console.WriteLine($"\n{issues} issues out of {total} total fields.");
-                return issues;
-            }
-            else if (args.Length == 2 && args[0] == "roundtrip-all")
-            {
-                BirthRecord b1 = new BirthRecord(File.ReadAllText(args[1]));
-                BirthRecord b2 = new BirthRecord(b1.ToJSON());
-                BirthRecord b3 = new BirthRecord();
-                List<PropertyInfo> properties = typeof(BirthRecord).GetProperties().ToList();
-                // HashSet<string> skipPropertyNames = new HashSet<string>() { "CausesOfDeath", "AgeAtDeathYears", "AgeAtDeathMonths", "AgeAtDeathDays", "AgeAtDeathHours", "AgeAtDeathMinutes" };
-                foreach (PropertyInfo property in properties)
-                {
-                    // if (skipPropertyNames.Contains(property.Name))
-                    // {
-                    //     continue;
-                    // }
-                    if (property.GetCustomAttribute<Property>() != null)
-                    {
-                        property.SetValue(b3, property.GetValue(b2));
-                    }
-                }
-
-                int good = 0;
-                int bad = 0;
-
-                foreach (PropertyInfo property in properties)
-                {
-                    // Console.WriteLine($"Property: Name: {property.Name.ToString()} Type: {property.PropertyType.ToString()}");
-                    string one;
-                    string two;
-                    string three;
-                    if (property.PropertyType.ToString() == "System.Collections.Generic.Dictionary`2[System.String,System.String]")
-                    {
-                        Dictionary<string, string> oneDict = (Dictionary<string, string>)property.GetValue(b1);
-                        Dictionary<string, string> twoDict = (Dictionary<string, string>)property.GetValue(b2);
-                        Dictionary<string, string> threeDict = (Dictionary<string, string>)property.GetValue(b3);
-                        // Ignore empty entries in the dictionary so they don't throw off comparisons.
-                        one = String.Join(", ", oneDict.Select(x => (x.Value != "") ? (x.Key + "=" + x.Value) : ("")).ToArray()).Replace(" ,", "");
-                        two = String.Join(", ", twoDict.Select(x => (x.Value != "") ? (x.Key + "=" + x.Value) : ("")).ToArray()).Replace(" ,", "");
-                        three = String.Join(", ", threeDict.Select(x => (x.Value != "") ? (x.Key + "=" + x.Value) : ("")).ToArray()).Replace(" ,", "");
-                    }
-                    else if (property.PropertyType.ToString() == "System.String[]")
-                    {
-                        one = String.Join(", ", (string[])property.GetValue(b1));
-                        two = String.Join(", ", (string[])property.GetValue(b2));
-                        three = String.Join(", ", (string[])property.GetValue(b3));
-                    }
-                    else
-                    {
-                        one = Convert.ToString(property.GetValue(b1));
-                        two = Convert.ToString(property.GetValue(b2));
-                        three = Convert.ToString(property.GetValue(b3));
-                    }
-                    if (one.ToLower() != three.ToLower())
-                    {
-                        Console.WriteLine("[***** MISMATCH *****]\t" + $"\"{one}\" (property: {property.Name}) does not equal \"{three}\"" + $"      1:\"{one}\" 2:\"{two}\" 3:\"{three}\"");
-                        bad++;
-                    }
-                    else
-                    {
-                        // We don't actually need to see all the matches and it makes it hard to see the mismatches
-                        // Console.WriteLine("[MATCH]\t" + $"\"{one}\" (property: {property.Name}) equals \"{three}\"" + $"      1:\"{one}\" 2:\"{two}\" 3:\"{three}\"");
-                        good++;
-                    }
-                }
-                Console.WriteLine($"\n{bad} mismatches out of {good + bad} total properties checked.");
-                if (bad > 0)
-                {
-                    return 1;
-                }
-                else
-                {
-                    return 0;
-                }
-            }
+           //     var filteredFile = FilterService.filterMessage(baseMessage).ToJson();
+           //     BirthRecordBaseMessage.Parse(filteredFile);
+           //     Console.WriteLine($"File successfully filtered and saved to {args[2]}");
+                    
+           //     File.WriteAllText(args[2], filteredFile);
+                
+           //     return 0;
+           //  }
             else if (args.Length == 2 && args[0] == "ije")
             {
                 string ijeString = File.ReadAllText(args[1]);
@@ -567,19 +493,14 @@ namespace BFDR.CLI
             else if (args.Length == 2 && args[0] == "roundtrip-all")
             {
                 BirthRecord b1 = new BirthRecord(File.ReadAllText(args[1]));
-                BirthRecord b2 = new BirthRecord(d1.ToJSON());
+                BirthRecord b2 = new BirthRecord(b1.ToJSON());
                 BirthRecord b3 = new BirthRecord();
                 List<PropertyInfo> properties = typeof(BirthRecord).GetProperties().ToList();
-                // HashSet<string> skipPropertyNames = new HashSet<string>() { "CausesOfDeath", "AgeAtDeathYears", "AgeAtDeathMonths", "AgeAtDeathDays", "AgeAtDeathHours", "AgeAtDeathMinutes" };
                 foreach (PropertyInfo property in properties)
                 {
-                    // if (skipPropertyNames.Contains(property.Name))
-                    // {
-                    //     continue;
-                    // }
                     if (property.GetCustomAttribute<Property>() != null)
                     {
-                        property.SetValue(d3, property.GetValue(d2));
+                        property.SetValue(b3, property.GetValue(b2));
                     }
                 }
 
@@ -588,19 +509,15 @@ namespace BFDR.CLI
 
                 foreach (PropertyInfo property in properties)
                 {
-                    if (skipPropertyNames.Contains(property.Name))
-                    {
-                        continue;
-                    }
                     // Console.WriteLine($"Property: Name: {property.Name.ToString()} Type: {property.PropertyType.ToString()}");
                     string one;
                     string two;
                     string three;
                     if (property.PropertyType.ToString() == "System.Collections.Generic.Dictionary`2[System.String,System.String]")
                     {
-                        Dictionary<string, string> oneDict = (Dictionary<string, string>)property.GetValue(d1);
-                        Dictionary<string, string> twoDict = (Dictionary<string, string>)property.GetValue(d2);
-                        Dictionary<string, string> threeDict = (Dictionary<string, string>)property.GetValue(d3);
+                        Dictionary<string, string> oneDict = (Dictionary<string, string>)property.GetValue(b1);
+                        Dictionary<string, string> twoDict = (Dictionary<string, string>)property.GetValue(b2);
+                        Dictionary<string, string> threeDict = (Dictionary<string, string>)property.GetValue(b3);
                         // Ignore empty entries in the dictionary so they don't throw off comparisons.
                         one = String.Join(", ", oneDict.Select(x => (x.Value != "") ? (x.Key + "=" + x.Value) : ("")).ToArray()).Replace(" ,", "");
                         two = String.Join(", ", twoDict.Select(x => (x.Value != "") ? (x.Key + "=" + x.Value) : ("")).ToArray()).Replace(" ,", "");
@@ -608,15 +525,15 @@ namespace BFDR.CLI
                     }
                     else if (property.PropertyType.ToString() == "System.String[]")
                     {
-                        one = String.Join(", ", (string[])property.GetValue(d1));
-                        two = String.Join(", ", (string[])property.GetValue(d2));
-                        three = String.Join(", ", (string[])property.GetValue(d3));
+                        one = String.Join(", ", (string[])property.GetValue(b1));
+                        two = String.Join(", ", (string[])property.GetValue(b2));
+                        three = String.Join(", ", (string[])property.GetValue(b3));
                     }
                     else
                     {
-                        one = Convert.ToString(property.GetValue(d1));
-                        two = Convert.ToString(property.GetValue(d2));
-                        three = Convert.ToString(property.GetValue(d3));
+                        one = Convert.ToString(property.GetValue(b1));
+                        two = Convert.ToString(property.GetValue(b2));
+                        three = Convert.ToString(property.GetValue(b3));
                     }
                     if (one.ToLower() != three.ToLower())
                     {
@@ -643,7 +560,7 @@ namespace BFDR.CLI
             else if (args.Length == 2 && args[0] == "ije")
             {
                 string ijeString = File.ReadAllText(args[1]);
-                List<PropertyInfo> properties = typeof(IJEMortality).GetProperties().ToList().OrderBy(p => p.GetCustomAttribute<IJEField>().Field).ToList();
+                List<PropertyInfo> properties = typeof(IJENatality).GetProperties().ToList().OrderBy(p => p.GetCustomAttribute<IJEField>().Field).ToList();
 
                 foreach (PropertyInfo property in properties)
                 {
@@ -674,7 +591,7 @@ namespace BFDR.CLI
                 IJENatality ije2 = new IJENatality(record2);
                 string ijeString2 = ije2.ToString();
 
-                List<PropertyInfo> properties = typeof(IJEMortality).GetProperties().ToList().OrderBy(p => p.GetCustomAttribute<IJEField>().Field).ToList();
+                List<PropertyInfo> properties = typeof(IJENatality).GetProperties().ToList().OrderBy(p => p.GetCustomAttribute<IJEField>().Field).ToList();
 
                 int differences = 0;
 
@@ -696,7 +613,7 @@ namespace BFDR.CLI
             }
             else if (args.Length == 2 && args[0] == "extract")
             {
-                BaseMessage message = BaseMessage.Parse(File.ReadAllText(args[1]));
+                BirthRecordBaseMessage message = BirthRecordBaseMessage.Parse(File.ReadAllText(args[1]));
                 BirthRecord record;
                 switch (message)
                 {
@@ -710,6 +627,10 @@ namespace BFDR.CLI
                         break;
                 }
                 return 0;
+            }
+            else
+            {
+                Console.WriteLine($"**** No such command {args[0]} with the number of arguments supplied");
             }
             return 0;
         }

--- a/projects/BFDR.Tests/BirthRecord.Tests.csproj
+++ b/projects/BFDR.Tests/BirthRecord.Tests.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\BFDR.Messaging\BFDRMessaging.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="fixtures/json/BirthRecordFake.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/BasicBirthRecord.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/RaceEthnicityCaseRecord.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/RaceEthnicityCaseRecord2.json" CopyToOutputDirectory="PreserveNewest" />

--- a/projects/BFDR.Tests/BirthRecord_Should.cs
+++ b/projects/BFDR.Tests/BirthRecord_Should.cs
@@ -1209,7 +1209,7 @@ namespace BFDR.Tests
       Assert.Equal("2023-01-01", FakeBirthRecord.DateOfBirth);
     }
     [Fact]
-    public void ParenttBirthDatesPresent()
+    public void ParentBirthDatesPresent()
     {
       Assert.Equal(1992, FakeBirthRecord.MotherBirthYear);
       Assert.Equal(1, FakeBirthRecord.MotherBirthMonth);

--- a/projects/BFDR.Tests/BirthRecord_Should.cs
+++ b/projects/BFDR.Tests/BirthRecord_Should.cs
@@ -1152,7 +1152,7 @@ namespace BFDR.Tests
     {
       Assert.Equal("100", FakeBirthRecord.Identifier);
       Assert.Equal("123", FakeBirthRecord.StateLocalIdentifier1);
-  
+    }
     [Fact]
     public void TestAttendantPropertiesSetter()
     {
@@ -1277,7 +1277,6 @@ namespace BFDR.Tests
                 return Path.GetRelativePath(Directory.GetCurrentDirectory(), filePath);
             }
         }
-  }
 
     [Fact]
     public void SetAttendantAfterParse()

--- a/projects/BFDR.Tests/BirthRecord_Should.cs
+++ b/projects/BFDR.Tests/BirthRecord_Should.cs
@@ -9,10 +9,12 @@ namespace BFDR.Tests
   public class BirthRecord_Should
   {
     private BirthRecord SetterBirthRecord;
+    private BirthRecord FakeBirthRecord;
 
     public BirthRecord_Should()
     {
       SetterBirthRecord = new BirthRecord();
+      FakeBirthRecord = new BirthRecord(File.ReadAllText(FixturePath("fixtures/json/BirthRecordFake.json")));
     }
 
     [Fact]
@@ -33,7 +35,6 @@ namespace BFDR.Tests
       Assert.True(SetterBirthRecord.Anencephaly);
       Assert.False(SetterBirthRecord.NoCongenitalAnomaliesOfTheNewborn);
     }
-
     [Fact]
     public void Set_Anencephaly()
     {
@@ -1146,7 +1147,12 @@ namespace BFDR.Tests
         }
         Assert.Equal(15, b2.FatherRace.Length);
     }
-
+    [Fact]
+    public void IdentifiersPresent()
+    {
+      Assert.Equal("100", FakeBirthRecord.Identifier);
+      Assert.Equal("123", FakeBirthRecord.StateLocalIdentifier1);
+  
     [Fact]
     public void TestAttendantPropertiesSetter()
     {
@@ -1194,6 +1200,84 @@ namespace BFDR.Tests
         Assert.Equal("5", ije2.ATTEND);
         Assert.Equal("Birth Clerk", ije2.ATTEND_OTH_TXT.Trim());
     }  
+    [Fact]
+    public void PatientBirthDatePresent()
+    {
+      Assert.Equal(2023, FakeBirthRecord.BirthYear);
+      Assert.Equal(1, FakeBirthRecord.BirthMonth);
+      Assert.Equal(1, FakeBirthRecord.BirthDay);
+      Assert.Equal("2023-01-01", FakeBirthRecord.DateOfBirth);
+    }
+    [Fact]
+    public void ParenttBirthDatesPresent()
+    {
+      Assert.Equal(1992, FakeBirthRecord.MotherBirthYear);
+      Assert.Equal(1, FakeBirthRecord.MotherBirthMonth);
+      Assert.Equal(12, FakeBirthRecord.MotherBirthDay);
+      Assert.Equal("1992-01-12", FakeBirthRecord.MotherDateOfBirth);
+      Assert.Equal(1990, FakeBirthRecord.FatherBirthYear );
+      Assert.Equal(9, FakeBirthRecord.FatherBirthMonth);
+      Assert.Equal(21, FakeBirthRecord.FatherBirthDay);
+      Assert.Equal("1990-09-21", FakeBirthRecord.FatherDateOfBirth);
+    }
+    [Fact]
+    public void ChildNamesPresent()
+    {
+      Assert.Equal("Alexander", FakeBirthRecord.ChildGivenNames[0]);
+      Assert.Equal("Arlo", FakeBirthRecord.ChildGivenNames[1]);
+      Assert.Equal("Adkins", FakeBirthRecord.ChildFamilyName);
+    }
+    [Fact]
+    public void MotherNamesPresent()
+    {
+      Assert.Equal("Xenia", FakeBirthRecord.MotherGivenNames[0]);
+      Assert.Equal("Adkins", FakeBirthRecord.MotherFamilyName);
+    }
+    [Fact]
+    public void BirthLocationPresent()
+    {
+      Assert.Equal("MA", FakeBirthRecord.BirthLocationJurisdiction);
+      Assert.Equal("123 Fake Street", FakeBirthRecord.PlaceOfBirth["addressLine1"]);
+      Assert.Equal("MA", FakeBirthRecord.PlaceOfBirth["addressState"]);
+      Assert.Equal("01101", FakeBirthRecord.PlaceOfBirth["addressZip"]);
+    }
+    [Fact]
+    public void PersonalIDsPresent()
+    {
+      Assert.Equal("7134703", FakeBirthRecord.InfantMedicalRecordNumber);
+      Assert.Equal("2286144", FakeBirthRecord.MotherMedicalRecordNumber);
+      Assert.Equal("133756482", FakeBirthRecord.MotherSocialSecurityNumber);
+    }
+    [Fact]
+    public void BirthDataPresent()
+    {
+      Assert.Null(FakeBirthRecord.SetOrder);
+      Assert.Null(FakeBirthRecord.Plurality);
+      Assert.True(FakeBirthRecord.NoCongenitalAnomaliesOfTheNewborn);
+      Assert.True(FakeBirthRecord.EpiduralOrSpinalAnesthesia );
+      Assert.True(FakeBirthRecord.AugmentationOfLabor);
+      Assert.True(FakeBirthRecord.NoSpecifiedAbnormalConditionsOfNewborn);
+      Assert.True(FakeBirthRecord.NoInfectionsPresentDuringPregnancy);
+      Assert.True(FakeBirthRecord.GestationalHypertension);
+      Assert.Equal("700000006", FakeBirthRecord.FinalRouteAndMethodOfDelivery["code"]);
+      Assert.True(FakeBirthRecord.NoObstetricProcedures);
+      // some negative cases
+      Assert.False(FakeBirthRecord.GestationalDiabetes);
+      Assert.False(FakeBirthRecord.ArtificialInsemination);
+    }
+
+    private string FixturePath(string filePath)
+        {
+            if (Path.IsPathRooted(filePath))
+            {
+                return filePath;
+            }
+            else
+            {
+                return Path.GetRelativePath(Directory.GetCurrentDirectory(), filePath);
+            }
+        }
+  }
 
     [Fact]
     public void SetAttendantAfterParse()

--- a/projects/BFDR.Tests/fixtures/json/BirthRecordFake.json
+++ b/projects/BFDR.Tests/fixtures/json/BirthRecordFake.json
@@ -1,0 +1,383 @@
+{
+  "resourceType": "Bundle",
+  "id": "9022d58c-4217-41ff-8388-8a6836d0c1af",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/bfdr/StructureDefinition/BundleDocumentBFDR"
+    ]
+  },
+  "identifier": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/us/bfdr/StructureDefinition/CertificateNumber",
+        "valueString": "100"
+      },
+      {
+        "url": "http://hl7.org/fhir/us/bfdr/StructureDefinition/AuxiliaryStateIdentifier1",
+        "valueString": "123"
+      }
+    ],
+    "system": "http://nchs.cdc.gov/bfdr_id",
+    "value": "2023XX000100"
+  },
+  "type": "document",
+  "timestamp": "2024-01-25T14:07:12.516136-05:00",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:9b4b8a46-7659-41bf-8499-e3f1b1b32b28",
+      "resource": {
+        "resourceType": "Composition",
+        "id": "9b4b8a46-7659-41bf-8499-e3f1b1b32b28",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/bfdr/StructureDefinition/CompositionJurisdictionLiveBirthReport"
+          ]
+        },
+        "status": "final",
+        "type": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "71230-7",
+              "display": "Birth certificate"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:eb12d4fa-b109-4f9f-a32b-e3be13b33493"
+        },
+        "title": "Birth Certificate",
+        "attester": [
+          {
+            "mode": "legal"
+          }
+        ],
+        "event": [
+          {
+            "code": [
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "103693007",
+                    "display": "Diagnostic procedure (procedure)"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "section": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "57075-4"
+                }
+              ]
+            },
+            "focus": {
+              "reference": "urn:uuid:eb12d4fa-b109-4f9f-a32b-e3be13b33493"
+            },
+            "entry": [
+              {
+                "reference": "urn:uuid:9d7b4de6-dc9f-4232-bb23-ed08170f8c2c"
+              },
+              {
+                "reference": "urn:uuid:54e5bd85-ec0a-4b98-9725-5d534767d0a9"
+              }
+            ]
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "55752-0"
+                }
+              ]
+            },
+            "focus": {
+              "reference": "urn:uuid:af0aab9d-93e3-40eb-bde5-093b54b8ce5d"
+            },
+            "entry": [
+              {
+                "reference": "urn:uuid:275eeeca-27c5-4197-a314-5e813816aa9d"
+              },
+              {
+                "reference": "urn:uuid:a14df606-bd54-48ae-a06a-fe16a2ff3726"
+              },
+              {
+                "reference": "urn:uuid:470ad320-930d-45c9-9862-486ae00d3f62"
+              },
+              {
+                "reference": "urn:uuid:7e51c41c-68a4-46b9-91cd-2a0bd824d495"
+              },
+              {
+                "reference": "urn:uuid:7326765f-9689-43e4-8b11-322886f8747a"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:eb12d4fa-b109-4f9f-a32b-e3be13b33493",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "eb12d4fa-b109-4f9f-a32b-e3be13b33493",
+        "meta": {
+          "profile": [
+            "http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-Patient-child-vr.html"
+          ]
+        },
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+            "valueString": "M"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+            "valueAddress": {
+              "line": [
+                "123 Fake Street"
+              ],
+              "city": "Springfield",
+              "district": "Hampden",
+              "state": "MA",
+              "postalCode": "01101",
+              "country": "US"
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "MR",
+                  "display": "Medical Record Number"
+                }
+              ]
+            },
+            "value": "7134703"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "Adkins",
+            "given": [
+              "Alexander",
+              "Arlo"
+            ]
+          }
+        ],
+        "birthDate": "2023-01-01",
+        "multipleBirthBoolean": false,
+        "_multipleBirthBoolean": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:af0aab9d-93e3-40eb-bde5-093b54b8ce5d",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "af0aab9d-93e3-40eb-bde5-093b54b8ce5d",
+        "meta": {
+          "profile": [
+            "http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-Patient-mother-vr.html"
+          ]
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "MR",
+                  "display": "Medical Record Number"
+                }
+              ]
+            },
+            "value": "2286144"
+          },
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "SS",
+                  "display": "Social Security Number"
+                }
+              ]
+            },
+            "value": "133756482"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "Adkins",
+            "given": [
+              "Xenia"
+            ]
+          }
+        ],
+        "birthDate": "1992-01-12"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:cb9e84e9-bbbe-4120-9166-100cde0dba9c",
+      "resource": {
+        "resourceType": "RelatedPerson",
+        "id": "cb9e84e9-bbbe-4120-9166-100cde0dba9c",
+        "meta": {
+          "profile": [
+            "http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-RelatedPerson-father-natural-vr.html"
+          ]
+        },
+        "birthDate": "1990-09-21"
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:275eeeca-27c5-4197-a314-5e813816aa9d",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "275eeeca-27c5-4197-a314-5e813816aa9d",
+        "category": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "73813-8"
+            }
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "18946005"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:af0aab9d-93e3-40eb-bde5-093b54b8ce5d"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:a14df606-bd54-48ae-a06a-fe16a2ff3726",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "a14df606-bd54-48ae-a06a-fe16a2ff3726",
+        "category": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "73813-8"
+            }
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "237001001"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:af0aab9d-93e3-40eb-bde5-093b54b8ce5d"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:470ad320-930d-45c9-9862-486ae00d3f62",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "470ad320-930d-45c9-9862-486ae00d3f62",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "code": "73775-9"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "48194001"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:af0aab9d-93e3-40eb-bde5-093b54b8ce5d"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:7e51c41c-68a4-46b9-91cd-2a0bd824d495",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "7e51c41c-68a4-46b9-91cd-2a0bd824d495",
+        "category": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "73762-7"
+            }
+          ]
+        },
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "700000006"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:af0aab9d-93e3-40eb-bde5-093b54b8ce5d"
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:7326765f-9689-43e4-8b11-322886f8747a",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "7326765f-9689-43e4-8b11-322886f8747a",
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "73814-6"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:af0aab9d-93e3-40eb-bde5-093b54b8ce5d"
+        },
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "260413007"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/projects/BFDR/BirthRecord.xml
+++ b/projects/BFDR/BirthRecord.xml
@@ -19,6 +19,11 @@
             Record. This class was designed to help consume and produce birth records that follow the
             HL7 FHIR Birth and Fetal Death Reporting Implementation Guide, as described at:
             TODO add link to BFDR IG
+            TODO BFDR STU2 has broken up its birth record bundles, the birth bundle has birthCertificateNumber + required birth compositions,
+            the fetal death bundle has fetalDeathReportNumber + required fetal death compositions,
+            the demographic bundle has a fileNumber + requiredCompositionCodedRaceAndEthnicity,
+            and the cause of death bundle has a fetalDeathReportNumber + required CompositionCodedCauseOfFetalDeath
+            TODO BFDR STU2 supports usual work and role extension
             </summary>
         </member>
         <member name="M:BFDR.BirthRecord.#ctor">
@@ -219,6 +224,7 @@
             </example>
         </member>
         <member name="P:BFDR.BirthRecord.MotherGivenNames">
+            TODO: should support father's name as well
             <summary>Mother's Legal Name - Given. Middle name should be the last entry.</summary>
             <value>the mother's name (first, etc., middle)</value>
             <example>
@@ -922,6 +928,8 @@
             </example>
         </member>
         <member name="P:BFDR.BirthRecord.MotherEthnicity1">
+            TODO: ethinicty/race component code still uses vrdr codesystem: http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs
+            should be http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component
             <summary>Mother's Ethnicity Hispanic Mexican.</summary>
             <value>the mother's ethnicity. A Dictionary representing a code, containing the following key/value pairs:
             <para>"code" - the code</para>
@@ -944,7 +952,7 @@
             <value>Mother's Ethnicity 1.</value>
             <example>
             <para>// Setter:</para>
-            <para>ExampleBirthRecord.EthnicityLevel = VRDR.ValueSets.YesNoUnknown.Yes;</para>
+            <para>ExampleBirthRecord.EthnicityLevel = VR.ValueSets.YesNoUnknown.Yes;</para>
             <para>// Getter:</para>
             <para>Console.WriteLine($"Mother's Ethnicity: {ExampleBirthRecord.MotherEthnicity1Helper}");</para>
             </example>
@@ -972,7 +980,7 @@
             <value>Mother's Ethnicity 2.</value>
             <example>
             <para>// Setter:</para>
-            <para>ExampleBirthRecord.EthnicityLevel = VRDR.ValueSets.YesNoUnknown.Yes;</para>
+            <para>ExampleBirthRecord.EthnicityLevel = VR.ValueSets.YesNoUnknown.Yes;</para>
             <para>// Getter:</para>
             <para>Console.WriteLine($"Mother's Ethnicity: {ExampleBirthRecord.MotherEthnicity2Helper}");</para>
             </example>
@@ -1000,7 +1008,7 @@
             <value>Mother's Ethnicity 3.</value>
             <example>
             <para>// Setter:</para>
-            <para>ExampleBirthRecord.EthnicityLevel = VRDR.ValueSets.YesNoUnknown.Yes;</para>
+            <para>ExampleBirthRecord.EthnicityLevel = VR.ValueSets.YesNoUnknown.Yes;</para>
             <para>// Getter:</para>
             <para>Console.WriteLine($"Mother's Ethnicity: {ExampleBirthRecord.MotherEthnicity3Helper}");</para>
             </example>
@@ -1028,7 +1036,7 @@
             <value>Mother's Ethnicity 4.</value>
             <example>
             <para>// Setter:</para>
-            <para>ExampleBirthRecord.EthnicityLevel = VRDR.ValueSets.YesNoUnknown.Yes;</para>
+            <para>ExampleBirthRecord.EthnicityLevel = VR.ValueSets.YesNoUnknown.Yes;</para>
             <para>// Getter:</para>
             <para>Console.WriteLine($"Mother's Ethnicity: {ExampleBirthRecord.MotherEthnicity4Helper}");</para>
             </example>
@@ -1081,7 +1089,7 @@
             <value>Father's Ethnicity 1.</value>
             <example>
             <para>// Setter:</para>
-            <para>ExampleBirthRecord.EthnicityLevel = VRDR.ValueSets.YesNoUnknown.Yes;</para>
+            <para>ExampleBirthRecord.EthnicityLevel = VR.ValueSets.YesNoUnknown.Yes;</para>
             <para>// Getter:</para>
             <para>Console.WriteLine($"Father's Ethnicity: {ExampleBirthRecord.FatherEthnicity1Helper}");</para>
             </example>
@@ -1109,7 +1117,7 @@
             <value>Father's Ethnicity 2.</value>
             <example>
             <para>// Setter:</para>
-            <para>ExampleBirthRecord.EthnicityLevel = VRDR.ValueSets.YesNoUnknown.Yes;</para>
+            <para>ExampleBirthRecord.EthnicityLevel = VR.ValueSets.YesNoUnknown.Yes;</para>
             <para>// Getter:</para>
             <para>Console.WriteLine($"Father's Ethnicity: {ExampleBirthRecord.FatherEthnicity2Helper}");</para>
             </example>
@@ -1137,7 +1145,7 @@
             <value>Father's Ethnicity 3.</value>
             <example>
             <para>// Setter:</para>
-            <para>ExampleBirthRecord.EthnicityLevel = VRDR.ValueSets.YesNoUnknown.Yes;</para>
+            <para>ExampleBirthRecord.EthnicityLevel = VR.ValueSets.YesNoUnknown.Yes;</para>
             <para>// Getter:</para>
             <para>Console.WriteLine($"Father's Ethnicity: {ExampleBirthRecord.FatherEthnicity3Helper}");</para>
             </example>
@@ -1165,7 +1173,7 @@
             <value>Father's Ethnicity 4.</value>
             <example>
             <para>// Setter:</para>
-            <para>ExampleBirthRecord.EthnicityLevel = VRDR.ValueSets.YesNoUnknown.Yes;</para>
+            <para>ExampleBirthRecord.EthnicityLevel = VR.ValueSets.YesNoUnknown.Yes;</para>
             <para>// Getter:</para>
             <para>Console.WriteLine($"Father's Ethnicity: {ExampleBirthRecord.FatherEthnicity4Helper}");</para>
             </example>

--- a/projects/BFDR/BirthRecord_submissionProperties.cs
+++ b/projects/BFDR/BirthRecord_submissionProperties.cs
@@ -14,6 +14,11 @@ namespace BFDR
     /// Record. This class was designed to help consume and produce birth records that follow the
     /// HL7 FHIR Birth and Fetal Death Reporting Implementation Guide, as described at:
     /// TODO add link to BFDR IG
+    /// TODO BFDR STU2 has broken up its birth record bundles, the birth bundle has birthCertificateNumber + required birth compositions,
+    /// the fetal death bundle has fetalDeathReportNumber + required fetal death compositions,
+    /// the demographic bundle has a fileNumber + requiredCompositionCodedRaceAndEthnicity,
+    /// and the cause of death bundle has a fetalDeathReportNumber + required CompositionCodedCauseOfFetalDeath
+    /// TODO BFDR STU2 supports usual work and role extension
     /// </summary>
     public partial class BirthRecord
     {
@@ -734,7 +739,7 @@ namespace BFDR
         {
             get
             {
-                return Child?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Suffix.First();
+                return Child?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Suffix.FirstOrDefault();
             }
             set
             {
@@ -2767,7 +2772,8 @@ namespace BFDR
                 this.Father.BirthDateElement = ConvertToDate(value);
             }
         }
-
+        /// TODO: ethinicty/race component code still uses vrdr codesystem: http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-component-cs
+        /// should be http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component
         /// <summary>Father's Age at Delivery</summary>
         /// <value>the father's age at Delivery in years</value>
         /// <example>
@@ -2890,7 +2896,7 @@ namespace BFDR
                 {
                     Observation.ComponentComponent ethnicity = InputRaceAndEthnicityObsMother.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Mexican);
                     if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
-                    {
+                    {   
                         return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
                     }
                 }
@@ -2914,7 +2920,7 @@ namespace BFDR
         /// <value>Mother's Ethnicity 1.</value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.EthnicityLevel = VRDR.ValueSets.YesNoUnknown.Yes;</para>
+        /// <para>ExampleBirthRecord.EthnicityLevel = VR.ValueSets.YesNoUnknown.Yes;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Mother's Ethnicity: {ExampleBirthRecord.MotherEthnicity1Helper}");</para>
         /// </example>
@@ -2993,7 +2999,7 @@ namespace BFDR
         /// <value>Mother's Ethnicity 2.</value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.EthnicityLevel = VRDR.ValueSets.YesNoUnknown.Yes;</para>
+        /// <para>ExampleBirthRecord.EthnicityLevel = VR.ValueSets.YesNoUnknown.Yes;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Mother's Ethnicity: {ExampleBirthRecord.MotherEthnicity2Helper}");</para>
         /// </example>
@@ -3072,7 +3078,7 @@ namespace BFDR
         /// <value>Mother's Ethnicity 3.</value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.EthnicityLevel = VRDR.ValueSets.YesNoUnknown.Yes;</para>
+        /// <para>ExampleBirthRecord.EthnicityLevel = VR.ValueSets.YesNoUnknown.Yes;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Mother's Ethnicity: {ExampleBirthRecord.MotherEthnicity3Helper}");</para>
         /// </example>
@@ -3152,7 +3158,7 @@ namespace BFDR
         /// <value>Mother's Ethnicity 4.</value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.EthnicityLevel = VRDR.ValueSets.YesNoUnknown.Yes;</para>
+        /// <para>ExampleBirthRecord.EthnicityLevel = VR.ValueSets.YesNoUnknown.Yes;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Mother's Ethnicity: {ExampleBirthRecord.MotherEthnicity4Helper}");</para>
         /// </example>
@@ -3385,7 +3391,7 @@ namespace BFDR
         /// <value>Father's Ethnicity 1.</value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.EthnicityLevel = VRDR.ValueSets.YesNoUnknown.Yes;</para>
+        /// <para>ExampleBirthRecord.EthnicityLevel = VR.ValueSets.YesNoUnknown.Yes;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Father's Ethnicity: {ExampleBirthRecord.FatherEthnicity1Helper}");</para>
         /// </example>
@@ -3464,7 +3470,7 @@ namespace BFDR
         /// <value>Father's Ethnicity 2.</value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.EthnicityLevel = VRDR.ValueSets.YesNoUnknown.Yes;</para>
+        /// <para>ExampleBirthRecord.EthnicityLevel = VR.ValueSets.YesNoUnknown.Yes;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Father's Ethnicity: {ExampleBirthRecord.FatherEthnicity2Helper}");</para>
         /// </example>
@@ -3543,7 +3549,7 @@ namespace BFDR
         /// <value>Father's Ethnicity 3.</value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.EthnicityLevel = VRDR.ValueSets.YesNoUnknown.Yes;</para>
+        /// <para>ExampleBirthRecord.EthnicityLevel = VR.ValueSets.YesNoUnknown.Yes;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Father's Ethnicity: {ExampleBirthRecord.FatherEthnicity3Helper}");</para>
         /// </example>
@@ -3623,7 +3629,7 @@ namespace BFDR
         /// <value>Father's Ethnicity 4.</value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.EthnicityLevel = VRDR.ValueSets.YesNoUnknown.Yes;</para>
+        /// <para>ExampleBirthRecord.EthnicityLevel = VR.ValueSets.YesNoUnknown.Yes;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Father's Ethnicity: {ExampleBirthRecord.FatherEthnicity4Helper}");</para>
         /// </example>


### PR DESCRIPTION


    Added features:
    Fake record
    Json2xml
    checkXml
    checkJson
    Xml2json
    Xml2xml
    Json2json
    Roundtrip-ije
    Roundtrip-all
    Ije
    Ijebuilder
    Compare
    Extract

    Added singleordefault() to suffix to avoid error in getter

    Added todo's to address issues/STU updates

Remaining Issues

    Race and ethnicity getter returns empty codeabledict when nothing is present, which causes json2json and xml2xml to generate a bunch of empty race/ethnicity entries that should be “no” or not present at all
    Roundtrip-ije which includes whitespace on occasion and flips Y’s to N’s in some cases
