### PR TITLE
Nvss 565 mother height

### DIFF
--- a/projects/BFDR.Tests/BirthRecord.Tests.csproj
+++ b/projects/BFDR.Tests/BirthRecord.Tests.csproj
@@ -17,7 +17,8 @@
     <ProjectReference Include="..\BFDR.Messaging\BFDRMessaging.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="fixtures/json/BirthRecordFake.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/BirthRecordFakeWithRace.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/BirthRecordFakeNoRace.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/BasicBirthRecord.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/RaceEthnicityCaseRecord.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/RaceEthnicityCaseRecord2.json" CopyToOutputDirectory="PreserveNewest" />

--- a/projects/BFDR.Tests/BirthRecord_Should.cs
+++ b/projects/BFDR.Tests/BirthRecord_Should.cs
@@ -14,7 +14,7 @@ namespace BFDR.Tests
     public BirthRecord_Should()
     {
       SetterBirthRecord = new BirthRecord();
-      FakeBirthRecord = new BirthRecord(File.ReadAllText(FixturePath("fixtures/json/BirthRecordFakeNoRace.json")));
+      FakeBirthRecord = new BirthRecord(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/BirthRecordFakeWithRace.json")));
     }
 
     [Fact]
@@ -1414,18 +1414,6 @@ namespace BFDR.Tests
         }
     }
 
-    private string FixturePath(string filePath)
-    {
-        if (Path.IsPathRooted(filePath))
-        {
-            return filePath;
-        }
-        else
-        {
-            return Path.GetRelativePath(Directory.GetCurrentDirectory(), filePath);
-        }
-    }
-
     [Fact]
     public void SetAttendantAfterParse()
     {
@@ -1480,6 +1468,25 @@ namespace BFDR.Tests
       Assert.Equal(4, SetterBirthRecord.LastMenstrualPeriodMonth);
       Assert.Null(SetterBirthRecord.LastMenstrualPeriodDay);
     }
+
+    [Fact]
+    public void TestMotherHeightPropertiesSetter()
+    {
+        BirthRecord record = new BirthRecord();
+        // Height
+        Assert.Null(record.MotherHeight);
+        record.MotherHeight = 67;
+        Assert.Equal(67, record.MotherHeight);
+        // Edit Flag
+        Assert.Equal("", record.MotherHeightEditFlag["code"]);
+        record.MotherHeightEditFlagHelper = VR.ValueSets.EditBypass01234.Edit_Passed;
+        Assert.Equal(VR.ValueSets.EditBypass01234.Edit_Passed, record.MotherHeightEditFlag["code"]);
+        // IJE translations
+        IJENatality ije1 = new IJENatality(record);
+        Assert.Equal("5", ije1.HFT);
+        Assert.Equal("7", ije1.HIN);  
+        Assert.Equal("0", ije1.HGT_BYPASS);
+    }  
 
     [Fact]
     public void SetFirstPrenatalCareVisit()

--- a/projects/BFDR.Tests/NatalityData_Should.cs
+++ b/projects/BFDR.Tests/NatalityData_Should.cs
@@ -744,6 +744,32 @@ namespace BFDR.Tests
     }
 
     [Fact]
