### PR TITLE
refactor(bfdr): constructor clean up

### DIFF
--- a/projects/BFDR.Tests/fixtures/json/BirthRecordDemographicsCodingUpdateMessage.json
+++ b/projects/BFDR.Tests/fixtures/json/BirthRecordDemographicsCodingUpdateMessage.json
@@ -1,1 +1,79 @@
-{"resourceType":"Bundle","id":"fcff7733-54dd-40a4-83df-8ed1924dfdbf","type":"message","timestamp":"2023-12-21T17:30:04.864065-05:00","entry":[{"fullUrl":"urn:uuid:ef3c64a6-eb49-4cb7-9e4b-7d4b246a8934","resource":{"resourceType":"MessageHeader","id":"ef3c64a6-eb49-4cb7-9e4b-7d4b246a8934","eventUri":"http://nchs.cdc.gov/bfdr_demographics_coding_update","destination":[{"endpoint":"http://nchs.cdc.gov/bfdr_submission"}],"focus":[{"reference":"urn:uuid:a9ee690e-2f09-4549-9c1f-414a25d37128"}]}},{"fullUrl":"urn:uuid:68fc19b3-7ac5-4ed0-a5f3-c3a1be96bda1","resource":{"resourceType":"Parameters","id":"68fc19b3-7ac5-4ed0-a5f3-c3a1be96bda1","parameter":[{"name":"cert_no","valueUnsignedInt":100},{"name":"state_auxiliary_id","valueString":"123"},{"name":"birth_year","valueUnsignedInt":2023},{"name":"jurisdiction_id","valueString":"YC"}]}},{"fullUrl":"urn:uuid:a9ee690e-2f09-4549-9c1f-414a25d37128","resource":{"resourceType":"Bundle","id":"a9ee690e-2f09-4549-9c1f-414a25d37128","meta":{"profile":["http://hl7.org/fhir/us/bfdr/StructureDefinition/bfdr-demographic-coded-bundle"]},"identifier":{"extension":[{"url":"http://hl7.org/fhir/us/vrdr/StructureDefinition/CertificateNumber","valueString":"100"},{"url":"http://hl7.org/fhir/us/bfdr/StructureDefinition/AuxiliaryStateIdentifier1","valueString":"123"}],"system":"http://nchs.cdc.gov/bfdr_id","value":"2023YC000100"},"type":"collection","timestamp":"2023-12-21T17:30:04.866126-05:00"}}]}
+{
+  "resourceType": "Bundle",
+  "id": "fcff7733-54dd-40a4-83df-8ed1924dfdbf",
+  "type": "message",
+  "timestamp": "2023-12-21T17:30:04.864065-05:00",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:ef3c64a6-eb49-4cb7-9e4b-7d4b246a8934",
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "ef3c64a6-eb49-4cb7-9e4b-7d4b246a8934",
+        "eventUri": "http://nchs.cdc.gov/bfdr_demographics_coding_update",
+        "destination": [
+          {
+            "endpoint": "http://nchs.cdc.gov/bfdr_submission"
+          }
+        ],
+        "focus": [
+          {
+            "reference": "urn:uuid:a9ee690e-2f09-4549-9c1f-414a25d37128"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:68fc19b3-7ac5-4ed0-a5f3-c3a1be96bda1",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "68fc19b3-7ac5-4ed0-a5f3-c3a1be96bda1",
+        "parameter": [
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 100
+          },
+          {
+            "name": "state_auxiliary_id",
+            "valueString": "123"
+          },
+          {
+            "name": "birth_year",
+            "valueUnsignedInt": 2023
+          },
+          {
+            "name": "jurisdiction_id",
+            "valueString": "YC"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:a9ee690e-2f09-4549-9c1f-414a25d37128",
+      "resource": {
+        "resourceType": "Bundle",
+        "id": "a9ee690e-2f09-4549-9c1f-414a25d37128",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/bfdr/StructureDefinition/bfdr-demographic-coded-bundle"
+          ]
+        },
+        "identifier": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/CertificateNumber",
+              "valueString": "100"
+            },
+            {
+              "url": "http://hl7.org/fhir/us/bfdr/StructureDefinition/AuxiliaryStateIdentifier1",
+              "valueString": "123"
+            }
+          ],
+          "system": "http://nchs.cdc.gov/bfdr_id",
+          "value": "2023YC000100"
+        },
+        "type": "collection",
+        "timestamp": "2023-12-21T17:30:04.866126-05:00"
+      }
+    }
+  ]
+}

--- a/projects/BFDR.Tests/fixtures/json/RaceEthnicityCaseRecord.json
+++ b/projects/BFDR.Tests/fixtures/json/RaceEthnicityCaseRecord.json
@@ -89,7 +89,7 @@
         "id": "patient-child-babyg-quinn",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrsandbox/StructureDefinition/Patient-child-vr"
