### PR TITLE
fix(bfdr): add FHIRSubject annotation for InfantLiving and SSNRequested

### DIFF
--- a/projects/BFDR/BirthRecord_submissionProperties.cs
+++ b/projects/BFDR/BirthRecord_submissionProperties.cs
@@ -5695,6 +5695,7 @@ namespace BFDR
         /// </example>
         [Property("InfantLiving", Property.Types.Bool, "InfantLiving", "InfantLiving", false, BFDR.IGURL.ObservationInfantLiving, true, 288)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='73757-7')", "")]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
         public bool? InfantLiving
         {
             get
@@ -5839,6 +5840,7 @@ namespace BFDR
         /// </example>
         [Property("SSNRequested", Property.Types.Bool, "SSNRequested", "SSNRequested", false, BFDR.IGURL.ObservationSSNRequestedForChild, true, 288)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='87295-2')", "")]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
         public bool? SSNRequested
         {
             get


### PR DESCRIPTION
I checked all fields where GetOrCreateObservation or UpdateEntry (also calls subjectID()) was used. Using the debugger, I validated that the correct FHIR subjects were being assigned