+    public void TestMotherHeightPropertiesSetter()
+    {
+        BirthRecord record = new BirthRecord();
+        IJENatality ije1 = new IJENatality(record);
+        // Height
+        Assert.Equal("  ",ije1.HIN);
+        Assert.Equal(" ",ije1.HFT);
+        ije1.HFT = "5";
+        ije1.HIN = "7";
+        Assert.Equal("7", ije1.HIN);
+        Assert.Equal("5", ije1.HFT);
+        ije1.HFT = "5";
+        ije1.HIN = "3";
+        Assert.Equal("5", ije1.HFT);
+        Assert.Equal("3", ije1.HIN);
+        // Edit Flag
+        Assert.Equal("", ije1.HGT_BYPASS);
+        ije1.HGT_BYPASS = "1";
+        Assert.Equal("1", ije1.HGT_BYPASS);
+        // FHIR translations
+        BirthRecord record1 = new BirthRecord(ije1.ToRecord().ToXML());
+        Assert.Equal(63, record1.MotherHeight);
+        Assert.Equal(VR.ValueSets.EditBypass01234.Edit_Failed_Data_Queried_And_Verified, record1.MotherHeightEditFlag["code"]);
+    }  
+
+    [Fact]
     public void TestFirstPrenatalCare()
     {
       BirthRecord fhir = new BirthRecord();
@@ -787,7 +813,7 @@ namespace BFDR.Tests
       Assert.Equal("24", ije.DOR_DY);
     }
 
-        [Fact]
+    [Fact]
     public void TestSetPayorType()
     {
       // Manually set ije values.

--- a/projects/BFDR/BirthRecord.xml
+++ b/projects/BFDR/BirthRecord.xml
@@ -1494,6 +1494,44 @@
             <para>Console.WriteLine($"Father's Industry: {ExampleBirthRecord.FatherIndustry}");</para>
             </example>
         </member>
+        <member name="P:BFDR.BirthRecord.MotherHeight">
+            <summary>Mother Height.</summary>
+            <value>the height of the mother, given in inches</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.MotherHeight = 55;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Mother's Height: {ExampleBirthRecord.MotherHeight}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.MotherHeightEditFlag">
+            <summary>Mother Height Edit Flag.</summary>
+            <value>the mother's height level edit flag. A Dictionary representing a code, containing the following key/value pairs:
+            <para>"code" - the code</para>
+            <para>"system" - the code system this code belongs to</para>
+            <para>"display" - a human readable meaning of the code</para>
+            </value>
+            <example>
+            <para>// Setter:</para>
+            <para>Dictionary&lt;string, string&gt; elevel = new Dictionary&lt;string, string&gt;();</para>
+            <para>height.Add("code", "0");</para>
+            <para>height.Add("system", CodeSystems.BypassEditFlag);</para>
+            <para>height.Add("display", "Edit Passed");</para>
+            <para>ExampleBirthRecord.MotherHeightEditFlag = height;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Mother Height: {ExampleBirthRecord.MotherHeightEditFlag['display']}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.MotherHeightEditFlagHelper">
+            <summary>Mother Height Edit Flag Helper</summary>
+            <value>Mother Height Edit Flag.</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.MotherHeightEditFlagHelper = "0";</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Mother's Height Edit Flag: {ExampleBirthRecord.MotherHeightHelperEditFlag}");</para>
+            </example>
+        </member>
         <member name="P:BFDR.BirthRecord.MotherEducationLevel">
             <summary>Mother's Education Level.</summary>
             <value>the mother's education level. A Dictionary representing a code, containing the following key/value pairs:</value>

--- a/projects/BFDR/BirthRecord_submissionProperties.cs
+++ b/projects/BFDR/BirthRecord_submissionProperties.cs
@@ -4735,6 +4735,131 @@ namespace BFDR
             set => SetIndustry("FTH", value);
         }
 