+            "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Patient-child-vr"
           ]
         },
         "text": {

--- a/projects/BFDR.Tests/fixtures/json/RaceEthnicityCaseRecord2.json
+++ b/projects/BFDR.Tests/fixtures/json/RaceEthnicityCaseRecord2.json
@@ -89,7 +89,7 @@
         "id": "patient-child-babyg-quinn",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/vrsandbox/StructureDefinition/Patient-child-vr"
+            "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Patient-child-vr"
           ]
         },
         "text": {

--- a/projects/BFDR/BirthRecord.xml
+++ b/projects/BFDR/BirthRecord.xml
@@ -62,12 +62,6 @@
         <member name="F:BFDR.BirthRecord.Certifier">
             <summary>The Certifier.</summary>
         </member>
-        <member name="F:BFDR.BirthRecord.InputRaceAndEthnicityObsMother">
-            <summary>The Mother's Race and Ethnicity provided by Jurisdiction.</summary>
-        </member>
-        <member name="F:BFDR.BirthRecord.InputRaceAndEthnicityObsFather">
-            <summary>The Father's Race and Ethnicity provided by Jurisdiction.</summary>
-        </member>
         <member name="F:BFDR.BirthRecord.EncounterBirth">
             <summary>The encounter of the birth.</summary>
         </member>
@@ -91,12 +85,6 @@
             the mother or newborn, then extract the corresponding resource id.</summary>
             <param name="propertyName">name of the BirthRecord property</param>
             <returns>the subject's resource id</returns>
-        </member>
-        <member name="M:BFDR.BirthRecord.CreateInputRaceEthnicityObsMother">
-            <summary> Create Mother Input Race and Ethnicity </summary>
-        </member>
-        <member name="M:BFDR.BirthRecord.CreateInputRaceEthnicityObsFather">
-            <summary> Create Father Input Race and Ethnicity </summary>
         </member>
         <member name="M:BFDR.BirthRecord.CreateAttendant">
             <summary>Create Attendant/Practitioner.</summary>

--- a/projects/BFDR/BirthRecord_constructors.cs
+++ b/projects/BFDR/BirthRecord_constructors.cs
@@ -203,7 +203,8 @@ namespace BFDR
                 Composition.Section.Add(fatherSection);
             } else 
             {
-                throw new System.ArgumentException("Failed to find a Mother or Father for Demographic Information.");
+                //TODO: demographic content composition should have a relevant mother and/or father - this should be an exception
+                Console.WriteLine("Failed to find a Mother or Father for Demographic Information.");
             }            
             // NOTE: If we want to put observations in the coded content bundle that don't have references we'll
             // need to move them over by grabbing them by the observation code

--- a/projects/BFDR/BirthRecord_constructors.cs
+++ b/projects/BFDR/BirthRecord_constructors.cs
@@ -267,18 +267,6 @@ namespace BFDR
                 {
                     throw new System.ArgumentException("Found an Observation resource that did not contain a code. All Observations must include a code to specify what the Observation is referring to.");
                 }
-                switch (obs.Code.Coding.First().Code)
-                {
-                    case "inputraceandethnicityMother":
-                        InputRaceAndEthnicityObsMother = (Observation)obs;
-                        break;
-                    case "inputraceandethnicityFather":
-                        InputRaceAndEthnicityObsFather = (Observation)obs;
-                        break;
-                    default:
-                        // skip
-                        break;
-                }
             }
 
         }

--- a/projects/BFDR/BirthRecord_constructors.cs
+++ b/projects/BFDR/BirthRecord_constructors.cs
@@ -85,12 +85,25 @@ namespace BFDR
                 ProfileURL.EncounterMaternity
             };
 
-            // TODO: Start with an empty certifier. - Need reference in Composition
             CreateCertifier();
+
+            Encounter.ParticipantComponent p = new Encounter.ParticipantComponent();
+            p.Type.Add(new CodeableConcept(VR.CodeSystems.LOINC, "87287-9"));
+            p.Individual = new ResourceReference("urn:uuid:" + Certifier.Id);
+            EncounterMaternity.Participant.Add(p);
+
             CreateAttendant();
 
+            //TODO: Author is a required field in the composition
+            // Author = new Organization();
+            // AuthorOrganization.Id = Guid.NewGuid().ToString();
+            // AuthorOrganization.Active = true;
+            // // Organization requires a name
+            // AuthorOrganization.Name = "VRO";
+
+
             // TODO: Start with an empty certification. - need reference in Composition
-            //CreateBirthCertification();
+            // CreateBirthCertification();
 
             // Add Composition to bundle. As the record is filled out, new entries will be added to this element.
             // Sections will be added to the composition as needed by the VitalRecord.AddReferenceToComposition method
@@ -101,7 +114,8 @@ namespace BFDR
             Composition.Meta.Profile = composition_profile;
             Composition.Type = new CodeableConcept(CodeSystems.LOINC, "71230-7", "Birth certificate", null);
             Composition.Subject = new ResourceReference("urn:uuid:" + Child.Id);
-            //Composition.Author.Add(new ResourceReference("urn:uuid:" + Certifier.Id));
+            // Author for jurisdictions is an organization (VRO)
+            // Composition.Author.Add(new ResourceReference("urn:uuid:" + Author.Id));
             Composition.Title = "Birth Certificate";
             Composition.Attester.Add(new Composition.AttesterComponent());
             //Composition.Attester.First().Party = new ResourceReference("urn:uuid:" + Certifier.Id);
@@ -111,6 +125,7 @@ namespace BFDR
             //eventComponent.Detail.Add(new ResourceReference("urn:uuid:" + BirthCertification.Id));
             Composition.Event.Add(eventComponent);
             Bundle.AddResourceEntry(Composition, "urn:uuid:" + Composition.Id);
+            Composition.Encounter = new ResourceReference("urn:uuid:" + EncounterMaternity.Id);
 
 
             // Add entries for the child, mother, and father.
