### PR TITLE
Nvss 603 create fetaldeathrecord

### DIFF
--- a/projects/BFDR.Tests/FetalDeathRecord_Should.cs
+++ b/projects/BFDR.Tests/FetalDeathRecord_Should.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using VR;
+using Xunit;
+
+namespace BFDR.Tests
+{
+  public class FetalDeathRecord_Should
+  {
+    private FetalDeathRecord SetterFetalDeathRecord;
+
+    public FetalDeathRecord_Should()
+    {
+      SetterFetalDeathRecord = new FetalDeathRecord();
+    }
+
+    [Fact]
+    public void TestFetalDeathIdentifierSetters()
+    {
+      // Record Identifiers
+      SetterFetalDeathRecord.CertificateNumber = "87366";
+      Assert.Equal("87366", SetterFetalDeathRecord.CertificateNumber);
+      Assert.Equal("0000XX087366", SetterFetalDeathRecord.RecordIdentifier);
+      Assert.Null(SetterFetalDeathRecord.StateLocalIdentifier1);
+      SetterFetalDeathRecord.StateLocalIdentifier1 = "0000033";
+      Assert.Equal("0000033", SetterFetalDeathRecord.StateLocalIdentifier1);
+      SetterFetalDeathRecord.BirthYear = 2020;
+      SetterFetalDeathRecord.CertificateNumber = "767676";
+      Assert.Equal("2020XX767676", SetterFetalDeathRecord.RecordIdentifier);
+      SetterFetalDeathRecord.BirthLocationJurisdiction = "WY";
+      SetterFetalDeathRecord.CertificateNumber = "898989";
+      Assert.Equal("2020WY898989", SetterFetalDeathRecord.RecordIdentifier);
+    }
+  }
+}

--- a/projects/BFDR/BFDR.xml
+++ b/projects/BFDR/BFDR.xml
@@ -27,6 +27,29 @@
         <member name="M:BFDR.BirthRecord.GetYear">
             <summary>Return the birth year for this record to be used in the identifier</summary>
         </member>
+        <member name="T:BFDR.FetalDeathRecord">
+            <summary>Class <c>FetalDeathRecord</c> is a class designed to help consume and produce fetal death records
+            that follow the HL7 FHIR Vital Records Birth Reporting Implementation Guide, as described at:
+            http://hl7.org/fhir/us/bfdr and https://github.com/hl7/bfdr.
+            </summary>
+        </member>
+        <member name="M:BFDR.FetalDeathRecord.#ctor">
+            <summary>Default constructor that creates a new, empty FetalDeathRecord.</summary>
+        </member>
+        <member name="M:BFDR.FetalDeathRecord.#ctor(System.String,System.Boolean)">
+            <summary>Constructor that takes a string that represents a FHIR Fetal Death Record in either XML or JSON format.</summary>
+            <param name="record">represents a FHIR Fetal Death Record in either XML or JSON format.</param>
+            <param name="permissive">if the parser should be permissive when parsing the given string</param>
+            <exception cref="T:System.ArgumentException">Record is neither valid XML nor JSON.</exception>
+        </member>
+        <member name="M:BFDR.FetalDeathRecord.#ctor(Hl7.Fhir.Model.Bundle)">
+            <summary>Constructor that takes a FHIR Bundle that represents a FHIR Fetal Death Record.</summary>
+            <param name="bundle">represents a FHIR Bundle.</param>
+            <exception cref="T:System.ArgumentException">Record is invalid.</exception>
+        </member>
+        <member name="M:BFDR.FetalDeathRecord.GetYear">
+            <summary>Return the birth year for this record to be used in the identifier</summary>
+        </member>
         <member name="T:BFDR.IJEBirth">
             <summary>A "wrapper" class to convert between a FHIR based <c>BirthRecord</c> and
             a record in IJE Natality format. Each property of this class corresponds exactly

--- a/projects/BFDR/FetalDeathRecord.cs
+++ b/projects/BFDR/FetalDeathRecord.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
+using VR;
+
+namespace BFDR
+{
+    /// <summary>Class <c>FetalDeathRecord</c> is a class designed to help consume and produce fetal death records
+    /// that follow the HL7 FHIR Vital Records Birth Reporting Implementation Guide, as described at:
+    /// http://hl7.org/fhir/us/bfdr and https://github.com/hl7/bfdr.
+    /// </summary>
+    public partial class FetalDeathRecord : NatalityRecord
+    {
+        /// <summary>Default constructor that creates a new, empty FetalDeathRecord.</summary>
+        public FetalDeathRecord() : base() {}
+
+        /// <summary>Constructor that takes a string that represents a FHIR Fetal Death Record in either XML or JSON format.</summary>
+        /// <param name="record">represents a FHIR Fetal Death Record in either XML or JSON format.</param>
+        /// <param name="permissive">if the parser should be permissive when parsing the given string</param>
+        /// <exception cref="ArgumentException">Record is neither valid XML nor JSON.</exception>
+        public FetalDeathRecord(string record, bool permissive = false) : base(record, permissive) {}
+
+        /// <summary>Constructor that takes a FHIR Bundle that represents a FHIR Fetal Death Record.</summary>
+        /// <param name="bundle">represents a FHIR Bundle.</param>
+        /// <exception cref="ArgumentException">Record is invalid.</exception>
+        public FetalDeathRecord(Bundle bundle) : base(bundle) {}
+
+        /// <summary>Return the birth year for this record to be used in the identifier</summary>
+        protected override uint? GetYear()
+        {
+            return (uint?)this.BirthYear;
+        }
+    }
+}


### PR DESCRIPTION
### Summary

* adding fetalDeathRecord constructors
* adding tests for identifier fields

These fields match what is in the birthRecord, so no changes were made to getters/setters (IJE fields, FHIR extensions and paths, field types match).