+        /// <summary>Mother Height.</summary>
+        /// <value>the height of the mother, given in inches</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.MotherHeight = 55;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Mother's Height: {ExampleBirthRecord.MotherHeight}");</para>
+        /// </example>
+        [Property("MotherHeight", Property.Types.Int32, "Mother Prenatal", "Mother's Height.", false, BFDR.IGURL.ObservationMotherHeight, true, 134)]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='8302-2')", "")]
+        public int? MotherHeight
+        {
+            get
+            {
+              Observation observation = GetObservation("8302-2");
+              return (int?)(observation?.Value as Hl7.Fhir.Model.Quantity)?.Value;
+            }
+
+            set
+            {
+              Observation obs = GetOrCreateObservation("8302-2", CodeSystems.LOINC, BFDR.ProfileURL.ObservationMotherHeight, MOTHER_PRENATAL_SECTION, Mother.Id);
+              obs.Category.Add(new CodeableConcept(CodeSystems.ObservationCategory, "vital-signs"));
+              string unit = "in_i";
+              // Create an empty quantity if needed
+              if (obs.Value == null || obs.Value as Quantity == null)
+              {
+                obs.Value = new Hl7.Fhir.Model.Quantity();
+              }
+              // Set the properties of the value individually to preserve any existing obs.Value.Extension entries
+              if (value != null)
+              {
+                (obs.Value as Quantity).Value = (int)value;
+                (obs.Value as Quantity).Unit = unit;
+                (obs.Value as Quantity).Code = unit;
+              }
+            }
+        }
+
+        /// <summary>Mother Height Edit Flag.</summary>
+        /// <value>the mother's height level edit flag. A Dictionary representing a code, containing the following key/value pairs:
+        /// <para>"code" - the code</para>
+        /// <para>"system" - the code system this code belongs to</para>
+        /// <para>"display" - a human readable meaning of the code</para>
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>Dictionary&lt;string, string&gt; elevel = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>height.Add("code", "0");</para>
+        /// <para>height.Add("system", CodeSystems.BypassEditFlag);</para>
+        /// <para>height.Add("display", "Edit Passed");</para>
+        /// <para>ExampleBirthRecord.MotherHeightEditFlag = height;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Mother Height: {ExampleBirthRecord.MotherHeightEditFlag['display']}");</para>
+        /// </example>
+        [Property("Mother Height Edit Flag", Property.Types.Dictionary, "Mother Prenatal", "Mother's Height Edit Flag.", true, IGURL.ObservationMotherHeight, true, 136)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='8302-2')", "")]
+        public Dictionary<string, string> MotherHeightEditFlag
+        {
+            get
+            {
+                Observation observation = GetObservation("8302-2");
+                Extension extension = observation?.Value?.Extension.FirstOrDefault(ext => ext.Url == VRExtensionURLs.BypassEditFlag);
+                if (extension != null && extension.Value != null && extension.Value.GetType() == typeof(CodeableConcept))
+                {
+                    return CodeableConceptToDict((CodeableConcept)extension.Value);
+                }
+                return EmptyCodeableDict();
+            }
+
+            set
+            {
+                Observation obs = GetOrCreateObservation("8302-2", CodeSystems.LOINC, BFDR.ProfileURL.ObservationMotherHeight, MOTHER_PRENATAL_SECTION, Mother.Id);
+                obs.Extension.RemoveAll(ext => ext.Url == VRExtensionURLs.BypassEditFlag);
+                obs.Extension.Add(new Extension(VRExtensionURLs.BypassEditFlag, DictToCodeableConcept(value)));
+            }
+        }
+
+        /// <summary>Mother Height Edit Flag Helper</summary>
+        /// <value>Mother Height Edit Flag.</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.MotherHeightEditFlagHelper = "0";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Mother's Height Edit Flag: {ExampleBirthRecord.MotherHeightHelperEditFlag}");</para>
+        /// </example>
+        [Property("Mother's Height Edit Flag Helper", Property.Types.String, "Mother Prenatal", "Mother's Height Edit Flag Helper.", false, IGURL.ObservationMotherHeight, true, 136)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='8302-2')", "")]
+        public string MotherHeightEditFlagHelper
+        {
+
+            get 
+            {
+              Dictionary<string, string> editFlag = GetWeightEditFlag("8302-2");
+              if (editFlag.ContainsKey("code"))
+              {
+                  string flagCode = editFlag["code"];
+                  if (!String.IsNullOrWhiteSpace(flagCode))
+                  {
+                      return flagCode;
+                  }
+              }
+              return null;
+            }
+            set 
+            {
+                Observation obs = GetOrCreateObservation("8302-2", CodeSystems.LOINC, BFDR.ProfileURL.ObservationMotherHeight, MOTHER_PRENATAL_SECTION, Mother.Id);
+                obs.Extension.RemoveAll(ext => ext.Url == VRExtensionURLs.BypassEditFlag);
+
+                if (String.IsNullOrEmpty(value))
+                {
+                    obs.Value.Extension.Add(new Extension(VRExtensionURLs.BypassEditFlag, DictToCodeableConcept(EmptyCodeDict())));
+                    return;
+                }
+                Dictionary<string, string> dictionary = new Dictionary<string, string>
+                {
+                    { "code", value },
+                    { "system", "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-vr-edit-flags" }
+                };
+                obs.Value.Extension.Add(new Extension(VRExtensionURLs.BypassEditFlag, DictToCodeableConcept(dictionary)));
+            }
+        }
         /// <summary>Mother's Education Level.</summary>
         /// <value>the mother's education level. A Dictionary representing a code, containing the following key/value pairs:</value>
         /// <example>