@@ -118,16 +133,10 @@ namespace BFDR
             Bundle.AddResourceEntry(Mother, "urn:uuid:" + Mother.Id);
             Bundle.AddResourceEntry(Father, "urn:uuid:" + Father.Id);
 
-            // AddReferenceToComposition(Certifier.Id, "BirthCertification");
             Bundle.AddResourceEntry(Certifier, "urn:uuid:" + Certifier.Id);
             Bundle.AddResourceEntry(Attendant, "urn:uuid:" + Attendant.Id);
             // AddReferenceToComposition(BirthCertification.Id, "BirthCertification");
             // Bundle.AddResourceEntry(BirthCertification, "urn:uuid:" + BirthCertification.Id);
-
-            // AddReferenceToComposition(Pronouncer.Id, "OBE");
-            // Bundle.AddResourceEntry(Pronouncer, "urn:uuid:" + Pronouncer.Id);
-            //Bundle.AddResourceEntry(Mortician, "urn:uuid:" + Mortician.Id);
-            //Bundle.AddResourceEntry(FuneralHomeDirector, "urn:uuid:" + FuneralHomeDirector.Id);
 
             // Create a Navigator for this new birth record.
             Navigator = Bundle.ToTypedElement();
@@ -164,7 +173,38 @@ namespace BFDR
             dccBundle.Timestamp = DateTime.Now;
             // Make sure to include the base identifiers, including certificate number and auxiliary state IDs
             dccBundle.Identifier = Bundle.Identifier;
-            // TODO: Here we'd determine what resources to add to this particular bundle, see VRDR for example
+            // Add composition
+            Composition.Id = Guid.NewGuid().ToString();
+            Composition.Status = CompositionStatus.Final;
+            Composition.Meta = new Meta();
+            string[] composition_profile = { ProfileURL.CompositionCodedRaceAndEthnicity};
+            Composition.Meta.Profile = composition_profile;
+            Composition.Type = new CodeableConcept(CodeSystems.LOINC, "86805-9", "Coded Race and Ethnicity", null);
+            // Child may also be a decedent fetus
+            // Composition.Subject = new ResourceReference("urn:uuid:" + Child.Id);
+            //TODO: Author is a required field for the composition - should be NCHS
+            // Composition.Author = new ResourceReference("urn:uuid:" + Author.Id);
+            Composition.Title = "Demographic Coded Content";
+            if (Mother != null)
+            {
+                Composition.SectionComponent motherSection = new Composition.SectionComponent
+                {
+                  Code = new CodeableConcept(CodeSystems.RoleCode_HL7_V3, "MTH")
+                  //TODO: add mother, input, coded race/ethnicity reference slices
+                };
+                Composition.Section.Add(motherSection);
+            } else if (Father != null)
+            {
+                Composition.SectionComponent fatherSection = new Composition.SectionComponent
+                {
+                  Code = new CodeableConcept(CodeSystems.RoleCode_HL7_V3, "NFTH")
+                  //TODO: add father, input, coded race/ethnicity reference slices
+                };
+                Composition.Section.Add(fatherSection);
+            } else 
+            {
+                throw new System.ArgumentException("Failed to find a Mother or Father for Demographic Information.");
+            }            
             // NOTE: If we want to put observations in the coded content bundle that don't have references we'll
             // need to move them over by grabbing them by the observation code
             return dccBundle;
@@ -175,9 +215,12 @@ namespace BFDR
         {
             // Depending on the type of bundle, some of this information may not be present, so check it in a null-safe way
             string profile = Bundle.Meta?.Profile?.FirstOrDefault();
-            // TODO: The BFDR composition type can be one of 4 types, described here:
-            // https://build.fhir.org/ig/HL7/fhir-bfdr/StructureDefinition-Bundle-document-bfdr.html
-            bool fullRecord = false;    // VRDR.ProfileURL.DeathCertificateDocument.Equals(profile);
+            // TODO: Currently we support natality: https://build.fhir.org/ig/HL7/fhir-bfdr/StructureDefinition-Bundle-document-birth-report.html
+            // but will want to support fetal death as well: https://build.fhir.org/ig/HL7/fhir-bfdr/StructureDefinition-Bundle-document-fetal-death-report.html
+            // and will have to check if it is birthRecord or fetalDeathRecords, rather than just fullRecord
+            // bool birthRecord = BFDR.ProfileURL.BundleDocumentBirthReport.Equals(profile);
+            // bool fetalDeathRecord = BFDR.ProfileURL.BundleDocumentBirthReport.Equals(profile);
+            bool fullRecord = BFDR.ProfileURL.BundleDocumentBirthReport.Equals(profile);
             // Grab Composition
             var compositionEntry = Bundle.Entry.FirstOrDefault(entry => entry.Resource is Composition);
             if (compositionEntry != null)
@@ -210,9 +253,10 @@ namespace BFDR
             {
                 throw new System.ArgumentException("Failed to find a Child (Patient).");
             }
+            // TODO: when supporting fetal death, will have to impl. fetalDeathIdentifier
             if (fullRecord)
             {
-                // TODO - this may need to have some behavior based on VRDR.RestoreReferences().
+              UpdateBirthRecordIdentifier();
             }
 
             // Scan through all Observations to make sure they all have codes!

--- a/projects/BFDR/BirthRecord_constructors.cs
+++ b/projects/BFDR/BirthRecord_constructors.cs
@@ -204,7 +204,7 @@ namespace BFDR
             } else 
             {
                 //TODO: demographic content composition should have a relevant mother and/or father - this should be an exception
-                Console.WriteLine("Failed to find a Mother or Father for Demographic Information.");
+                Console.WriteLine("Warning: Failed to find a Mother or Father for Demographic Information.");
             }            
             // NOTE: If we want to put observations in the coded content bundle that don't have references we'll
             // need to move them over by grabbing them by the observation code

--- a/projects/BFDR/BirthRecord_fieldsAndCreateMethods.cs
+++ b/projects/BFDR/BirthRecord_fieldsAndCreateMethods.cs
@@ -43,12 +43,6 @@ namespace BFDR
         /// <summary>The Certifier.</summary>
         private Practitioner Certifier;
 
-        /// <summary>The Mother's Race and Ethnicity provided by Jurisdiction.</summary>
-        private Observation InputRaceAndEthnicityObsMother;
-
-        /// <summary>The Father's Race and Ethnicity provided by Jurisdiction.</summary>
-        private Observation InputRaceAndEthnicityObsFather;
-
         /// <summary>The encounter of the birth.</summary>
         private Encounter EncounterBirth;
 
@@ -109,37 +103,6 @@ namespace BFDR
                 return Mother.Id;
             }
             return subjects.First().subject == FHIRSubject.Subject.Newborn ? Child.Id : Mother.Id;
-        }
-
-        /// <summary> Create Mother Input Race and Ethnicity </summary>
-        private void CreateInputRaceEthnicityObsMother()
-        {
-            InputRaceAndEthnicityObsMother = new Observation();
-            InputRaceAndEthnicityObsMother.Id = Guid.NewGuid().ToString();
-            InputRaceAndEthnicityObsMother.Meta = new Meta();
-            string[] raceethnicity_profile = { VR.ProfileURL.InputRaceAndEthnicity };
-            InputRaceAndEthnicityObsMother.Meta.Profile = raceethnicity_profile;
-            InputRaceAndEthnicityObsMother.Status = ObservationStatus.Final;
-            InputRaceAndEthnicityObsMother.Code = new CodeableConcept(CodeSystems.InputRaceAndEthnicityPerson, "inputraceandethnicityMother", "Input Race and Ethnicity Person", null);
-            InputRaceAndEthnicityObsMother.Subject = new ResourceReference("urn:uuid:" + Child.Id);
-            InputRaceAndEthnicityObsMother.Focus.Add(new ResourceReference("urn:uuid:" + Mother.Id));
-            AddReferenceToComposition(InputRaceAndEthnicityObsMother.Id, RACE_ETHNICITY_PROFILE_MOTHER);
-            Bundle.AddResourceEntry(InputRaceAndEthnicityObsMother, "urn:uuid:" + InputRaceAndEthnicityObsMother.Id);
-        }
-
-        /// <summary> Create Father Input Race and Ethnicity </summary>
-        private void CreateInputRaceEthnicityObsFather()
-        {
-            InputRaceAndEthnicityObsFather = new Observation();
-            InputRaceAndEthnicityObsFather.Id = Guid.NewGuid().ToString();
-            InputRaceAndEthnicityObsFather.Meta = new Meta();
-            string[] raceethnicity_profile = { VR.ProfileURL.InputRaceAndEthnicity };
-            InputRaceAndEthnicityObsFather.Meta.Profile = raceethnicity_profile;
-            InputRaceAndEthnicityObsFather.Status = ObservationStatus.Final;
-            InputRaceAndEthnicityObsFather.Code = new CodeableConcept(CodeSystems.InputRaceAndEthnicityPerson, "inputraceandethnicityFather", "Input Race and Ethnicity Person", null);
-            InputRaceAndEthnicityObsFather.Subject = new ResourceReference("urn:uuid:" + Child.Id);
-            AddReferenceToComposition(InputRaceAndEthnicityObsFather.Id, RACE_ETHNICITY_PROFILE_FATHER);
-            Bundle.AddResourceEntry(InputRaceAndEthnicityObsFather, "urn:uuid:" + InputRaceAndEthnicityObsFather.Id);
         }
 
         /// <summary>Create Attendant/Practitioner.</summary>