--- a/projects/BFDR/IJENatality.cs
+++ b/projects/BFDR/IJENatality.cs
@@ -2391,12 +2391,26 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
+                // not using NumericAllowingUnknown_Get due to the length of the ije field (ft) being then imposed on FHIR field (in)
+                // string height_ft = NumericAllowingUnknown_Get("HFT", "MotherHeight");
+                IJEField info = FieldInfo("HFT");
+                int? value = (int?)Record.GetType().GetProperty("MotherHeight").GetValue(record);
+                if (value == null) return new String(' ', info.Length); // No value specified
+                if (value == -1) return new String('9', info.Length); // Explicitly set to unknown
+                return (value / 12).ToString();
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location:
+              if (value != "9" && !string.IsNullOrWhiteSpace(value)){
+                if (!string.IsNullOrWhiteSpace(HIN) && HIN != "-1"){
+                    record.MotherHeight = int.Parse(value)*12+int.Parse(HIN);
+                } else {
+                  record.MotherHeight = int.Parse(value);
+                }
+                record.MotherHeight = int.Parse(value)*12;
+              } else {
+                record.MotherHeight = -1;
+              }
             }
         }
 
@@ -2406,12 +2420,25 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
+                // not using NumericAllowingUnknown_Get due to the length of the ije field (%12 in) being then imposed on FHIR field (total in)
+                // string height_in = NumericAllowingUnknown_Get("HIN", "MotherHeight");
+                IJEField info = FieldInfo("HIN");
+                int? value = (int?)Record.GetType().GetProperty("MotherHeight").GetValue(record);
+                if (value == null) return new String(' ', info.Length); // No value specified
+                if (value == -1) return new String('9', info.Length); // Explicitly set to unknown
+                return (value % 12).ToString();
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location:
+              if (value != "99" && !string.IsNullOrWhiteSpace(value)){
+                if (!string.IsNullOrWhiteSpace(HFT) && HFT != "-1"){
+                    record.MotherHeight = int.Parse(value)+(int.Parse(HFT)*12);
+                  } else {
+                    record.MotherHeight = int.Parse(value);
+                  }
+              } else {
+                record.MotherHeight = -1;
+              }
             }
         }
 
@@ -2421,12 +2448,11 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
+                return Get_MappingFHIRToIJE(VR.Mappings.EditBypass01234.FHIRToIJE, "MotherHeightEditFlag", "HGT_BYPASS");
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location:
+                Set_MappingIJEToFHIR(VR.Mappings.EditBypass01234.IJEToFHIR, "HGT_BYPASS", "MotherHeightEditFlag",  value);
             }
         }
 


### PR DESCRIPTION
### Summary

Because HIN (height inches) and HFT (height feet) both map to a single FHIR field, both IJE setters take height in inches. This seemed like the most parsimonious solution - open to feedback on a different implementation. See the tests in `NatalityData_should` for how it looks in practice.