--- a/projects/BFDR/BirthRecord_submissionProperties.cs
+++ b/projects/BFDR/BirthRecord_submissionProperties.cs
@@ -3215,6 +3215,7 @@ namespace BFDR
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='inputraceandethnicityMother')", "")]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
         public Dictionary<string, string> MotherEthnicity1
         {
             get
@@ -3293,6 +3294,7 @@ namespace BFDR
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='inputraceandethnicityMother')", "")]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
         public Dictionary<string, string> MotherEthnicity2
         {
             get
@@ -3371,6 +3373,7 @@ namespace BFDR
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='inputraceandethnicityMother')", "")]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
         public Dictionary<string, string> MotherEthnicity3
         {
             get
@@ -3450,6 +3453,7 @@ namespace BFDR
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='inputraceandethnicityMother')", "")]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
         public Dictionary<string, string> MotherEthnicity4
         {
             get
@@ -3521,6 +3525,7 @@ namespace BFDR
         [Property("MotherEthnicityLiteral", Property.Types.String, "Race and Ethnicity Profiles", "Mother's Ethnicity Literal.", true, VR.IGURL.InputRaceAndEthnicity, false, 34)]
         [PropertyParam("ethnicity", "The literal string to describe ethnicity.")]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='inputraceandethnicityMother')", "")]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
         public string MotherEthnicityLiteral
         {
             get
@@ -3559,6 +3564,7 @@ namespace BFDR
         /// </example>
         [Property("MotherRace", Property.Types.TupleArr, "Race and Ethnicity Profiles", "Mother's Race", true, VR.IGURL.InputRaceAndEthnicity, true, 38)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='inputraceandethnicityMother')", "")]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
         public Tuple<string, string>[] MotherRace
         {
             get
@@ -3679,6 +3685,7 @@ namespace BFDR
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='inputraceandethnicityFather')", "")]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
         public Dictionary<string, string> FatherEthnicity1
         {
             get
@@ -3757,6 +3764,7 @@ namespace BFDR
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='inputraceandethnicityFather')", "")]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
         public Dictionary<string, string> FatherEthnicity2
         {
             get
@@ -3835,6 +3843,7 @@ namespace BFDR
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='inputraceandethnicityFather')", "")]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
         public Dictionary<string, string> FatherEthnicity3
         {
             get
@@ -3914,6 +3923,7 @@ namespace BFDR
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='inputraceandethnicityFather')", "")]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
         public Dictionary<string, string> FatherEthnicity4
         {
             get
@@ -3986,6 +3996,7 @@ namespace BFDR
         [Property("FatherEthnicityLiteral", Property.Types.String, "Race and Ethnicity Profiles", "Father's Ethnicity Literal.", true, VR.IGURL.InputRaceAndEthnicity, false, 34)]
         [PropertyParam("ethnicity", "The literal string to describe ethnicity.")]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='inputraceandethnicityFather')", "")]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
         public string FatherEthnicityLiteral
         {
             get
@@ -4025,6 +4036,7 @@ namespace BFDR
         /// </example>
         [Property("FatherRace", Property.Types.TupleArr, "Race and Ethnicity Profiles", "Father's Race", true, VR.IGURL.InputRaceAndEthnicity, true, 38)]
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='inputraceandethnicityFather')", "")]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
         public Tuple<string, string>[] FatherRace
         {
             get

--- a/projects/BFDR/BirthRecord_submissionProperties.cs
+++ b/projects/BFDR/BirthRecord_submissionProperties.cs
@@ -3219,13 +3219,11 @@ namespace BFDR
         {
             get
             {
-                if (InputRaceAndEthnicityObsMother != null)
+                Observation obs = GetOrCreateObservation("inputraceandethnicityMother", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
+                Observation.ComponentComponent ethnicity = obs.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Mexican);
+                if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
                 {
-                    Observation.ComponentComponent ethnicity = InputRaceAndEthnicityObsMother.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Mexican);
-                    if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
-                    {
-                        return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
-                    }
+                    return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
                 }
                 return EmptyCodeableDict();
             }
@@ -3234,15 +3232,13 @@ namespace BFDR
                 if (value["code"] == "") {
                     return;
                 }
-                if (InputRaceAndEthnicityObsMother == null)
-                {
-                    CreateInputRaceEthnicityObsMother();
-                }
-                InputRaceAndEthnicityObsMother.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Mexican);
+                Observation obs = GetOrCreateObservation("inputraceandethnicityMother", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
+                obs.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Mexican);
                 Observation.ComponentComponent component = new Observation.ComponentComponent();
                 component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, NvssEthnicity.Mexican, NvssEthnicity.MexicanDisplay, null);
                 component.Value = DictToCodeableConcept(value);
-                InputRaceAndEthnicityObsMother.Component.Add(component);
+                obs.Component.Add(component);
+                obs.Subject = new ResourceReference("urn:uuid:" + Child.Id);
             }
         }
 
@@ -3301,13 +3297,11 @@ namespace BFDR
         {
             get
             {
-                if (InputRaceAndEthnicityObsMother != null)
+                Observation obs = GetOrCreateObservation("inputraceandethnicityMother", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
+                Observation.ComponentComponent ethnicity = obs.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.PuertoRican);
+                if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
                 {
-                    Observation.ComponentComponent ethnicity = InputRaceAndEthnicityObsMother.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.PuertoRican);
-                    if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
-                    {
-                        return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
-                    }
+                    return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
                 }
                 return EmptyCodeableDict();
             }
@@ -3316,15 +3310,13 @@ namespace BFDR
                 if (value["code"] == "") {
                     return;
                 }
-                if (InputRaceAndEthnicityObsMother == null)
-                {
-                    CreateInputRaceEthnicityObsMother();
-                }
-                InputRaceAndEthnicityObsMother.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.PuertoRican);
+                Observation obs = GetOrCreateObservation("inputraceandethnicityMother", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
+                obs.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.PuertoRican);
                 Observation.ComponentComponent component = new Observation.ComponentComponent();
                 component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, NvssEthnicity.PuertoRican, NvssEthnicity.PuertoRicanDisplay, null);
                 component.Value = DictToCodeableConcept(value);
-                InputRaceAndEthnicityObsMother.Component.Add(component);
+                obs.Component.Add(component);
+                obs.Subject = new ResourceReference("urn:uuid:" + Child.Id);
             }
         }
 
@@ -3383,13 +3375,11 @@ namespace BFDR
         {
             get
             {
-                if (InputRaceAndEthnicityObsMother != null)
+                Observation obs = GetOrCreateObservation("inputraceandethnicityMother", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
+                Observation.ComponentComponent ethnicity = obs.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Cuban);
+                if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
                 {
-                    Observation.ComponentComponent ethnicity = InputRaceAndEthnicityObsMother.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Cuban);
-                    if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
-                    {
-                        return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
-                    }
+                    return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
                 }
                 return EmptyCodeableDict();
             }
@@ -3398,15 +3388,13 @@ namespace BFDR
                 if (value["code"] == "") {
                     return;
                 }
-                if (InputRaceAndEthnicityObsMother == null)
-                {
-                    CreateInputRaceEthnicityObsMother();
-                }
-                InputRaceAndEthnicityObsMother.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Cuban);
+                Observation obs = GetOrCreateObservation("inputraceandethnicityMother", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
+                obs.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Cuban);
                 Observation.ComponentComponent component = new Observation.ComponentComponent();
                 component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, NvssEthnicity.Cuban, NvssEthnicity.CubanDisplay, null);
                 component.Value = DictToCodeableConcept(value);
-                InputRaceAndEthnicityObsMother.Component.Add(component);
+                obs.Component.Add(component);
+                obs.Subject = new ResourceReference("urn:uuid:" + Child.Id);
             }
         }
 
@@ -3466,13 +3454,11 @@ namespace BFDR
         {
             get
             {
-                if (InputRaceAndEthnicityObsMother != null)
+                Observation obs = GetOrCreateObservation("inputraceandethnicityMother", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
+                Observation.ComponentComponent ethnicity = obs.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Other);
+                if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
                 {
-                    Observation.ComponentComponent ethnicity = InputRaceAndEthnicityObsMother.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Other);
-                    if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
-                    {
-                        return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
-                    }
+                    return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
                 }
                 return EmptyCodeableDict();
             }
@@ -3481,15 +3467,12 @@ namespace BFDR
                 if (value["code"] == "") {
                     return;
                 }
-                if (InputRaceAndEthnicityObsMother == null)
-                {
-                    CreateInputRaceEthnicityObsMother();
-                }
-                InputRaceAndEthnicityObsMother.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Other);
+                Observation obs = GetOrCreateObservation("inputraceandethnicityMother", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
+                obs.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Other);
                 Observation.ComponentComponent component = new Observation.ComponentComponent();
                 component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, NvssEthnicity.Other, NvssEthnicity.OtherDisplay, null);
                 component.Value = DictToCodeableConcept(value);
-                InputRaceAndEthnicityObsMother.Component.Add(component);
+                obs.Component.Add(component);
             }
         }
 
@@ -3542,13 +3525,11 @@ namespace BFDR
         {
             get
             {
-                if (InputRaceAndEthnicityObsMother != null)
+                Observation obs = GetOrCreateObservation("inputraceandethnicityMother", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
+                Observation.ComponentComponent ethnicity = obs.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Literal);
+                if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as FhirString != null)
                 {
-                    Observation.ComponentComponent ethnicity = InputRaceAndEthnicityObsMother.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Literal);
-                    if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as FhirString != null)
-                    {
-                        return ethnicity.Value.ToString();
-                    }
+                    return ethnicity.Value.ToString();
                 }
                 return null;
             }
@@ -3558,15 +3539,12 @@ namespace BFDR
                 {
                     return;
                 }
-                if (InputRaceAndEthnicityObsMother == null)
-                {
-                    CreateInputRaceEthnicityObsMother();
-                }
-                InputRaceAndEthnicityObsMother.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Literal);
+                Observation obs = GetOrCreateObservation("inputraceandethnicityMother", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
+                obs.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Literal);
                 Observation.ComponentComponent component = new Observation.ComponentComponent();
                 component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, NvssEthnicity.Literal, NvssEthnicity.LiteralDisplay, null);
                 component.Value = new FhirString(value);
-                InputRaceAndEthnicityObsMother.Component.Add(component);
+                obs.Component.Add(component);
             }
         }
 
@@ -3591,13 +3569,15 @@ namespace BFDR
 
                 var races = new List<Tuple<string, string>>() { };
 
-                if (InputRaceAndEthnicityObsMother == null)
+                Observation obs = GetOrCreateObservation("inputraceandethnicityMother", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
+
+                if (!obs.Component.Any())
                 {
                     return races.ToArray();
                 }
                 foreach (string raceCode in raceCodes)
                 {
-                    Observation.ComponentComponent component = InputRaceAndEthnicityObsMother.Component.Where(c => c.Code.Coding[0].Code == raceCode).FirstOrDefault();
+                    Observation.ComponentComponent component = obs.Component.Where(c => c.Code.Coding[0].Code == raceCode).FirstOrDefault();
                     if (component != null)
                     {
                         // convert boolean race codes to strings
@@ -3644,15 +3624,12 @@ namespace BFDR
                 if (value.FirstOrDefault() == null) {
                     return;
                 }
-                if (InputRaceAndEthnicityObsMother == null)
-                {
-                    CreateInputRaceEthnicityObsMother();
-                }
+                Observation obs = GetOrCreateObservation("inputraceandethnicityMother", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
                 var booleanRaceCodes = NvssRace.GetBooleanRaceCodes();
                 var literalRaceCodes = NvssRace.GetLiteralRaceCodes();
                 foreach (Tuple<string, string> element in value)
                 {
-                    InputRaceAndEthnicityObsMother.Component.RemoveAll(c => c.Code.Coding[0].Code == element.Item1);
+                    obs.Component.RemoveAll(c => c.Code.Coding[0].Code == element.Item1);
                     Observation.ComponentComponent component = new Observation.ComponentComponent();
                     String displayValue = NvssRace.GetDisplayValueForCode(element.Item1);
                     component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, element.Item1, displayValue, null);
@@ -3675,7 +3652,7 @@ namespace BFDR
                     {
                         throw new ArgumentException("Invalid race literal code found: " + element.Item1 + " with value: " + element.Item2);
                     }
-                    InputRaceAndEthnicityObsMother.Component.Add(component);
+                    obs.Component.Add(component);
                 }
 
             }
@@ -3706,13 +3683,11 @@ namespace BFDR
         {
             get
             {
-                if (InputRaceAndEthnicityObsFather != null)
+                Observation obs = GetOrCreateObservation("inputraceandethnicityFather", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
+                Observation.ComponentComponent ethnicity = obs.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Mexican);
+                if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
                 {
-                    Observation.ComponentComponent ethnicity = InputRaceAndEthnicityObsFather.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Mexican);
-                    if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
-                    {
-                        return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
-                    }
+                    return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
                 }
                 return EmptyCodeableDict();
             }
@@ -3721,15 +3696,13 @@ namespace BFDR
                 if (value["code"] == "") {
                     return;
                 }
-                if (InputRaceAndEthnicityObsFather == null)
-                {
-                    CreateInputRaceEthnicityObsFather();
-                }
-                InputRaceAndEthnicityObsFather.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Mexican);
+                Observation obs = GetOrCreateObservation("inputraceandethnicityFather", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
+                obs.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Mexican);
                 Observation.ComponentComponent component = new Observation.ComponentComponent();
                 component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, NvssEthnicity.Mexican, NvssEthnicity.MexicanDisplay, null);
                 component.Value = DictToCodeableConcept(value);
-                InputRaceAndEthnicityObsFather.Component.Add(component);
+                obs.Component.Add(component);
+                obs.Subject = new ResourceReference("urn:uuid:" + Child.Id);
             }
         }
 
@@ -3788,13 +3761,11 @@ namespace BFDR
         {
             get
             {
-                if (InputRaceAndEthnicityObsFather != null)
+                Observation obs = GetOrCreateObservation("inputraceandethnicityFather", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
+                Observation.ComponentComponent ethnicity = obs.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.PuertoRican);
+                if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
                 {
-                    Observation.ComponentComponent ethnicity = InputRaceAndEthnicityObsFather.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.PuertoRican);
-                    if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
-                    {
-                        return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
-                    }
+                    return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
                 }
                 return EmptyCodeableDict();
             }
@@ -3803,15 +3774,13 @@ namespace BFDR
                 if (value["code"] == "") {
                     return;
                 }
-                if (InputRaceAndEthnicityObsFather == null)
-                {
-                    CreateInputRaceEthnicityObsFather();
-                }
-                InputRaceAndEthnicityObsFather.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.PuertoRican);
+                Observation obs = GetOrCreateObservation("inputraceandethnicityFather", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
+                obs.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.PuertoRican);
                 Observation.ComponentComponent component = new Observation.ComponentComponent();
                 component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, NvssEthnicity.PuertoRican, NvssEthnicity.PuertoRicanDisplay, null);
                 component.Value = DictToCodeableConcept(value);
-                InputRaceAndEthnicityObsFather.Component.Add(component);
+                obs.Component.Add(component);
+                obs.Subject = new ResourceReference("urn:uuid:" + Child.Id);
             }
         }
 
@@ -3870,13 +3839,11 @@ namespace BFDR
         {
             get
             {
-                if (InputRaceAndEthnicityObsFather != null)
+                Observation obs = GetOrCreateObservation("inputraceandethnicityFather", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
+                Observation.ComponentComponent ethnicity = obs.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Cuban);
+                if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
                 {
-                    Observation.ComponentComponent ethnicity = InputRaceAndEthnicityObsFather.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Cuban);
-                    if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
-                    {
-                        return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
-                    }
+                    return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
                 }
                 return EmptyCodeableDict();
             }
@@ -3885,15 +3852,13 @@ namespace BFDR
                 if (value["code"] == "") {
                     return;
                 }
-                if (InputRaceAndEthnicityObsFather == null)
-                {
-                    CreateInputRaceEthnicityObsFather();
-                }
-                InputRaceAndEthnicityObsFather.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Cuban);
+                Observation obs = GetOrCreateObservation("inputraceandethnicityFather", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
+                obs.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Cuban);
                 Observation.ComponentComponent component = new Observation.ComponentComponent();
                 component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, NvssEthnicity.Cuban, NvssEthnicity.CubanDisplay, null);
                 component.Value = DictToCodeableConcept(value);
-                InputRaceAndEthnicityObsFather.Component.Add(component);
+                obs.Component.Add(component);
+                obs.Subject = new ResourceReference("urn:uuid:" + Child.Id);
             }
         }
 
@@ -3953,13 +3918,11 @@ namespace BFDR
         {
             get
             {
-                if (InputRaceAndEthnicityObsFather != null)
+                Observation obs = GetOrCreateObservation("inputraceandethnicityFather", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
+                Observation.ComponentComponent ethnicity = obs.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Other);
+                if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
                 {
-                    Observation.ComponentComponent ethnicity = InputRaceAndEthnicityObsFather.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Other);
-                    if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as CodeableConcept != null)
-                    {
-                        return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
-                    }
+                    return CodeableConceptToDict((CodeableConcept)ethnicity.Value);
                 }
                 return EmptyCodeableDict();
             }
@@ -3968,15 +3931,13 @@ namespace BFDR
                 if (value["code"] == "") {
                     return;
                 }
-                if (InputRaceAndEthnicityObsFather == null)
-                {
-                    CreateInputRaceEthnicityObsFather();
-                }
-                InputRaceAndEthnicityObsFather.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Other);
+                Observation obs = GetOrCreateObservation("inputraceandethnicityFather", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
+                obs.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Other);
                 Observation.ComponentComponent component = new Observation.ComponentComponent();
                 component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, NvssEthnicity.Other, NvssEthnicity.OtherDisplay, null);
                 component.Value = DictToCodeableConcept(value);
-                InputRaceAndEthnicityObsFather.Component.Add(component);
+                obs.Component.Add(component);
+                obs.Subject = new ResourceReference("urn:uuid:" + Child.Id);
             }
         }
 
@@ -4029,13 +3990,11 @@ namespace BFDR
         {
             get
             {
-                if (InputRaceAndEthnicityObsFather != null)
+                Observation obs = GetOrCreateObservation("inputraceandethnicityFather", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
+                Observation.ComponentComponent ethnicity = obs.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Literal);
+                if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as FhirString != null)
                 {
-                    Observation.ComponentComponent ethnicity = InputRaceAndEthnicityObsFather.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Literal);
-                    if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as FhirString != null)
-                    {
-                        return ethnicity.Value.ToString();
-                    }
+                    return ethnicity.Value.ToString();
                 }
                 return null;
             }
@@ -4045,15 +4004,13 @@ namespace BFDR
                 {
                     return;
                 }
-                if (InputRaceAndEthnicityObsFather == null)
-                {
-                    CreateInputRaceEthnicityObsFather();
-                }
-                InputRaceAndEthnicityObsFather.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Literal);
+                Observation obs = GetOrCreateObservation("inputraceandethnicityFather", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
+                obs.Component.RemoveAll(c => c.Code.Coding[0].Code == NvssEthnicity.Literal);
                 Observation.ComponentComponent component = new Observation.ComponentComponent();
                 component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, NvssEthnicity.Literal, NvssEthnicity.LiteralDisplay, null);
                 component.Value = new FhirString(value);
-                InputRaceAndEthnicityObsFather.Component.Add(component);
+                obs.Component.Add(component);
+                obs.Subject = new ResourceReference("urn:uuid:" + Child.Id);
             }
         }
 
@@ -4078,13 +4035,15 @@ namespace BFDR
 
                 var races = new List<Tuple<string, string>>() { };
 
-                if (InputRaceAndEthnicityObsFather == null)
+                Observation obs = GetOrCreateObservation("inputraceandethnicityFather", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
+
+                if (!obs.Component.Any())
                 {
                     return races.ToArray();
                 }
                 foreach (string raceCode in raceCodes)
                 {
-                    Observation.ComponentComponent component = InputRaceAndEthnicityObsFather.Component.Where(c => c.Code.Coding[0].Code == raceCode).FirstOrDefault();
+                    Observation.ComponentComponent component = obs.Component.Where(c => c.Code.Coding[0].Code == raceCode).FirstOrDefault();
                     if (component != null)
                     {
                         // convert boolean race codes to strings
@@ -4131,15 +4090,12 @@ namespace BFDR
                 if (value.FirstOrDefault() == null) {
                     return;
                 }
-                if (InputRaceAndEthnicityObsFather == null)
-                {
-                    CreateInputRaceEthnicityObsFather();
-                }
+                Observation obs = GetOrCreateObservation("inputraceandethnicityFather", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
                 var booleanRaceCodes = NvssRace.GetBooleanRaceCodes();
                 var literalRaceCodes = NvssRace.GetLiteralRaceCodes();
                 foreach (Tuple<string, string> element in value)
                 {
-                    InputRaceAndEthnicityObsFather.Component.RemoveAll(c => c.Code.Coding[0].Code == element.Item1);
+                    obs.Component.RemoveAll(c => c.Code.Coding[0].Code == element.Item1);
                     Observation.ComponentComponent component = new Observation.ComponentComponent();
                     String displayValue = NvssRace.GetDisplayValueForCode(element.Item1);
                     component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, element.Item1, displayValue, null);
@@ -4162,7 +4118,7 @@ namespace BFDR
                     {
                         throw new ArgumentException("Invalid race literal code found: " + element.Item1 + " with value: " + element.Item2);
                     }
-                    InputRaceAndEthnicityObsFather.Component.Add(component);
+                    obs.Component.Add(component);
                 }
             }
         }


### PR DESCRIPTION
## Summary 

Constructors: removing comments to birth constructors, adding others.

Removed race/ethnicity fields and create methods and replaced with getOrCreateObservation helper.

Am getting two types of errors:

1. One is an exception I put in, so it might be that I should just cut it out. In BirthRecord_constructors, `GetDemographicCodedContentBundle()` was returning a bundle with no composittion (a required field) so I added it along with the required mother or father sections. If there is no mother or father to report on, it seems like a pointless record, so I have it raise the exception. Is this pre-emptive validation inappropriate?
2. The other is a null reference exception in the `SubjectId()` method in fieldsAndCreateMethods. When I switched to using the getOrCreateObservation method for race/ethnicity, it was no longer finding a subject ID when trying to `get` an ethnicity field. Trying to determine if this is something wrong in the record or an implementation issue.

