### PR TITLE
feat(bfdr): Update Child/DecedentFetus references, Date of Registration

### DIFF
--- a/projects/BFDR.Tests/BFDR.Tests.csproj
+++ b/projects/BFDR.Tests/BFDR.Tests.csproj
@@ -36,5 +36,6 @@
     <None Update="fixtures/json/BirthRecordFakeWithRace.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/BirthRecordFakeNoRace.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/BirthRecordStatusMessage.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/FetalDeathReport.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/projects/BFDR.Tests/FetalDeathRecord_Should.cs
+++ b/projects/BFDR.Tests/FetalDeathRecord_Should.cs
@@ -35,28 +35,6 @@ namespace BFDR.Tests
     }
 
     [Fact]
-    public void TestRegistrationDate()
-    {
-      FetalDeathRecord fhir = new FetalDeathRecord();
-      IJEFetalDeath ije = new IJEFetalDeath(fhir);
-      Assert.Equal("    ", ije.DOR_YR);
-      Assert.Equal("  ", ije.DOR_MO);
-      Assert.Equal("  ", ije.DOR_DY);
-      ije.DOR_DY = "24";
-      Assert.Equal("    ", ije.DOR_YR);
-      Assert.Equal("  ", ije.DOR_MO);
-      Assert.Equal("24", ije.DOR_DY);
-      ije.DOR_MO = "02";
-      Assert.Equal("    ", ije.DOR_YR);
-      Assert.Equal("02", ije.DOR_MO);
-      Assert.Equal("24", ije.DOR_DY);
-      ije.DOR_YR = "2023";
-      Assert.Equal("2023", ije.DOR_YR);
-      Assert.Equal("02", ije.DOR_MO);
-      Assert.Equal("24", ije.DOR_DY);
-    }
-
-    [Fact]
     public void ParseRegistrationDate()
     { 
       FetalDeathRecord record = new(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/FetalDeathReport.json")));

--- a/projects/BFDR.Tests/FetalDeathRecord_Should.cs
+++ b/projects/BFDR.Tests/FetalDeathRecord_Should.cs
@@ -33,5 +33,49 @@ namespace BFDR.Tests
       SetterFetalDeathRecord.CertificateNumber = "898989";
       Assert.Equal("0000WY898989", SetterFetalDeathRecord.RecordIdentifier);
     }
+
+    [Fact]
+    public void TestRegistrationDate()
+    {
+      FetalDeathRecord fhir = new FetalDeathRecord();
+      IJEFetalDeath ije = new IJEFetalDeath(fhir);
+      Assert.Equal("    ", ije.DOR_YR);
+      Assert.Equal("  ", ije.DOR_MO);
+      Assert.Equal("  ", ije.DOR_DY);
+      ije.DOR_DY = "24";
+      Assert.Equal("    ", ije.DOR_YR);
+      Assert.Equal("  ", ije.DOR_MO);
+      Assert.Equal("24", ije.DOR_DY);
+      ije.DOR_MO = "02";
+      Assert.Equal("    ", ije.DOR_YR);
+      Assert.Equal("02", ije.DOR_MO);
+      Assert.Equal("24", ije.DOR_DY);
+      ije.DOR_YR = "2023";
+      Assert.Equal("2023", ije.DOR_YR);
+      Assert.Equal("02", ije.DOR_MO);
+      Assert.Equal("24", ije.DOR_DY);
+    }
+
+    [Fact]
+    public void ParseRegistrationDate()
+    { 
+      FetalDeathRecord record = new(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/FetalDeathReport.json")));
+      Assert.Equal("2019-01-09", record.RegistrationDate);
+      Assert.Equal(2019, record.RegistrationDateYear);
+      Assert.Equal(1, record.RegistrationDateMonth);
+      Assert.Equal(9, record.RegistrationDateDay);
+
+      IJEFetalDeath ije = new(record);
+      Assert.Equal("2019", ije.DOR_YR);
+      Assert.Equal("01", ije.DOR_MO);
+      Assert.Equal("09", ije.DOR_DY);
+
+      //set after parse
+      record.FirstPrenatalCareVisit = "2024-05"; 
+      Assert.Equal("2024-05", record.FirstPrenatalCareVisit);
+      Assert.Equal(2024, record.FirstPrenatalCareVisitYear);
+      Assert.Equal(5, record.FirstPrenatalCareVisitMonth);
+      Assert.Null(record.FirstPrenatalCareVisitDay);
+    }
   }
 }

--- a/projects/BFDR.Tests/IJEFetalDeath_Should.cs
+++ b/projects/BFDR.Tests/IJEFetalDeath_Should.cs
@@ -1,0 +1,30 @@
+using Xunit;
+
+namespace BFDR.Tests
+{
+  public class IJEFetalDeath_Should
+  {
+
+    [Fact]
+    public void SetRegistrationDate()
+    {
+      FetalDeathRecord fhir = new FetalDeathRecord();
+      IJEFetalDeath ije = new IJEFetalDeath(fhir);
+      Assert.Equal("    ", ije.DOR_YR);
+      Assert.Equal("  ", ije.DOR_MO);
+      Assert.Equal("  ", ije.DOR_DY);
+      ije.DOR_DY = "24";
+      Assert.Equal("    ", ije.DOR_YR);
+      Assert.Equal("  ", ije.DOR_MO);
+      Assert.Equal("24", ije.DOR_DY);
+      ije.DOR_MO = "02";
+      Assert.Equal("    ", ije.DOR_YR);
+      Assert.Equal("02", ije.DOR_MO);
+      Assert.Equal("24", ije.DOR_DY);
+      ije.DOR_YR = "2023";
+      Assert.Equal("2023", ije.DOR_YR);
+      Assert.Equal("02", ije.DOR_MO);
+      Assert.Equal("24", ije.DOR_DY);
+    }
+  }
+}

--- a/projects/BFDR.Tests/fixtures/json/FetalDeathReport.json
+++ b/projects/BFDR.Tests/fixtures/json/FetalDeathReport.json
@@ -1,0 +1,2482 @@
+{
+  "resourceType": "Bundle",
+  "id": "bundle-jurisdiction-fetal-death-not-named",
+  "meta": {
+      "profile": [
+          "http://hl7.org/fhir/us/bfdr/StructureDefinition/Bundle-document-fetal-death-report"
+      ]
+  },
+  "identifier": {
+      "extension": [
+          {
+              "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/CertificateNumber",
+              "valueString": "9876"
+          },
+          {
+              "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/AuxiliaryStateIdentifier1",
+              "valueString": "11111-11111"
+          }
+      ],
+      "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-ije-vr",
+      "value": "2019NJ009876"
+  },
+  "type": "document",
+  "timestamp": "2019-10-15T08:51:14.637+00:00",
+  "entry": [
+      {
+          "fullUrl": "http://www.example.org/fhir/Composition/composition-jurisdiction-fetal-death-not-named",
+          "resource": {
+              "resourceType": "Composition",
+              "id": "composition-jurisdiction-fetal-death-not-named",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Composition-jurisdiction-fetal-death-report"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Composition_composition-jurisdiction-fetal-death-not-named\"> </a><p><b>Generated Narrative: Composition</b><a name=\"composition-jurisdiction-fetal-death-not-named\"> </a><a name=\"hccomposition-jurisdiction-fetal-death-not-named\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Composition &quot;composition-jurisdiction-fetal-death-not-named&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Composition-jurisdiction-fetal-death-report.html\">Composition - Jurisdiction Fetal Death Report</a></p></div><p><b>status</b>: final</p><p><b>type</b>: Jurisdiction fetal death report Document <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#92010-8)</span></p><p><b>encounter</b>: <a href=\"#Encounter_encounter-maternity-carmen-teresa-lee\">See above (Encounter/encounter-maternity-carmen-teresa-lee)</a></p><p><b>date</b>: 2019-01-09</p><p><b>author</b>: <a href=\"#Organization_organization-jurisdictional-vital-records-office\">See above (Organization/organization-jurisdictional-vital-records-office)</a></p><p><b>title</b>: Jurisdiction fetal death report Document</p></div>"
+              },
+              "status": "final",
+              "type": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "92010-8",
+                          "display": "Jurisdiction fetal death report Document"
+                      }
+                  ]
+              },
+              "subject": {
+                  "reference": "Patient/patient-decedent-fetus-not-named"
+              },
+              "encounter": {
+                  "reference": "Encounter/encounter-maternity-carmen-teresa-lee"
+              },
+              "date": "2019-01-09",
+              "author": [
+                  {
+                      "reference": "Organization/organization-jurisdictional-vital-records-office"
+                  }
+              ],
+              "title": "Jurisdiction fetal death report Document",
+              "section": [
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://loinc.org",
+                                  "code": "57073-9"
+                              }
+                          ]
+                      },
+                      "focus": {
+                          "reference": "Patient/patient-mother-carmen-teresa-lee"
+                      },
+                      "entry": [
+                          {
+                              "reference": "Observation/observation-date-of-first-prenatal-care-visit-carmen-teresa-lee"
+                          },
+                          {
+                              "reference": "Observation/observation-last-menstrual-period-carmen-teresa-lee"
+                          },
+                          {
+                              "reference": "Observation/observation-number-births-now-living-carmen-teresa-lee"
+                          },
+                          {
+                              "reference": "Observation/observation-number-births-now-dead-carmen-teresa-lee"
+                          },
+                          {
+                              "reference": "Observation/observation-date-of-last-live-birth-carmen-teresa-lee"
+                          },
+                          {
+                              "reference": "Observation/observation-mother-height-carmen-teresa-lee-w-edit"
+                          },
+                          {
+                              "reference": "Observation/observation-mother-prepregnancy-weight-carmen-teresa-lee-w-edit"
+                          },
+                          {
+                              "reference": "Observation/observation-mother-received-wic-food-carmen-teresa-lee"
+                          },
+                          {
+                              "reference": "Observation/observation-cig-smoking-pregnancy-1-carmen-teresa-lee"
+                          },
+                          {
+                              "reference": "Observation/observation-cig-smoking-pregnancy-2-carmen-teresa-lee"
+                          },
+                          {
+                              "reference": "Observation/observation-cig-smoking-pregnancy-3-carmen-teresa-lee"
+                          },
+                          {
+                              "reference": "Observation/observation-cig-smoking-pregnancy-4-carmen-teresa-lee"
+                          }
+                      ]
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://loinc.org",
+                                  "code": "55752-0"
+                              }
+                          ]
+                      },
+                      "focus": {
+                          "reference": "Patient/patient-mother-carmen-teresa-lee"
+                      },
+                      "entry": [
+                          {
+                              "reference": "Observation/observation-number-previous-cesareans-carmen-teresa-lee-w-edit"
+                          },
+                          {
+                              "reference": "Observation/observation-fetal-presentation-not-named"
+                          },
+                          {
+                              "reference": "Procedure/procedure-final-route-method-delivery-not-named"
+                          }
+                      ]
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://loinc.org",
+                                  "code": "76400-1"
+                              }
+                          ]
+                      },
+                      "entry": [
+                          {
+                              "reference": "Observation/observation-birth-weight-not-named-w-edit"
+                          },
+                          {
+                              "reference": "Observation/observation-gestational-age-at-delivery-not-named-w-edit"
+                          },
+                          {
+                              "reference": "Condition/condition-fetal-death-cause-or-condition-not-named"
+                          },
+                          {
+                              "reference": "Condition/condition-fetal-death-other-significant-cause-not-named"
+                          },
+                          {
+                              "reference": "Observation/observation-fetal-death-time-point-not-named"
+                          },
+                          {
+                              "reference": "Observation/observation-autopsy-performed-not-named"
+                          },
+                          {
+                              "reference": "Observation/observation-histological-placental-exam-performed-not-named"
+                          },
+                          {
+                              "reference": "Observation/observation-autopsy-histological-exam-results-used-not-named"
+                          },
+                          {
+                              "reference": "Observation/observation-number-deaths-this-delivery-carmen-teresa-lee"
+                          }
+                      ]
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://loinc.org",
+                                  "code": "92014-0"
+                              }
+                          ]
+                      },
+                      "focus": {
+                          "reference": "Patient/patient-mother-carmen-teresa-lee"
+                      },
+                      "entry": [
+                          {
+                              "reference": "Observation/observation-parent-education-level-carmen-teresa-lee-w-edit"
+                          },
+                          {
+                              "reference": "Observation/observation-usual-work-carmen-teresa-lee"
+                          },
+                          {
+                              "reference": "Observation/observation-input-race-and-ethnicity-carmen-teresa-lee"
+                          }
+                      ]
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://loinc.org",
+                                  "code": "92013-2"
+                              }
+                          ]
+                      },
+                      "focus": {
+                          "reference": "RelatedPerson/relatedperson-father-natural-tom-yan-lee"
+                      },
+                      "entry": [
+                          {
+                              "reference": "Observation/observation-usual-work-tom-yan-lee"
+                          }
+                      ]
+                  }
+              ]
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Patient/patient-decedent-fetus-not-named",
+          "resource": {
+              "resourceType": "Patient",
+              "id": "patient-decedent-fetus-not-named",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Patient-decedent-fetus"
+                  ]
+              },
+              "text": {
+                  "status": "extensions",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Patient_patient-decedent-fetus-not-named\"> </a><p><b>Generated Narrative: Patient</b><a name=\"patient-decedent-fetus-not-named\"> </a><a name=\"hcpatient-decedent-fetus-not-named\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Patient &quot;patient-decedent-fetus-not-named&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Patient-decedent-fetus.html\">Patient - Decedent Fetus</a></p></div><p><b>US Core Birth Sex Extension</b>: F</p><p><b>Birth Place</b>: Ann Arbor MI 48103 </p><blockquote><p><b>Reported Parent Age At Delivery Vital Records</b></p><blockquote><p><b>url</b></p><code>reportedAge</code></blockquote><p><b>value</b>: 34 a<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM code a = 'a')</span></p><blockquote><p><b>url</b></p><code>motherOrFather</code></blockquote><p><b>value</b>: mother <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-v3-RoleCode.html\">RoleCode</a>#MTH)</span></p></blockquote><blockquote><p><b>Reported Parent Age At Delivery Vital Records</b></p><blockquote><p><b>url</b></p><code>reportedAge</code></blockquote><p><b>value</b>: 35 a<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM code a = 'a')</span></p><blockquote><p><b>url</b></p><code>motherOrFather</code></blockquote><p><b>value</b>: father <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-v3-RoleCode.html\">RoleCode</a>#FTH)</span></p></blockquote><p><b>identifier</b>: Medical Record Number/9932702 (use: USUAL)</p><p><b>name</b>: null (OFFICIAL)</p><p><b>gender</b>: female</p><p><b>birthDate</b>: 2019-01-09</p><p><b>multipleBirth</b>: 3</p></div>"
+              },
+              "extension": [
+                  {
+                      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+                      "valueCode": "F"
+                  },
+                  {
+                      "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+                      "valueAddress": {
+                          "city": "Ann Arbor",
+                          "state": "MI",
+                          "postalCode": "48103"
+                      }
+                  },
+                  {
+                      "extension": [
+                          {
+                              "url": "reportedAge",
+                              "valueQuantity": {
+                                  "value": 34,
+                                  "system": "http://unitsofmeasure.org",
+                                  "code": "a"
+                              }
+                          },
+                          {
+                              "url": "motherOrFather",
+                              "valueCodeableConcept": {
+                                  "coding": [
+                                      {
+                                          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                                          "code": "MTH",
+                                          "display": "mother"
+                                      }
+                                  ]
+                              }
+                          }
+                      ],
+                      "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-reported-parent-age-at-delivery-vr"
+                  },
+                  {
+                      "extension": [
+                          {
+                              "url": "reportedAge",
+                              "valueQuantity": {
+                                  "value": 35,
+                                  "system": "http://unitsofmeasure.org",
+                                  "code": "a"
+                              }
+                          },
+                          {
+                              "url": "motherOrFather",
+                              "valueCodeableConcept": {
+                                  "coding": [
+                                      {
+                                          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                                          "code": "FTH",
+                                          "display": "father"
+                                      }
+                                  ]
+                              }
+                          }
+                      ],
+                      "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-reported-parent-age-at-delivery-vr"
+                  }
+              ],
+              "identifier": [
+                  {
+                      "use": "usual",
+                      "type": {
+                          "coding": [
+                              {
+                                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                  "code": "MR",
+                                  "display": "Medical Record Number"
+                              }
+                          ]
+                      },
+                      "system": "http://hospital.smarthealthit.org",
+                      "value": "9932702"
+                  }
+              ],
+              "name": [
+                  {
+                      "use": "official",
+                      "_family": {
+                          "extension": [
+                              {
+                                  "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                                  "valueCode": "not-applicable"
+                              }
+                          ]
+                      }
+                  }
+              ],
+              "gender": "female",
+              "birthDate": "2019-01-09",
+              "_birthDate": {
+                  "extension": [
+                      {
+                          "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+                          "valueDateTime": "2019-01-09T18:23:00-07:00"
+                      }
+                  ]
+              },
+              "multipleBirthInteger": 3
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Encounter/encounter-maternity-carmen-teresa-lee",
+          "resource": {
+              "resourceType": "Encounter",
+              "id": "encounter-maternity-carmen-teresa-lee",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Encounter-maternity"
+                  ]
+              },
+              "text": {
+                  "status": "extensions",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Encounter_encounter-maternity-carmen-teresa-lee\"> </a><p><b>Generated Narrative: Encounter</b><a name=\"encounter-maternity-carmen-teresa-lee\"> </a><a name=\"hcencounter-maternity-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Encounter &quot;encounter-maternity-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Encounter-maternity.html\">Encounter - Maternity</a></p></div><p><b>Role Vital Records</b>: mother <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-v3-RoleCode.html\">RoleCode</a>#MTH)</span></p><p><b>identifier</b>: <code>http://hospital.smarthealthit.org</code>/8937015</p><p><b>status</b>: finished</p><p><b>class</b>: inpatient encounter (Details: http://terminology.hl7.org/CodeSystem/v3-ActCode code IMP = 'inpatient encounter', stated as 'inpatient encounter')</p><p><b>type</b>: Under Observation or Inpatient Care Services (Including Admission and Discharge Services) <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-CPT.html\">Current Procedural Terminology (CPT®)</a>#99234)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee))</a></p><h3>Participants</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Type</b></td><td><b>Individual</b></td></tr><tr><td style=\"display: none\">*</td><td>Birth attendant [Extended Identifier] <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#87286-1)</span></td><td><a href=\"#Practitioner_practitioner-vital-records-janet-seito\">See above (Practitioner/practitioner-vital-records-janet-seito: Practitioner - Vital Records (Janet Seito, DO))</a></td></tr></table><p><b>period</b>: 2019-01-08 10:00:00-0700 --&gt; 2019-01-09 17:00:00-0700</p><h3>Locations</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Location</b></td><td><b>PhysicalType</b></td></tr><tr><td style=\"display: none\">*</td><td><a href=\"#Location_location-south-hospital\">See above (Location/location-south-hospital: Location - US Core Location (South Hospital))</a></td><td>Hospital <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#22232009)</span></td></tr></table><p><b>serviceProvider</b>: <a href=\"#Organization_organization-south-hospital\">See above (Organization/organization-south-hospital: Organization - US Core Organization (South Hospital Organization))</a></p></div>"
+              },
+              "extension": [
+                  {
+                      "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-role-vr",
+                      "valueCodeableConcept": {
+                          "coding": [
+                              {
+                                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                                  "code": "MTH"
+                              }
+                          ]
+                      }
+                  }
+              ],
+              "identifier": [
+                  {
+                      "system": "http://hospital.smarthealthit.org",
+                      "value": "8937015"
+                  }
+              ],
+              "status": "finished",
+              "class": {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+                  "code": "IMP",
+                  "display": "inpatient encounter"
+              },
+              "type": [
+                  {
+                      "coding": [
+                          {
+                              "system": "http://www.ama-assn.org/go/cpt",
+                              "code": "99234"
+                          }
+                      ],
+                      "text": "Under Observation or Inpatient Care Services (Including Admission and Discharge Services)"
+                  }
+              ],
+              "subject": {
+                  "reference": "Patient/patient-mother-carmen-teresa-lee",
+                  "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "participant": [
+                  {
+                      "type": [
+                          {
+                              "coding": [
+                                  {
+                                      "system": "http://loinc.org",
+                                      "code": "87286-1",
+                                      "display": "Birth attendant [Extended Identifier]"
+                                  }
+                              ]
+                          }
+                      ],
+                      "individual": {
+                          "reference": "Practitioner/practitioner-vital-records-janet-seito",
+                          "display": "Practitioner - Vital Records (Janet Seito, DO)"
+                      }
+                  }
+              ],
+              "period": {
+                  "start": "2019-01-08T10:00:00-07:00",
+                  "end": "2019-01-09T17:00:00-07:00"
+              },
+              "location": [
+                  {
+                      "location": {
+                          "reference": "Location/location-south-hospital",
+                          "display": "Location - US Core Location (South Hospital)"
+                      },
+                      "physicalType": {
+                          "coding": [
+                              {
+                                  "system": "http://snomed.info/sct",
+                                  "code": "22232009",
+                                  "display": "Hospital"
+                              }
+                          ]
+                      }
+                  }
+              ],
+              "serviceProvider": {
+                  "reference": "Organization/organization-south-hospital",
+                  "display": "Organization - US Core Organization (South Hospital Organization)"
+              }
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Organization/organization-jurisdictional-vital-records-office",
+          "resource": {
+              "resourceType": "Organization",
+              "id": "organization-jurisdictional-vital-records-office",
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Organization_organization-jurisdictional-vital-records-office\"> </a><p><b>Generated Narrative: Organization</b><a name=\"organization-jurisdictional-vital-records-office\"> </a><a name=\"hcorganization-jurisdictional-vital-records-office\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Organization &quot;organization-jurisdictional-vital-records-office&quot; </p></div><p><b>active</b>: true</p><p><b>name</b>: Jurisdictional Vital Records Office</p></div>"
+              },
+              "active": true,
+              "name": "Jurisdictional Vital Records Office"
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Patient/patient-mother-carmen-teresa-lee",
+          "resource": {
+              "resourceType": "Patient",
+              "id": "patient-mother-carmen-teresa-lee",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Patient-mother-vr"
+                  ]
+              },
+              "text": {
+                  "status": "extensions",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Patient_patient-mother-carmen-teresa-lee\"> </a><p><b>Generated Narrative: Patient</b><a name=\"patient-mother-carmen-teresa-lee\"> </a><a name=\"hcpatient-mother-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Patient &quot;patient-mother-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"https://build.fhir.org/ig/HL7/vr-common-library//StructureDefinition-Patient-mother-vr.html\">Patient - Mother Vital Records</a></p></div><blockquote><p><b>US Core Race Extension</b></p><blockquote><p><b>url</b></p><code>ombCategory</code></blockquote><p><b>value</b>: Black or African American (Details: urn:oid:2.16.840.1.113883.6.238 code 2054-5 = 'Black or African American', stated as 'Black or African American')</p><blockquote><p><b>url</b></p><code>text</code></blockquote><p><b>value</b>: Black or African America</p></blockquote><blockquote><p><b>US Core Ethnicity Extension</b></p><blockquote><p><b>url</b></p><code>ombCategory</code></blockquote><p><b>value</b>: Hispanic or Latino (Details: urn:oid:2.16.840.1.113883.6.238 code 2135-2 = 'Hispanic or Latino', stated as 'Hispanic or Latino')</p><blockquote><p><b>url</b></p><code>text</code></blockquote><p><b>value</b>: Hispanic or Latino</p></blockquote><p><b>US Core Birth Sex Extension</b>: F</p><p><b>Birth Place</b>: PR </p><p><b>identifier</b>: Medical Record Number/9992702 (use: USUAL)</p><p><b>name</b>: Carmen Teresa Lee (OFFICIAL), Carmen Teresa Santos (MAIDEN)</p><p><b>gender</b>: female</p><p><b>birthDate</b>: 1986-02-15</p><p><b>address</b>: 3670 Miller Road Ann Arbor MI 48103 US (HOME)</p><h3>Links</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Other</b></td><td><b>Type</b></td></tr><tr><td style=\"display: none\">*</td><td><a href=\"#RelatedPerson_relatedperson-mother-carmen-teresa-lee\">See above (RelatedPerson/relatedperson-mother-carmen-teresa-lee)</a></td><td>seealso</td></tr></table></div>"
+              },
+              "extension": [
+                  {
+                      "extension": [
+                          {
+                              "url": "ombCategory",
+                              "valueCoding": {
+                                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                                  "code": "2054-5",
+                                  "display": "Black or African American"
+                              }
+                          },
+                          {
+                              "url": "text",
+                              "valueString": "Black or African America"
+                          }
+                      ],
+                      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+                  },
+                  {
+                      "extension": [
+                          {
+                              "url": "ombCategory",
+                              "valueCoding": {
+                                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                                  "code": "2135-2",
+                                  "display": "Hispanic or Latino"
+                              }
+                          },
+                          {
+                              "url": "text",
+                              "valueString": "Hispanic or Latino"
+                          }
+                      ],
+                      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+                  },
+                  {
+                      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+                      "valueCode": "F"
+                  },
+                  {
+                      "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+                      "valueAddress": {
+                          "state": "PR"
+                      }
+                  }
+              ],
+              "identifier": [
+                  {
+                      "use": "usual",
+                      "type": {
+                          "coding": [
+                              {
+                                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                                  "code": "MR",
+                                  "display": "Medical Record Number"
+                              }
+                          ]
+                      },
+                      "system": "http://hospital.smarthealthit.org",
+                      "value": "9992702"
+                  }
+              ],
+              "name": [
+                  {
+                      "use": "official",
+                      "family": "Lee",
+                      "given": [
+                          "Carmen",
+                          "Teresa"
+                      ]
+                  },
+                  {
+                      "use": "maiden",
+                      "family": "Santos",
+                      "given": [
+                          "Carmen",
+                          "Teresa"
+                      ]
+                  }
+              ],
+              "gender": "female",
+              "birthDate": "1986-02-15",
+              "address": [
+                  {
+                      "extension": [
+                          {
+                              "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-within-city-limits-indicator-vr",
+                              "valueCoding": {
+                                  "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                                  "code": "N",
+                                  "display": "No"
+                              }
+                          }
+                      ],
+                      "use": "home",
+                      "line": [
+                          "3670 Miller Road"
+                      ],
+                      "city": "Ann Arbor",
+                      "state": "MI",
+                      "postalCode": "48103",
+                      "country": "US"
+                  }
+              ],
+              "link": [
+                  {
+                      "other": {
+                          "reference": "RelatedPerson/relatedperson-mother-carmen-teresa-lee"
+                      },
+                      "type": "seealso"
+                  }
+              ]
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-date-of-first-prenatal-care-visit-carmen-teresa-lee",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-date-of-first-prenatal-care-visit-carmen-teresa-lee",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-date-of-first-prenatal-care-visit"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-date-of-first-prenatal-care-visit-carmen-teresa-lee\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-date-of-first-prenatal-care-visit-carmen-teresa-lee\"> </a><a name=\"hcobservation-date-of-first-prenatal-care-visit-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-date-of-first-prenatal-care-visit-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-date-of-first-prenatal-care-visit.html\">Observation - Date of First Prenatal Care Visit</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Date of first prenatal care visit <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#69044-6)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee))</a></p><p><b>focus</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Practitioner_practitioner-vital-records-janet-seito\">See above (Practitioner/practitioner-vital-records-janet-seito)</a></p><p><b>value</b>: 2018-05-18</p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "69044-6"
+                      }
+                  ]
+              },
+              "subject": {
+                  "reference": "Patient/patient-mother-carmen-teresa-lee",
+                  "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "focus": [
+                  {
+                      "reference": "Patient/patient-decedent-fetus-not-named",
+                      "display": "Patient - Decedent Fetus (Fetus Not Named)"
+                  }
+              ],
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Practitioner/practitioner-vital-records-janet-seito"
+                  }
+              ],
+              "valueDateTime": "2018-05-18"
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-last-menstrual-period-carmen-teresa-lee",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-last-menstrual-period-carmen-teresa-lee",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-last-menstrual-period"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-last-menstrual-period-carmen-teresa-lee\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-last-menstrual-period-carmen-teresa-lee\"> </a><a name=\"hcobservation-last-menstrual-period-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-last-menstrual-period-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-last-menstrual-period.html\">Observation - Last Menstrual Period</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Last menstrual period start date <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#8665-2)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee))</a></p><p><b>effective</b>: 2018-05-02</p><p><b>performer</b>: <a href=\"#Practitioner_practitioner-vital-records-janet-seito\">See above (Practitioner/practitioner-vital-records-janet-seito)</a></p><p><b>value</b>: 2018-04-18</p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "8665-2",
+                          "display": "Last menstrual period start date"
+                      }
+                  ],
+                  "text": "Last menstrual period start date"
+              },
+              "subject": {
+                  "reference": "Patient/patient-mother-carmen-teresa-lee",
+                  "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "effectiveDateTime": "2018-05-02",
+              "performer": [
+                  {
+                      "reference": "Practitioner/practitioner-vital-records-janet-seito"
+                  }
+              ],
+              "valueDateTime": "2018-04-18"
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-number-births-now-living-carmen-teresa-lee",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-number-births-now-living-carmen-teresa-lee",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-number-births-now-living"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-number-births-now-living-carmen-teresa-lee\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-number-births-now-living-carmen-teresa-lee\"> </a><a name=\"hcobservation-number-births-now-living-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-number-births-now-living-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-number-births-now-living.html\">Observation - Number of Births Now Living</a></p></div><p><b>status</b>: final</p><p><b>code</b>: [#] Births.still living <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#11638-4)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Practitioner_practitioner-vital-records-janet-seito\">See above (Practitioner/practitioner-vital-records-janet-seito)</a></p><p><b>value</b>: 1</p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "11638-4",
+                          "display": "[#] Births.still living"
+                      }
+                  ],
+                  "text": "[#] Births.still living"
+              },
+              "subject": {
+                  "reference": "Patient/patient-mother-carmen-teresa-lee",
+                  "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Practitioner/practitioner-vital-records-janet-seito"
+                  }
+              ],
+              "valueInteger": 1
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-number-births-now-dead-carmen-teresa-lee",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-number-births-now-dead-carmen-teresa-lee",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-number-births-now-dead"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-number-births-now-dead-carmen-teresa-lee\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-number-births-now-dead-carmen-teresa-lee\"> </a><a name=\"hcobservation-number-births-now-dead-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-number-births-now-dead-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-number-births-now-dead.html\">Observation - Number of Births Now Dead</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Previous live births now dead # <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#68496-9)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Practitioner_practitioner-vital-records-janet-seito\">See above (Practitioner/practitioner-vital-records-janet-seito)</a></p><p><b>value</b>: 0</p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "68496-9",
+                          "display": "Previous live births now dead #"
+                      }
+                  ],
+                  "text": "Previous live births now dead #"
+              },
+              "subject": {
+                  "reference": "Patient/patient-mother-carmen-teresa-lee",
+                  "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Practitioner/practitioner-vital-records-janet-seito"
+                  }
+              ],
+              "valueInteger": 0
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-date-of-last-live-birth-carmen-teresa-lee",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-date-of-last-live-birth-carmen-teresa-lee",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-date-of-last-live-birth"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-date-of-last-live-birth-carmen-teresa-lee\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-date-of-last-live-birth-carmen-teresa-lee\"> </a><a name=\"hcobservation-date-of-last-live-birth-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-date-of-last-live-birth-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-date-of-last-live-birth.html\">Observation - Date of Last Live Birth</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Date of last live birth <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#68499-3 &quot;Date last live birth&quot;)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Practitioner_practitioner-vital-records-janet-seito\">See above (Practitioner/practitioner-vital-records-janet-seito)</a></p><p><b>value</b>: 2016-01-28</p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "68499-3",
+                          "display": "Date last live birth"
+                      }
+                  ],
+                  "text": "Date of last live birth"
+              },
+              "subject": {
+                  "reference": "Patient/patient-mother-carmen-teresa-lee",
+                  "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Practitioner/practitioner-vital-records-janet-seito"
+                  }
+              ],
+              "valueDateTime": "2016-01-28"
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-mother-height-carmen-teresa-lee-w-edit",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-mother-height-carmen-teresa-lee-w-edit",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-mother-height"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-mother-height-carmen-teresa-lee-w-edit\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-mother-height-carmen-teresa-lee-w-edit\"> </a><a name=\"hcobservation-mother-height-carmen-teresa-lee-w-edit\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-mother-height-carmen-teresa-lee-w-edit&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-mother-height.html\">Observation - Mother Height</a></p></div><p><b>status</b>: final</p><p><b>category</b>: Vital Signs <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-observation-category.html\">Observation Category Codes</a>#vital-signs)</span></p><p><b>code</b>: Body height <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#8302-2)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee))</a></p><p><b>effective</b>: 2019-01-10</p><p><b>performer</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee)</a></p><p><b>value</b>: 56 in<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM code [in_i] = '[in_i]')</span></p></div>"
+              },
+              "status": "final",
+              "category": [
+                  {
+                      "coding": [
+                          {
+                              "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                              "code": "vital-signs"
+                          }
+                      ]
+                  }
+              ],
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "8302-2"
+                      }
+                  ]
+              },
+              "subject": {
+                  "reference": "Patient/patient-mother-carmen-teresa-lee",
+                  "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "effectiveDateTime": "2019-01-10",
+              "performer": [
+                  {
+                      "reference": "Patient/patient-mother-carmen-teresa-lee"
+                  }
+              ],
+              "valueQuantity": {
+                  "extension": [
+                      {
+                          "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag",
+                          "valueCodeableConcept": {
+                              "coding": [
+                                  {
+                                      "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-vr-edit-flags",
+                                      "code": "0",
+                                      "display": "Edit Passed"
+                                  }
+                              ]
+                          }
+                      }
+                  ],
+                  "value": 56,
+                  "unit": "in",
+                  "system": "http://unitsofmeasure.org",
+                  "code": "[in_i]"
+              }
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-mother-prepregnancy-weight-carmen-teresa-lee-w-edit",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-mother-prepregnancy-weight-carmen-teresa-lee-w-edit",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-mother-prepregnancy-weight"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-mother-prepregnancy-weight-carmen-teresa-lee-w-edit\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-mother-prepregnancy-weight-carmen-teresa-lee-w-edit\"> </a><a name=\"hcobservation-mother-prepregnancy-weight-carmen-teresa-lee-w-edit\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-mother-prepregnancy-weight-carmen-teresa-lee-w-edit&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-mother-prepregnancy-weight.html\">Observation - Mother Prepregnancy Weight</a></p></div><p><b>status</b>: final</p><p><b>category</b>: Vital Signs <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-observation-category.html\">Observation Category Codes</a>#vital-signs)</span></p><p><b>code</b>: Body weight --pre current pregnancy <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#56077-1)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Practitioner_practitioner-vital-records-janet-seito\">See above (Practitioner/practitioner-vital-records-janet-seito)</a></p><p><b>value</b>: 180 [lb_av]<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM code [lb_av] = '[lb_av]')</span></p></div>"
+              },
+              "status": "final",
+              "category": [
+                  {
+                      "coding": [
+                          {
+                              "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                              "code": "vital-signs",
+                              "display": "Vital Signs"
+                          }
+                      ]
+                  }
+              ],
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "56077-1",
+                          "display": "Body weight --pre current pregnancy"
+                      }
+                  ]
+              },
+              "subject": {
+                  "reference": "Patient/patient-mother-carmen-teresa-lee",
+                  "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Practitioner/practitioner-vital-records-janet-seito"
+                  }
+              ],
+              "valueQuantity": {
+                  "extension": [
+                      {
+                          "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag",
+                          "valueCodeableConcept": {
+                              "coding": [
+                                  {
+                                      "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-vr-edit-flags",
+                                      "code": "0",
+                                      "display": "Edit Passed"
+                                  }
+                              ]
+                          }
+                      }
+                  ],
+                  "value": 180,
+                  "system": "http://unitsofmeasure.org",
+                  "code": "[lb_av]"
+              }
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-mother-received-wic-food-carmen-teresa-lee",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-mother-received-wic-food-carmen-teresa-lee",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-mother-received-wic-food"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-mother-received-wic-food-carmen-teresa-lee\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-mother-received-wic-food-carmen-teresa-lee\"> </a><a name=\"hcobservation-mother-received-wic-food-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-mother-received-wic-food-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-mother-received-wic-food.html\">Observation - Mother Recieved WIC Food</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Mother WIC food recipient <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#87303-4)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee))</a></p><p><b>focus</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee)</a></p><p><b>value</b>: No <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#N)</span></p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "87303-4"
+                      }
+                  ]
+              },
+              "subject": {
+                  "reference": "Patient/patient-mother-carmen-teresa-lee",
+                  "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "focus": [
+                  {
+                      "reference": "Patient/patient-decedent-fetus-not-named",
+                      "display": "Patient - Decedent Fetus (Fetus Not Named)"
+                  }
+              ],
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Patient/patient-mother-carmen-teresa-lee"
+                  }
+              ],
+              "valueCodeableConcept": {
+                  "coding": [
+                      {
+                          "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                          "code": "N",
+                          "display": "No"
+                      }
+                  ]
+              }
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-cig-smoking-pregnancy-1-carmen-teresa-lee",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-cig-smoking-pregnancy-1-carmen-teresa-lee",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-cigarette-smoking-before-during-pregnancy"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-cig-smoking-pregnancy-1-carmen-teresa-lee\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-cig-smoking-pregnancy-1-carmen-teresa-lee\"> </a><a name=\"hcobservation-cig-smoking-pregnancy-1-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-cig-smoking-pregnancy-1-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-cigarette-smoking-before-during-pregnancy.html\">Observation - Cigarette Smoking Before and During Pregnancy</a></p></div><p><b>status</b>: final</p><p><b>code</b>: In the 3 months before you got pregnant, how many cigarettes did you smoke on an average day [PhenX] <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#64794-1)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee))</a></p><p><b>focus</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee)</a></p><p><b>value</b>: 0</p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "64794-1",
+                          "display": "In the 3 months before you got pregnant, how many cigarettes did you smoke on an average day [PhenX]"
+                      }
+                  ],
+                  "text": "In the 3 months before you got pregnant, how many cigarettes did you smoke on an average day [PhenX]"
+              },
+              "subject": {
+                  "reference": "Patient/patient-mother-carmen-teresa-lee",
+                  "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "focus": [
+                  {
+                      "reference": "Patient/patient-decedent-fetus-not-named",
+                      "display": "Patient - Decedent Fetus (Fetus Not Named)"
+                  }
+              ],
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Patient/patient-mother-carmen-teresa-lee"
+                  }
+              ],
+              "valueInteger": 0
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-cig-smoking-pregnancy-2-carmen-teresa-lee",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-cig-smoking-pregnancy-2-carmen-teresa-lee",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-cigarette-smoking-before-during-pregnancy"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-cig-smoking-pregnancy-2-carmen-teresa-lee\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-cig-smoking-pregnancy-2-carmen-teresa-lee\"> </a><a name=\"hcobservation-cig-smoking-pregnancy-2-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-cig-smoking-pregnancy-2-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-cigarette-smoking-before-during-pregnancy.html\">Observation - Cigarette Smoking Before and During Pregnancy</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Cigarettes smoked per day by Mother--1st trimester <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#87298-6)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee))</a></p><p><b>focus</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee)</a></p><p><b>value</b>: 0</p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "87298-6",
+                          "display": "Cigarettes smoked per day by Mother--1st trimester"
+                      }
+                  ],
+                  "text": "Cigarettes smoked per day by Mother--1st trimester"
+              },
+              "subject": {
+                  "reference": "Patient/patient-mother-carmen-teresa-lee",
+                  "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "focus": [
+                  {
+                      "reference": "Patient/patient-decedent-fetus-not-named",
+                      "display": "Patient - Decedent Fetus (Fetus Not Named)"
+                  }
+              ],
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Patient/patient-mother-carmen-teresa-lee"
+                  }
+              ],
+              "valueInteger": 0
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-cig-smoking-pregnancy-3-carmen-teresa-lee",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-cig-smoking-pregnancy-3-carmen-teresa-lee",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-cigarette-smoking-before-during-pregnancy"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-cig-smoking-pregnancy-3-carmen-teresa-lee\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-cig-smoking-pregnancy-3-carmen-teresa-lee\"> </a><a name=\"hcobservation-cig-smoking-pregnancy-3-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-cig-smoking-pregnancy-3-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-cigarette-smoking-before-during-pregnancy.html\">Observation - Cigarette Smoking Before and During Pregnancy</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Cigarettes smoked per day by Mother--2nd trimester <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#87299-4)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee))</a></p><p><b>focus</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee)</a></p><p><b>value</b>: 1</p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "87299-4",
+                          "display": "Cigarettes smoked per day by Mother--2nd trimester"
+                      }
+                  ],
+                  "text": "Cigarettes smoked per day by Mother--2nd trimester"
+              },
+              "subject": {
+                  "reference": "Patient/patient-mother-carmen-teresa-lee",
+                  "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "focus": [
+                  {
+                      "reference": "Patient/patient-decedent-fetus-not-named",
+                      "display": "Patient - Decedent Fetus (Fetus Not Named)"
+                  }
+              ],
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Patient/patient-mother-carmen-teresa-lee"
+                  }
+              ],
+              "valueInteger": 1
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-cig-smoking-pregnancy-4-carmen-teresa-lee",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-cig-smoking-pregnancy-4-carmen-teresa-lee",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-cigarette-smoking-before-during-pregnancy"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-cig-smoking-pregnancy-4-carmen-teresa-lee\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-cig-smoking-pregnancy-4-carmen-teresa-lee\"> </a><a name=\"hcobservation-cig-smoking-pregnancy-4-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-cig-smoking-pregnancy-4-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-cigarette-smoking-before-during-pregnancy.html\">Observation - Cigarette Smoking Before and During Pregnancy</a></p></div><p><b>status</b>: final</p><p><b>code</b>: In the last 3 months of your pregnancy, how many cigarettes did you smoke on an average day [PhenX] <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#64795-8)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee))</a></p><p><b>focus</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee)</a></p><p><b>value</b>: 0</p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "64795-8",
+                          "display": "In the last 3 months of your pregnancy, how many cigarettes did you smoke on an average day [PhenX]"
+                      }
+                  ],
+                  "text": "In the last 3 months of your pregnancy, how many cigarettes did you smoke on an average day [PhenX]"
+              },
+              "subject": {
+                  "reference": "Patient/patient-mother-carmen-teresa-lee",
+                  "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "focus": [
+                  {
+                      "reference": "Patient/patient-decedent-fetus-not-named",
+                      "display": "Patient - Decedent Fetus (Fetus Not Named)"
+                  }
+              ],
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Patient/patient-mother-carmen-teresa-lee"
+                  }
+              ],
+              "valueInteger": 0
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-number-previous-cesareans-carmen-teresa-lee-w-edit",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-number-previous-cesareans-carmen-teresa-lee-w-edit",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-number-previous-cesareans"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-number-previous-cesareans-carmen-teresa-lee-w-edit\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-number-previous-cesareans-carmen-teresa-lee-w-edit\"> </a><a name=\"hcobservation-number-previous-cesareans-carmen-teresa-lee-w-edit\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-number-previous-cesareans-carmen-teresa-lee-w-edit&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-number-previous-cesareans.html\">Observation - Number of Previous Cesareans</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Previous cesarean deliveries # <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#68497-7)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Practitioner_practitioner-vital-records-janet-seito\">See above (Practitioner/practitioner-vital-records-janet-seito)</a></p><p><b>value</b>: 1</p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "68497-7",
+                          "display": "Previous cesarean deliveries #"
+                      }
+                  ],
+                  "text": "Previous cesarean deliveries #"
+              },
+              "subject": {
+                  "reference": "Patient/patient-mother-carmen-teresa-lee",
+                  "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Practitioner/practitioner-vital-records-janet-seito"
+                  }
+              ],
+              "valueInteger": 1,
+              "_valueInteger": {
+                  "extension": [
+                      {
+                          "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag",
+                          "valueCodeableConcept": {
+                              "coding": [
+                                  {
+                                      "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-vr-edit-flags",
+                                      "code": "0",
+                                      "display": "Edit Passed"
+                                  }
+                              ]
+                          }
+                      }
+                  ]
+              }
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-fetal-presentation-not-named",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-fetal-presentation-not-named",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-fetal-presentation"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-fetal-presentation-not-named\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-fetal-presentation-not-named\"> </a><a name=\"hcobservation-fetal-presentation-not-named\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-fetal-presentation-not-named&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-fetal-presentation.html\">Observation - Fetal Presentation at Birth/Delivery</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Fetal presentation--at birth [US Standard Certificate of Live Birth] <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#73761-9)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Practitioner_practitioner-vital-records-janet-seito\">See above (Practitioner/practitioner-vital-records-janet-seito)</a></p><p><b>value</b>: Breech presentation (finding) <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#6096002)</span></p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "73761-9"
+                      }
+                  ]
+              },
+              "subject": {
+                  "reference": "Patient/patient-decedent-fetus-not-named",
+                  "display": "Patient - Decedent Fetus (Fetus Not Named)"
+              },
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Practitioner/practitioner-vital-records-janet-seito"
+                  }
+              ],
+              "valueCodeableConcept": {
+                  "coding": [
+                      {
+                          "system": "http://snomed.info/sct",
+                          "code": "6096002",
+                          "display": "Breech presentation (finding)"
+                      }
+                  ]
+              }
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Procedure/procedure-final-route-method-delivery-not-named",
+          "resource": {
+              "resourceType": "Procedure",
+              "id": "procedure-final-route-method-delivery-not-named",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Procedure-final-route-method-delivery"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Procedure_procedure-final-route-method-delivery-not-named\"> </a><p><b>Generated Narrative: Procedure</b><a name=\"procedure-final-route-method-delivery-not-named\"> </a><a name=\"hcprocedure-final-route-method-delivery-not-named\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Procedure &quot;procedure-final-route-method-delivery-not-named&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Procedure-final-route-method-delivery.html\">Procedure - Final Route and Method of Delivery</a></p></div><p><b>status</b>: completed</p><p><b>category</b>: Final route and method of delivery [US Standard Certificate of Live Birth] <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#73762-7)</span></p><p><b>code</b>: Spontaneous vaginal delivery <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#700000006 &quot;Vaginal delivery of fetus (procedure)&quot;)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee))</a></p><p><b>performed</b>: 2019-01-19 18:00:00-0700 --&gt; 2019-01-19 18:23:00-0700</p></div>"
+              },
+              "status": "completed",
+              "category": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "73762-7"
+                      }
+                  ]
+              },
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://snomed.info/sct",
+                          "code": "700000006",
+                          "display": "Vaginal delivery of fetus (procedure)"
+                      }
+                  ],
+                  "text": "Spontaneous vaginal delivery"
+              },
+              "subject": {
+                  "reference": "Patient/patient-mother-carmen-teresa-lee",
+                  "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "performedPeriod": {
+                  "start": "2019-01-19T18:00:00-07:00",
+                  "end": "2019-01-19T18:23:00-07:00"
+              }
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-birth-weight-not-named-w-edit",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-birth-weight-not-named-w-edit",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-birth-weight"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-birth-weight-not-named-w-edit\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-birth-weight-not-named-w-edit\"> </a><a name=\"hcobservation-birth-weight-not-named-w-edit\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-birth-weight-not-named-w-edit&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-birth-weight.html\">Observation - Birth Weight</a></p></div><p><b>status</b>: final</p><p><b>category</b>: Vital Signs <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-observation-category.html\">Observation Category Codes</a>#vital-signs)</span></p><p><b>code</b>: Birth weight Measured <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#8339-4)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p><p><b>effective</b>: 2019-02-10</p><p><b>performer</b>: <a href=\"#Organization_organization-jurisdictional-vital-records-office\">See above (Organization/organization-jurisdictional-vital-records-office)</a></p><p><b>value</b>: 1530 g<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM code g = 'g')</span></p></div>"
+              },
+              "status": "final",
+              "category": [
+                  {
+                      "coding": [
+                          {
+                              "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                              "code": "vital-signs"
+                          }
+                      ]
+                  }
+              ],
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "8339-4"
+                      }
+                  ]
+              },
+              "subject": {
+                  "reference": "Patient/patient-decedent-fetus-not-named",
+                  "display": "Patient - Decedent Fetus (Fetus Not Named)"
+              },
+              "effectiveDateTime": "2019-02-10",
+              "performer": [
+                  {
+                      "reference": "Organization/organization-jurisdictional-vital-records-office"
+                  }
+              ],
+              "valueQuantity": {
+                  "extension": [
+                      {
+                          "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag",
+                          "valueCodeableConcept": {
+                              "coding": [
+                                  {
+                                      "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-vr-edit-flags",
+                                      "code": "0off",
+                                      "display": "Off"
+                                  }
+                              ]
+                          }
+                      }
+                  ],
+                  "value": 1530,
+                  "system": "http://unitsofmeasure.org",
+                  "code": "g"
+              }
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-gestational-age-at-delivery-not-named-w-edit",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-gestational-age-at-delivery-not-named-w-edit",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-gestational-age-at-delivery"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-gestational-age-at-delivery-not-named-w-edit\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-gestational-age-at-delivery-not-named-w-edit\"> </a><a name=\"hcobservation-gestational-age-at-delivery-not-named-w-edit\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-gestational-age-at-delivery-not-named-w-edit&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-gestational-age-at-delivery.html\">Observation - Gestational Age at Delivery</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Gestational age Estimated <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#11884-4)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Practitioner_practitioner-vital-records-janet-seito\">See above (Practitioner/practitioner-vital-records-janet-seito)</a></p><p><b>value</b>: 20 wk<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM code wk = 'wk')</span></p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "11884-4",
+                          "display": "Gestational age Estimated"
+                      }
+                  ]
+              },
+              "subject": {
+                  "reference": "Patient/patient-decedent-fetus-not-named",
+                  "display": "Patient - Decedent Fetus (Fetus Not Named)"
+              },
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Practitioner/practitioner-vital-records-janet-seito"
+                  }
+              ],
+              "valueQuantity": {
+                  "extension": [
+                      {
+                          "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag",
+                          "valueCodeableConcept": {
+                              "coding": [
+                                  {
+                                      "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-vr-edit-flags",
+                                      "code": "0off",
+                                      "display": "Off"
+                                  }
+                              ]
+                          }
+                      }
+                  ],
+                  "value": 20,
+                  "system": "http://unitsofmeasure.org",
+                  "code": "wk"
+              }
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Condition/condition-fetal-death-cause-or-condition-not-named",
+          "resource": {
+              "resourceType": "Condition",
+              "id": "condition-fetal-death-cause-or-condition-not-named",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Condition-fetal-death-cause-or-condition"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Condition_condition-fetal-death-cause-or-condition-not-named\"> </a><p><b>Generated Narrative: Condition</b><a name=\"condition-fetal-death-cause-or-condition-not-named\"> </a><a name=\"hccondition-fetal-death-cause-or-condition-not-named\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Condition &quot;condition-fetal-death-cause-or-condition-not-named&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Condition-fetal-death-cause-or-condition.html\">Condition - Fetal Death Cause or Condition</a></p></div><p><b>category</b>: Encounter Diagnosis <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-condition-category.html\">Condition Category Codes</a>#encounter-diagnosis)</span>, Initiating cause or condition of fetal death [US Standard Report of Fetal Death] <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#76060-3)</span></p><p><b>code</b>: Premature rupture of membranes (disorder) <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#44223004)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p></div>"
+              },
+              "category": [
+                  {
+                      "coding": [
+                          {
+                              "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                              "code": "encounter-diagnosis",
+                              "display": "Encounter Diagnosis"
+                          }
+                      ]
+                  },
+                  {
+                      "coding": [
+                          {
+                              "system": "http://loinc.org",
+                              "code": "76060-3",
+                              "display": "Initiating cause or condition of fetal death [US Standard Report of Fetal Death]"
+                          }
+                      ]
+                  }
+              ],
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://snomed.info/sct",
+                          "code": "44223004",
+                          "display": "Premature rupture of membranes (disorder)"
+                      }
+                  ],
+                  "text": "Premature rupture of membranes (disorder)"
+              },
+              "subject": {
+                  "reference": "Patient/patient-decedent-fetus-not-named",
+                  "display": "Patient - Decedent Fetus (Fetus Not Named)"
+              }
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Condition/condition-fetal-death-other-significant-cause-not-named",
+          "resource": {
+              "resourceType": "Condition",
+              "id": "condition-fetal-death-other-significant-cause-not-named",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Condition-fetal-death-other-cause-or-condition"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Condition_condition-fetal-death-other-significant-cause-not-named\"> </a><p><b>Generated Narrative: Condition</b><a name=\"condition-fetal-death-other-significant-cause-not-named\"> </a><a name=\"hccondition-fetal-death-other-significant-cause-not-named\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Condition &quot;condition-fetal-death-other-significant-cause-not-named&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Condition-fetal-death-other-cause-or-condition.html\">Condition - Fetal Death Other Cause or Condition</a></p></div><p><b>category</b>: Encounter Diagnosis <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-condition-category.html\">Condition Category Codes</a>#encounter-diagnosis)</span>, Other significant causes or conditions of fetal death [US Standard Report of Fetal Death] <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#76061-1)</span></p><p><b>code</b>: Placental insufficiency (disorder) <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#237292005)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p></div>"
+              },
+              "category": [
+                  {
+                      "coding": [
+                          {
+                              "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                              "code": "encounter-diagnosis",
+                              "display": "Encounter Diagnosis"
+                          }
+                      ]
+                  },
+                  {
+                      "coding": [
+                          {
+                              "system": "http://loinc.org",
+                              "code": "76061-1",
+                              "display": "Other significant causes or conditions of fetal death [US Standard Report of Fetal Death]"
+                          }
+                      ]
+                  }
+              ],
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://snomed.info/sct",
+                          "code": "237292005",
+                          "display": "Placental insufficiency (disorder)"
+                      }
+                  ],
+                  "text": "Placental insufficiency (disorder)"
+              },
+              "subject": {
+                  "reference": "Patient/patient-decedent-fetus-not-named",
+                  "display": "Patient - Decedent Fetus (Fetus Not Named)"
+              }
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-fetal-death-time-point-not-named",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-fetal-death-time-point-not-named",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-fetal-death-time-point"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-fetal-death-time-point-not-named\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-fetal-death-time-point-not-named\"> </a><a name=\"hcobservation-fetal-death-time-point-not-named\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-fetal-death-time-point-not-named&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-fetal-death-time-point.html\">Observation - Fetal Death Time Point</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Estimated timing of fetal death [US Standard Report of Fetal Death] <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#73811-2)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Practitioner_practitioner-vital-records-janet-seito\">See above (Practitioner/practitioner-vital-records-janet-seito)</a></p><p><b>value</b>: Fetal intrapartum death after first assessment (event) <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#434631000124100)</span></p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "73811-2"
+                      }
+                  ]
+              },
+              "subject": {
+                  "reference": "Patient/patient-decedent-fetus-not-named",
+                  "display": "Patient - Decedent Fetus (Fetus Not Named)"
+              },
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Practitioner/practitioner-vital-records-janet-seito"
+                  }
+              ],
+              "valueCodeableConcept": {
+                  "coding": [
+                      {
+                          "system": "http://snomed.info/sct",
+                          "code": "434631000124100",
+                          "display": "Fetal intrapartum death after first assessment (event)"
+                      }
+                  ]
+              }
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-autopsy-performed-not-named",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-autopsy-performed-not-named",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Observation-autopsy-performed-indicator-vr"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-autopsy-performed-not-named\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-autopsy-performed-not-named\"> </a><a name=\"hcobservation-autopsy-performed-not-named\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-autopsy-performed-not-named&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"https://build.fhir.org/ig/HL7/vr-common-library//StructureDefinition-Observation-autopsy-performed-indicator-vr.html\">Observation - Autopsy Performed Indicator Vital Records</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Autopsy was performed <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#85699-7)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Practitioner_practitioner-vital-records-janet-seito\">See above (Practitioner/practitioner-vital-records-janet-seito)</a></p><p><b>value</b>: Yes <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#Y)</span></p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "85699-7",
+                          "display": "Autopsy was performed"
+                      }
+                  ]
+              },
+              "subject": {
+                  "reference": "Patient/patient-decedent-fetus-not-named",
+                  "display": "Patient - Decedent Fetus (Fetus Not Named)"
+              },
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Practitioner/practitioner-vital-records-janet-seito"
+                  }
+              ],
+              "valueCodeableConcept": {
+                  "coding": [
+                      {
+                          "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                          "code": "Y",
+                          "display": "Yes"
+                      }
+                  ]
+              }
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-histological-placental-exam-performed-not-named",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-histological-placental-exam-performed-not-named",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-histological-placental-exam-performed"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-histological-placental-exam-performed-not-named\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-histological-placental-exam-performed-not-named\"> </a><a name=\"hcobservation-histological-placental-exam-performed-not-named\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-histological-placental-exam-performed-not-named&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-histological-placental-exam-performed.html\">Observation - Histological Placental Exam Performed</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Was an histological placental examination performed? <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#73767-6)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Practitioner_practitioner-vital-records-janet-seito\">See above (Practitioner/practitioner-vital-records-janet-seito)</a></p><p><b>value</b>: Performed <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#398166005)</span></p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "73767-6"
+                      }
+                  ]
+              },
+              "subject": {
+                  "reference": "Patient/patient-decedent-fetus-not-named",
+                  "display": "Patient - Decedent Fetus (Fetus Not Named)"
+              },
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Practitioner/practitioner-vital-records-janet-seito"
+                  }
+              ],
+              "valueCodeableConcept": {
+                  "coding": [
+                      {
+                          "system": "http://snomed.info/sct",
+                          "code": "398166005",
+                          "display": "Performed"
+                      }
+                  ]
+              }
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-autopsy-histological-exam-results-used-not-named",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-autopsy-histological-exam-results-used-not-named",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-autopsy-histological-exam-results-used"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-autopsy-histological-exam-results-used-not-named\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-autopsy-histological-exam-results-used-not-named\"> </a><a name=\"hcobservation-autopsy-histological-exam-results-used-not-named\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-autopsy-histological-exam-results-used-not-named&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-autopsy-histological-exam-results-used.html\">Observation - Autopsy or Histological Exam Results Used</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Autopsy or histological placental examination results were used [US Standard Report of Fetal Death] <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#74498-7)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Practitioner_practitioner-vital-records-janet-seito\">See above (Practitioner/practitioner-vital-records-janet-seito)</a></p><p><b>value</b>: Yes <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#Y)</span></p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "74498-7",
+                          "display": "Autopsy or histological placental examination results were used [US Standard Report of Fetal Death]"
+                      }
+                  ]
+              },
+              "subject": {
+                  "reference": "Patient/patient-decedent-fetus-not-named",
+                  "display": "Patient - Decedent Fetus (Fetus Not Named)"
+              },
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Practitioner/practitioner-vital-records-janet-seito"
+                  }
+              ],
+              "valueCodeableConcept": {
+                  "coding": [
+                      {
+                          "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                          "code": "Y",
+                          "display": "Yes"
+                      }
+                  ]
+              }
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-number-deaths-this-delivery-carmen-teresa-lee",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-number-deaths-this-delivery-carmen-teresa-lee",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-number-fetal-deaths-this-delivery"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-number-deaths-this-delivery-carmen-teresa-lee\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-number-deaths-this-delivery-carmen-teresa-lee\"> </a><a name=\"hcobservation-number-deaths-this-delivery-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-number-deaths-this-delivery-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Observation-number-fetal-deaths-this-delivery.html\">Observation - Number of Fetal Deaths This Delivery</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Number of fetal deaths delivered <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#73772-6)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee))</a></p><p><b>focus</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Practitioner_practitioner-vital-records-janet-seito\">See above (Practitioner/practitioner-vital-records-janet-seito)</a></p><p><b>value</b>: 1</p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "73772-6",
+                          "display": "Number of fetal deaths delivered"
+                      }
+                  ],
+                  "text": "Number of fetal deaths delivered"
+              },
+              "subject": {
+                  "reference": "Patient/patient-mother-carmen-teresa-lee",
+                  "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "focus": [
+                  {
+                      "reference": "Patient/patient-decedent-fetus-not-named",
+                      "display": "Patient - Decedent Fetus (Fetus Not Named)"
+                  }
+              ],
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Practitioner/practitioner-vital-records-janet-seito"
+                  }
+              ],
+              "valueInteger": 1
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-parent-education-level-carmen-teresa-lee-w-edit",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-parent-education-level-carmen-teresa-lee-w-edit",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Observation-education-level-vr"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-parent-education-level-carmen-teresa-lee-w-edit\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-parent-education-level-carmen-teresa-lee-w-edit\"> </a><a name=\"hcobservation-parent-education-level-carmen-teresa-lee-w-edit\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-parent-education-level-carmen-teresa-lee-w-edit&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"https://build.fhir.org/ig/HL7/vr-common-library//StructureDefinition-Observation-education-level-vr.html\">Observation - Education Level Vital Records</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Highest level of education Mother <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#57712-2)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p><p><b>focus</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee))</a></p><p><b>effective</b>: 2019-12-02</p><p><b>performer</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee)</a></p><p><b>value</b>: 9th through 12th grade; no diploma <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-v3-EducationLevel.html\">Education Level</a>#SEC &quot;Some secondary or high school education&quot;)</span></p></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "57712-2",
+                          "display": "Highest level of education Mother"
+                      }
+                  ]
+              },
+              "subject": {
+                  "reference": "Patient/patient-decedent-fetus-not-named",
+                  "display": "Patient - Decedent Fetus (Fetus Not Named)"
+              },
+              "focus": [
+                  {
+                      "reference": "Patient/patient-mother-carmen-teresa-lee",
+                      "display": "Patient - Mother (Carmen Teresa Lee)"
+                  }
+              ],
+              "effectiveDateTime": "2019-12-02",
+              "performer": [
+                  {
+                      "reference": "Patient/patient-mother-carmen-teresa-lee"
+                  }
+              ],
+              "valueCodeableConcept": {
+                  "extension": [
+                      {
+                          "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag",
+                          "valueCodeableConcept": {
+                              "coding": [
+                                  {
+                                      "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-vr-edit-flags",
+                                      "code": "0",
+                                      "display": "Edit Passed"
+                                  }
+                              ]
+                          }
+                      }
+                  ],
+                  "coding": [
+                      {
+                          "system": "http://terminology.hl7.org/CodeSystem/v3-EducationLevel",
+                          "code": "SEC",
+                          "display": "Some secondary or high school education"
+                      }
+                  ],
+                  "text": "9th through 12th grade; no diploma"
+              }
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-usual-work-carmen-teresa-lee",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-usual-work-carmen-teresa-lee",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Observation-usual-work-vr"
+                  ]
+              },
+              "text": {
+                  "status": "extensions",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-usual-work-carmen-teresa-lee\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-usual-work-carmen-teresa-lee\"> </a><a name=\"hcobservation-usual-work-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-usual-work-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"https://build.fhir.org/ig/HL7/vr-common-library//StructureDefinition-Observation-usual-work-vr.html\">Observation - Usual Work</a></p></div><p><b>Role Vital Records</b>: mother <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-v3-RoleCode.html\">RoleCode</a>#MTH)</span></p><p><b>status</b>: final</p><p><b>code</b>: Hx of Usual occupation <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#21843-8)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named)</a></p><p><b>focus</b>: <a href=\"#RelatedPerson_relatedperson-mother-carmen-teresa-lee\">See above (RelatedPerson/relatedperson-mother-carmen-teresa-lee)</a></p><p><b>value</b>: Secretary <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> ()</span></p><h3>Components</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Code</b></td><td><b>Value[x]</b></td></tr><tr><td style=\"display: none\">*</td><td>Hx of Usual industry <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#21844-6)</span></td><td>State Agency <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> ()</span></td></tr></table></div>"
+              },
+              "extension": [
+                  {
+                      "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-role-vr",
+                      "valueCodeableConcept": {
+                          "coding": [
+                              {
+                                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                                  "code": "MTH",
+                                  "display": "mother"
+                              }
+                          ]
+                      }
+                  }
+              ],
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "21843-8"
+                      }
+                  ]
+              },
+              "subject": {
+                  "reference": "Patient/patient-decedent-fetus-not-named"
+              },
+              "focus": [
+                  {
+                      "reference": "RelatedPerson/relatedperson-mother-carmen-teresa-lee"
+                  }
+              ],
+              "valueCodeableConcept": {
+                  "text": "Secretary"
+              },
+              "component": [
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://loinc.org",
+                                  "code": "21844-6"
+                              }
+                          ]
+                      },
+                      "valueCodeableConcept": {
+                          "text": "State Agency"
+                      }
+                  }
+              ]
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-usual-work-tom-yan-lee",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-usual-work-tom-yan-lee",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Observation-usual-work-vr"
+                  ]
+              },
+              "text": {
+                  "status": "extensions",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-usual-work-tom-yan-lee\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-usual-work-tom-yan-lee\"> </a><a name=\"hcobservation-usual-work-tom-yan-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-usual-work-tom-yan-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"https://build.fhir.org/ig/HL7/vr-common-library//StructureDefinition-Observation-usual-work-vr.html\">Observation - Usual Work</a></p></div><p><b>Role Vital Records</b>: father <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-v3-RoleCode.html\">RoleCode</a>#FTH)</span></p><p><b>status</b>: final</p><p><b>code</b>: Hx of Usual occupation <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#21843-8)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named)</a></p><p><b>focus</b>: <a href=\"#RelatedPerson_relatedperson-father-natural-tom-yan-lee\">See above (RelatedPerson/relatedperson-father-natural-tom-yan-lee)</a></p><p><b>value</b>: Teaching Assistant <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> ()</span></p><h3>Components</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Code</b></td><td><b>Value[x]</b></td></tr><tr><td style=\"display: none\">*</td><td>Hx of Usual industry <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#21844-6)</span></td><td>Elementary and Secondary Schools <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> ()</span></td></tr></table></div>"
+              },
+              "extension": [
+                  {
+                      "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-role-vr",
+                      "valueCodeableConcept": {
+                          "coding": [
+                              {
+                                  "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                                  "code": "FTH",
+                                  "display": "father"
+                              }
+                          ]
+                      }
+                  }
+              ],
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "21843-8"
+                      }
+                  ]
+              },
+              "subject": {
+                  "reference": "Patient/patient-decedent-fetus-not-named"
+              },
+              "focus": [
+                  {
+                      "reference": "RelatedPerson/relatedperson-father-natural-tom-yan-lee"
+                  }
+              ],
+              "valueCodeableConcept": {
+                  "text": "Teaching Assistant"
+              },
+              "component": [
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://loinc.org",
+                                  "code": "21844-6"
+                              }
+                          ]
+                      },
+                      "valueCodeableConcept": {
+                          "text": "Elementary and Secondary Schools"
+                      }
+                  }
+              ]
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Observation/observation-input-race-and-ethnicity-carmen-teresa-lee",
+          "resource": {
+              "resourceType": "Observation",
+              "id": "observation-input-race-and-ethnicity-carmen-teresa-lee",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/input-race-and-ethnicity-vr"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Observation_observation-input-race-and-ethnicity-carmen-teresa-lee\"> </a><p><b>Generated Narrative: Observation</b><a name=\"observation-input-race-and-ethnicity-carmen-teresa-lee\"> </a><a name=\"hcobservation-input-race-and-ethnicity-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-input-race-and-ethnicity-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"https://build.fhir.org/ig/HL7/vr-common-library//StructureDefinition-input-race-and-ethnicity-vr.html\">Observation - Input Race and Ethnicity Vital Records</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Mother Input Race and Ethnicity <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-CodeSystem-local-observation-codes-vr.html\">Local Observation Codes Vital Records</a>#inputraceandethnicityMother)</span></p><p><b>subject</b>: <a href=\"#Patient_patient-mother-carmen-teresa-lee\">See above (Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee))</a></p><blockquote><p><b>component</b></p><p><b>code</b>: White <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#White)</span></p><p><b>value</b>: true</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Black Or African American <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#BlackOrAfricanAmerican)</span></p><p><b>value</b>: true</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: American Indian Or Alaska Native <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#AmericanIndianOrAlaskanNative)</span></p><p><b>value</b>: true</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Asian Indian <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#AsianIndian)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Chinese <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Chinese)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Filipino <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Filipino)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Japanese <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Japanese)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Korean <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Korean)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Vietnamese <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Vietnamese)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Other Asian <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#OtherAsian)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Native Hawaiian <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#NativeHawaiian)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Guamanian Or Chamorro <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#GuamanianOrChamorro)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Samoan <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Samoan)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Other Pacific Islander <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#OtherPacificIslander)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Other Race <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#OtherRace)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: First Other Asian Literal <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#FirstOtherAsianLiteral)</span></p><p><b>value</b>: Malaysian</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: First American Indian Or Alaska Native Literal <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#FirstAmericanIndianOrAlaskanNativeLiteral)</span></p><p><b>value</b>: Arikara</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Hispanic Mexican <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#HispanicMexican)</span></p><p><b>value</b>: Yes <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#Y)</span></p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Hispanic Cuban <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#HispanicCuban)</span></p><p><b>value</b>: Yes <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#Y)</span></p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Hispanic Puerto Rican <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#HispanicPuertoRican)</span></p><p><b>value</b>: Yes <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#Y)</span></p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Hispanic Other <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://build.fhir.org/ig/HL7/vr-common-library//CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#HispanicOther)</span></p><p><b>value</b>: No <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#N)</span></p></blockquote></div>"
+              },
+              "status": "final",
+              "code": {
+                  "coding": [
+                      {
+                          "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-local-observation-codes-vr",
+                          "code": "inputraceandethnicityMother"
+                      }
+                  ]
+              },
+              "subject": {
+                  "reference": "Patient/patient-mother-carmen-teresa-lee",
+                  "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "component": [
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "White"
+                              }
+                          ]
+                      },
+                      "valueBoolean": true
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "BlackOrAfricanAmerican"
+                              }
+                          ]
+                      },
+                      "valueBoolean": true
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "AmericanIndianOrAlaskanNative"
+                              }
+                          ]
+                      },
+                      "valueBoolean": true
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "AsianIndian"
+                              }
+                          ]
+                      },
+                      "valueBoolean": false
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "Chinese"
+                              }
+                          ]
+                      },
+                      "valueBoolean": false
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "Filipino"
+                              }
+                          ]
+                      },
+                      "valueBoolean": false
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "Japanese"
+                              }
+                          ]
+                      },
+                      "valueBoolean": false
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "Korean"
+                              }
+                          ]
+                      },
+                      "valueBoolean": false
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "Vietnamese"
+                              }
+                          ]
+                      },
+                      "valueBoolean": false
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "OtherAsian"
+                              }
+                          ]
+                      },
+                      "valueBoolean": false
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "NativeHawaiian"
+                              }
+                          ]
+                      },
+                      "valueBoolean": false
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "GuamanianOrChamorro"
+                              }
+                          ]
+                      },
+                      "valueBoolean": false
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "Samoan"
+                              }
+                          ]
+                      },
+                      "valueBoolean": false
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "OtherPacificIslander"
+                              }
+                          ]
+                      },
+                      "valueBoolean": false
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "OtherRace"
+                              }
+                          ]
+                      },
+                      "valueBoolean": false
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "FirstOtherAsianLiteral"
+                              }
+                          ]
+                      },
+                      "valueString": "Malaysian"
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "FirstAmericanIndianOrAlaskanNativeLiteral"
+                              }
+                          ]
+                      },
+                      "valueString": "Arikara"
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "HispanicMexican"
+                              }
+                          ]
+                      },
+                      "valueCodeableConcept": {
+                          "coding": [
+                              {
+                                  "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                                  "code": "Y",
+                                  "display": "Yes"
+                              }
+                          ]
+                      }
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "HispanicCuban"
+                              }
+                          ]
+                      },
+                      "valueCodeableConcept": {
+                          "coding": [
+                              {
+                                  "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                                  "code": "Y",
+                                  "display": "Yes"
+                              }
+                          ]
+                      }
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "HispanicPuertoRican"
+                              }
+                          ]
+                      },
+                      "valueCodeableConcept": {
+                          "coding": [
+                              {
+                                  "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                                  "code": "Y",
+                                  "display": "Yes"
+                              }
+                          ]
+                      }
+                  },
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                                  "code": "HispanicOther"
+                              }
+                          ]
+                      },
+                      "valueCodeableConcept": {
+                          "coding": [
+                              {
+                                  "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                                  "code": "N",
+                                  "display": "No"
+                              }
+                          ]
+                      }
+                  }
+              ]
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Practitioner/practitioner-vital-records-janet-seito",
+          "resource": {
+              "resourceType": "Practitioner",
+              "id": "practitioner-vital-records-janet-seito",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Practitioner-vr"
+                  ]
+              },
+              "text": {
+                  "status": "extensions",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Practitioner_practitioner-vital-records-janet-seito\"> </a><p><b>Generated Narrative: Practitioner</b><a name=\"practitioner-vital-records-janet-seito\"> </a><a name=\"hcpractitioner-vital-records-janet-seito\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Practitioner &quot;practitioner-vital-records-janet-seito&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"https://build.fhir.org/ig/HL7/vr-common-library//StructureDefinition-Practitioner-vr.html\">Practitioner - Vital Records</a></p></div><p><b>Practitioner Role - Birth Attendant</b>: attendant</p><p><b>Practitioner Role - Certifier</b>: certifier</p><p><b>identifier</b>: <a href=\"http://terminology.hl7.org/5.0.0/NamingSystem-npi.html\" title=\"National Provider Identifier\">NPI</a>/223347044</p><p><b>name</b>: Janet Seito</p><h3>Qualifications</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Code</b></td></tr><tr><td style=\"display: none\">*</td><td>Osteopath (occupation) <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://browser.ihtsdotools.org/\">SNOMED CT</a>#76231001)</span></td></tr></table></div>"
+              },
+              "extension": [
+                  {
+                      "url": "http://hl7.org/fhir/us/bfdr/StructureDefinition/practitioner-role-birth-attendant",
+                      "valueCode": "attendant"
+                  },
+                  {
+                      "url": "http://hl7.org/fhir/us/bfdr/StructureDefinition/practitioner-role-birth-certifier",
+                      "valueCode": "certifier"
+                  }
+              ],
+              "identifier": [
+                  {
+                      "system": "http://hl7.org/fhir/sid/us-npi",
+                      "value": "223347044"
+                  }
+              ],
+              "name": [
+                  {
+                      "text": "Janet Seito",
+                      "family": "Janet",
+                      "given": [
+                          "Seito"
+                      ],
+                      "suffix": [
+                          "D.O."
+                      ]
+                  }
+              ],
+              "qualification": [
+                  {
+                      "code": {
+                          "coding": [
+                              {
+                                  "system": "http://snomed.info/sct",
+                                  "code": "76231001",
+                                  "display": "Osteopath (occupation)"
+                              }
+                          ]
+                      }
+                  }
+              ]
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Location/location-south-hospital",
+          "resource": {
+              "resourceType": "Location",
+              "id": "location-south-hospital",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Location-bfdr"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Location_location-south-hospital\"> </a><p><b>Generated Narrative: Location</b><a name=\"location-south-hospital\"> </a><a name=\"hclocation-south-hospital\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Location &quot;location-south-hospital&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Location-bfdr.html\">Birth and Fetal Death Location</a></p></div><p><b>identifier</b>: <a href=\"http://terminology.hl7.org/5.0.0/NamingSystem-npi.html\" title=\"National Provider Identifier\">NPI</a>/116441967701</p><p><b>status</b>: active</p><p><b>name</b>: South Hospital</p><p><b>type</b>: Hospital <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-v3-RoleCode.html\">RoleCode</a>#HOSP)</span>, Birth Location <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"CodeSystem-CodeSystem-local-bfdr-codes.html\">Local BFDR Codes</a>#loc_birth)</span></p><p><b>address</b>: 2100 North Ave Salt Lake City UT 84116 US </p><h3>Positions</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Longitude</b></td><td><b>Latitude</b></td></tr><tr><td style=\"display: none\">*</td><td>40.8</td><td>111.9</td></tr></table><p><b>managingOrganization</b>: <a href=\"#Organization_organization-south-hospital\">See above (Organization/organization-south-hospital: Organization - South Hospital)</a></p></div>"
+              },
+              "identifier": [
+                  {
+                      "extension": [
+                          {
+                              "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/AuxiliaryStateIdentifier1",
+                              "valueString": "UT1234567"
+                          }
+                      ],
+                      "system": "http://hl7.org/fhir/sid/us-npi",
+                      "value": "116441967701"
+                  }
+              ],
+              "status": "active",
+              "name": "South Hospital",
+              "type": [
+                  {
+                      "coding": [
+                          {
+                              "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                              "code": "HOSP",
+                              "display": "Hospital"
+                          }
+                      ]
+                  },
+                  {
+                      "coding": [
+                          {
+                              "system": "http://hl7.org/fhir/us/bfdr/CodeSystem/CodeSystem-local-bfdr-codes",
+                              "code": "loc_birth",
+                              "display": "Birth Location"
+                          }
+                      ]
+                  }
+              ],
+              "address": {
+                  "line": [
+                      "2100 North Ave"
+                  ],
+                  "city": "Salt Lake City",
+                  "district": "Made Up",
+                  "state": "UT",
+                  "postalCode": "84116",
+                  "country": "US"
+              },
+              "position": {
+                  "longitude": 40.8,
+                  "latitude": 111.9
+              },
+              "managingOrganization": {
+                  "reference": "Organization/organization-south-hospital",
+                  "display": "Organization - South Hospital"
+              }
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/Organization/organization-south-hospital",
+          "resource": {
+              "resourceType": "Organization",
+              "id": "organization-south-hospital",
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Organization_organization-south-hospital\"> </a><p><b>Generated Narrative: Organization</b><a name=\"organization-south-hospital\"> </a><a name=\"hcorganization-south-hospital\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Organization &quot;organization-south-hospital&quot; </p></div><p><b>identifier</b>: <a href=\"http://terminology.hl7.org/5.0.0/NamingSystem-npi.html\" title=\"National Provider Identifier\">NPI</a>/5555512</p><p><b>active</b>: true</p><p><b>type</b>: Hospital <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-v3-RoleCode.html\">RoleCode</a>#HOSP)</span></p><p><b>name</b>: South Hospital</p><p><b>telecom</b>: <a href=\"tel:+1-555-555-1111\">+1-555-555-1111</a>, <a href=\"mailto:mail@southhospital.com\">mail@southhospital.com</a></p><p><b>address</b>: 2100 North Ave Salt Lake City UT 84116 US </p></div>"
+              },
+              "identifier": [
+                  {
+                      "system": "http://hl7.org/fhir/sid/us-npi",
+                      "value": "5555512"
+                  }
+              ],
+              "active": true,
+              "type": [
+                  {
+                      "coding": [
+                          {
+                              "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                              "code": "HOSP",
+                              "display": "Hospital"
+                          }
+                      ]
+                  }
+              ],
+              "name": "South Hospital",
+              "telecom": [
+                  {
+                      "system": "phone",
+                      "value": "+1-555-555-1111"
+                  },
+                  {
+                      "system": "email",
+                      "value": "mail@southhospital.com"
+                  }
+              ],
+              "address": [
+                  {
+                      "line": [
+                          "2100 North Ave"
+                      ],
+                      "city": "Salt Lake City",
+                      "state": "UT",
+                      "postalCode": "84116",
+                      "country": "US"
+                  }
+              ]
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/RelatedPerson/relatedperson-mother-carmen-teresa-lee",
+          "resource": {
+              "resourceType": "RelatedPerson",
+              "id": "relatedperson-mother-carmen-teresa-lee",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/RelatedPerson-mother-vr"
+                  ]
+              },
+              "text": {
+                  "status": "generated",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"RelatedPerson_relatedperson-mother-carmen-teresa-lee\"> </a><p><b>Generated Narrative: RelatedPerson</b><a name=\"relatedperson-mother-carmen-teresa-lee\"> </a><a name=\"hcrelatedperson-mother-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource RelatedPerson &quot;relatedperson-mother-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"https://build.fhir.org/ig/HL7/vr-common-library//StructureDefinition-RelatedPerson-mother-vr.html\">RelatedPerson - Mother Vital Records</a></p></div><p><b>active</b>: true</p><p><b>patient</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p><p><b>relationship</b>: Gestational Mother <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-v3-RoleCode.html\">RoleCode</a>#GESTM &quot;gestational mother&quot;)</span></p><p><b>name</b>: Carmen Teresa Lee (OFFICIAL)</p><p><b>gender</b>: female</p><p><b>birthDate</b>: 1986-02-15</p></div>"
+              },
+              "active": true,
+              "patient": {
+                  "reference": "Patient/patient-decedent-fetus-not-named",
+                  "display": "Patient - Decedent Fetus (Fetus Not Named)"
+              },
+              "relationship": [
+                  {
+                      "coding": [
+                          {
+                              "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                              "code": "GESTM",
+                              "display": "gestational mother"
+                          }
+                      ],
+                      "text": "Gestational Mother"
+                  }
+              ],
+              "name": [
+                  {
+                      "use": "official",
+                      "family": "Lee",
+                      "given": [
+                          "Carmen",
+                          "Teresa"
+                      ]
+                  }
+              ],
+              "gender": "female",
+              "birthDate": "1986-02-15"
+          }
+      },
+      {
+          "fullUrl": "http://www.example.org/fhir/RelatedPerson/relatedperson-father-natural-tom-yan-lee",
+          "resource": {
+              "resourceType": "RelatedPerson",
+              "id": "relatedperson-father-natural-tom-yan-lee",
+              "meta": {
+                  "profile": [
+                      "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/RelatedPerson-father-natural-vr"
+                  ]
+              },
+              "text": {
+                  "status": "extensions",
+                  "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"RelatedPerson_relatedperson-father-natural-tom-yan-lee\"> </a><p><b>Generated Narrative: RelatedPerson</b><a name=\"relatedperson-father-natural-tom-yan-lee\"> </a><a name=\"hcrelatedperson-father-natural-tom-yan-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource RelatedPerson &quot;relatedperson-father-natural-tom-yan-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"https://build.fhir.org/ig/HL7/vr-common-library//StructureDefinition-RelatedPerson-father-natural-vr.html\">RelatedPerson - Father Natural Vital Records</a></p></div><p><b>RelatedPerson Birth Place Vital Records</b>: NY </p><p><b>active</b>: true</p><p><b>patient</b>: <a href=\"#Patient_patient-decedent-fetus-not-named\">See above (Patient/patient-decedent-fetus-not-named: Patient - Decedent Fetus (Fetus Not Named))</a></p><p><b>relationship</b>: Natural Father <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-v3-RoleCode.html\">RoleCode</a>#NFTH &quot;natural father&quot;)</span></p><p><b>name</b>: Tom Yan Lee (OFFICIAL)</p><p><b>gender</b>: male</p><p><b>birthDate</b>: 1984-02-27</p></div>"
+              },
+              "extension": [
+                  {
+                      "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-relatedperson-birthplace-vr",
+                      "valueAddress": {
+                          "state": "NY"
+                      }
+                  }
+              ],
+              "active": true,
+              "patient": {
+                  "reference": "Patient/patient-decedent-fetus-not-named",
+                  "display": "Patient - Decedent Fetus (Fetus Not Named)"
+              },
+              "relationship": [
+                  {
+                      "coding": [
+                          {
+                              "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                              "code": "NFTH",
+                              "display": "natural father"
+                          }
+                      ],
+                      "text": "Natural Father"
+                  }
+              ],
+              "name": [
+                  {
+                      "use": "official",
+                      "family": "Lee",
+                      "given": [
+                          "Tom",
+                          "Yan"
+                      ]
+                  }
+              ],
+              "gender": "male",
+              "birthDate": "1984-02-27"
+          }
+      }
+  ]
+}

--- a/projects/BFDR/BFDR.xml
+++ b/projects/BFDR/BFDR.xml
@@ -27,6 +27,9 @@
         <member name="M:BFDR.BirthRecord.GetYear">
             <summary>Return the birth year for this record to be used in the identifier</summary>
         </member>
+        <member name="M:BFDR.BirthRecord.RestoreReferences">
+            <inheritdoc/>
+        </member>
         <member name="T:BFDR.FetalDeathRecord">
             <summary>Class <c>FetalDeathRecord</c> is a class designed to help consume and produce fetal death
             records that follow the HL7 FHIR Vital Records FetalDeath Reporting Implementation Guide, as described
@@ -49,6 +52,9 @@
         </member>
         <member name="M:BFDR.FetalDeathRecord.GetYear">
             <summary>Return the birth year for this record to be used in the identifier</summary>
+        </member>
+        <member name="M:BFDR.FetalDeathRecord.RestoreReferences">
+            <inheritdoc/>
         </member>
         <member name="T:BFDR.IJEBirth">
             <summary>A "wrapper" class to convert between a FHIR based <c>BirthRecord</c> and
@@ -2462,8 +2468,8 @@
         <member name="M:BFDR.NatalityRecord.RestoreReferences">
             <summary>Restores class references from a newly parsed record.</summary>
         </member>
-        <member name="F:BFDR.NatalityRecord.Child">
-            <summary>The Child.</summary>
+        <member name="F:BFDR.NatalityRecord.Subject">
+            <summary>The Natality Subject - eithr a Child or a DecedentFetus.</summary>
         </member>
         <member name="F:BFDR.NatalityRecord.Mother">
             <summary>The Mother.</summary>

--- a/projects/BFDR/BFDR.xml
+++ b/projects/BFDR/BFDR.xml
@@ -30,6 +30,9 @@
         <member name="M:BFDR.BirthRecord.RestoreReferences">
             <inheritdoc/>
         </member>
+        <member name="M:BFDR.BirthRecord.InitializeCompositionAndSubject">
+            <inheritdoc/>
+        </member>
         <member name="T:BFDR.FetalDeathRecord">
             <summary>Class <c>FetalDeathRecord</c> is a class designed to help consume and produce fetal death
             records that follow the HL7 FHIR Vital Records FetalDeath Reporting Implementation Guide, as described
@@ -54,6 +57,9 @@
             <summary>Return the birth year for this record to be used in the identifier</summary>
         </member>
         <member name="M:BFDR.FetalDeathRecord.RestoreReferences">
+            <inheritdoc/>
+        </member>
+        <member name="M:BFDR.FetalDeathRecord.InitializeCompositionAndSubject">
             <inheritdoc/>
         </member>
         <member name="T:BFDR.IJEBirth">

--- a/projects/BFDR/IJEFetalDeath.cs
+++ b/projects/BFDR/IJEFetalDeath.cs
@@ -2701,12 +2701,11 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
+                return NumericAllowingUnknown_Get("DOR_YR", "RegistrationDateYear");
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                NumericAllowingUnknown_Set("DOR_YR", "RegistrationDateYear", value);
             }
         }
 
@@ -2716,12 +2715,11 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
+                return NumericAllowingUnknown_Get("DOR_MO", "RegistrationDateMonth");
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                NumericAllowingUnknown_Set("DOR_MO", "RegistrationDateMonth", value);
             }
         }
 
@@ -2731,12 +2729,11 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
+                return NumericAllowingUnknown_Get("DOR_DY", "RegistrationDateDay");
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                NumericAllowingUnknown_Set("DOR_DY", "RegistrationDateDay", value);
             }
         }
 

--- a/projects/BFDR/NatalityRecord_constructors.cs
+++ b/projects/BFDR/NatalityRecord_constructors.cs
@@ -19,6 +19,8 @@ namespace BFDR
         /// <summary>Default constructor that creates a new, empty NatalityRecord.</summary>
         public NatalityRecord() : base()
         {
+            InitializeCompositionAndSubject();
+
             // Start with an empty Bundle.
             Bundle = new Bundle();
             Bundle.Id = Guid.NewGuid().ToString();
@@ -27,13 +29,6 @@ namespace BFDR
             string[] bundle_profile = { ProfileURL.BundleDocumentBirthReport };
             Bundle.Timestamp = DateTime.Now;
             Bundle.Meta.Profile = bundle_profile;
-
-            // Start with an empty child. Need reference in Composition.
-            Child = new Patient();
-            Child.Id = Guid.NewGuid().ToString();
-            Child.Meta = new Meta();
-            string[] child_profile = { VR.ProfileURL.Child };
-            Child.Meta.Profile = child_profile;
 
             // Start with an empty mother. Need reference in Composition.
             Mother = new Patient();
@@ -109,14 +104,9 @@ namespace BFDR
             // Sections will be added to the composition as needed by the VitalRecord.AddReferenceToComposition method
             Composition.Id = Guid.NewGuid().ToString();
             Composition.Status = CompositionStatus.Final;
-            Composition.Meta = new Meta();
-            string[] composition_profile = { ProfileURL.CompositionJurisdictionLiveBirthReport };
-            Composition.Meta.Profile = composition_profile;
-            Composition.Type = new CodeableConcept(CodeSystems.LOINC, "71230-7", "Birth certificate", null);
-            Composition.Subject = new ResourceReference("urn:uuid:" + Child.Id);
+            Composition.Subject = new ResourceReference("urn:uuid:" + Subject.Id);
             // Author for jurisdictions is an organization (VRO)
             // Composition.Author.Add(new ResourceReference("urn:uuid:" + Author.Id));
-            Composition.Title = "Birth Certificate";
             Composition.Attester.Add(new Composition.AttesterComponent());
             //Composition.Attester.First().Party = new ResourceReference("urn:uuid:" + Certifier.Id);
             Composition.Attester.First().ModeElement = new Code<Hl7.Fhir.Model.Composition.CompositionAttestationMode>(Hl7.Fhir.Model.Composition.CompositionAttestationMode.Legal);
@@ -129,7 +119,7 @@ namespace BFDR
 
 
             // Add entries for the child, mother, and father.
-            Bundle.AddResourceEntry(Child, "urn:uuid:" + Child.Id);
+            Bundle.AddResourceEntry(Subject, "urn:uuid:" + Subject.Id);
             Bundle.AddResourceEntry(Mother, "urn:uuid:" + Mother.Id);
             Bundle.AddResourceEntry(Father, "urn:uuid:" + Father.Id);
 
@@ -143,6 +133,8 @@ namespace BFDR
 
             UpdateRecordIdentifier();
         }
+
+        protected abstract void InitializeCompositionAndSubject();
 
         /// <summary>Constructor that takes a string that represents a FHIR Natality Record in either XML or JSON format.</summary>
         /// <param name="record">represents a FHIR Natality Record in either XML or JSON format.</param>
@@ -267,7 +259,6 @@ namespace BFDR
                 throw new System.ArgumentException("The Composition is missing a subject (a reference to the Child resource).");
             }
             List<Patient> patients = Bundle.Entry.FindAll(entry => entry.Resource is Patient).ConvertAll(entry => (Patient) entry.Resource);
-            Child = patients.Find(patient => patient.Meta.Profile.Any(patientProfile => patientProfile == VR.ProfileURL.Child));
             Mother = patients.Find(patient => patient.Meta.Profile.Any(patientProfile => patientProfile == VR.ProfileURL.Mother));
             // Grab Father
             Father = Bundle.Entry.FindAll(entry => entry.Resource is RelatedPerson).ConvertAll(entry => (RelatedPerson) entry.Resource).Find(resource => resource.Meta.Profile.Any(relatedPersonProfile => relatedPersonProfile == VR.ProfileURL.RelatedPersonFatherNatural));
@@ -279,7 +270,7 @@ namespace BFDR
             Attendant = practitioners.Find(patient => patient.Extension.Any(ext => Convert.ToString(ext.Value) == "attendant"));
             Certifier = practitioners.Find(patient => patient.Extension.Any(ext => Convert.ToString(ext.Value) == "certifier"));
 
-            if (fullRecord && Child == null)
+            if (fullRecord && Subject == null)
             {
                 throw new System.ArgumentException("Failed to find a Child (Patient).");
             }

--- a/projects/BFDR/NatalityRecord_fieldsAndCreateMethods.cs
+++ b/projects/BFDR/NatalityRecord_fieldsAndCreateMethods.cs
@@ -28,8 +28,8 @@ namespace BFDR
     /// </summary>
     public partial class NatalityRecord
     {
-        /// <summary>The Child.</summary>
-        protected Patient Child;
+        /// <summary>The Natality Subject - eithr a Child or a DecedentFetus.</summary>
+        protected Patient Subject;
 
         /// <summary>The Mother.</summary>
         protected Patient Mother;
@@ -102,7 +102,7 @@ namespace BFDR
             {
                 return Mother.Id;
             }
-            return subjects.First().subject == FHIRSubject.Subject.Newborn ? Child.Id : Mother.Id;
+            return subjects.First().subject == FHIRSubject.Subject.Newborn ? Subject.Id : Mother.Id;
         }
 
         /// <summary>Create Attendant/Practitioner.</summary>

--- a/projects/BFDR/NatalityRecord_submissionProperties.cs
+++ b/projects/BFDR/NatalityRecord_submissionProperties.cs
@@ -151,19 +151,19 @@ namespace BFDR
         {
             get
             {
-                return GetDateElementNoTime(Child?.BirthDateElement, VR.ExtensionURL.PartialDateTimeYearVR);
+                return GetDateElementNoTime(Subject?.BirthDateElement, VR.ExtensionURL.PartialDateTimeYearVR);
             }
             set
             {
-                if (Child.BirthDateElement == null)
+                if (Subject.BirthDateElement == null)
                 {
-                    AddBirthDateToPatient(Child, false);
+                    AddBirthDateToPatient(Subject, false);
                 }
                 string time = this.BirthTime;
-                Date newDate = SetYear(value, Child.BirthDateElement);
+                Date newDate = SetYear(value, Subject.BirthDateElement);
                 if (newDate != null)
                 {
-                    Child.BirthDateElement = newDate;
+                    Subject.BirthDateElement = newDate;
                 }
                 this.BirthTime = time;
             }
@@ -175,20 +175,20 @@ namespace BFDR
             if (BirthTime != null && BirthTime != "temp-unknown")
             {
                 Time time = new Time(BirthTime);
-                Child.BirthDateElement = new Date(completeDate.Year, completeDate.Month, completeDate.Day);
+                Subject.BirthDateElement = new Date(completeDate.Year, completeDate.Month, completeDate.Day);
                 // Is the TimeSpan.Zero safe for time offset? Got this line from VR.ConvertFhirTimeToFhirDateTime().
                 FhirDateTime dateTime = new FhirDateTime(completeDate.Year, completeDate.Month, completeDate.Day, FhirTimeHour(time), FhirTimeMin(time), FhirTimeSec(time), TimeSpan.Zero);
-                Child.BirthDateElement.SetExtension(VR.ExtensionURL.PatientBirthTime, dateTime);
+                Subject.BirthDateElement.SetExtension(VR.ExtensionURL.PatientBirthTime, dateTime);
             }
             else
             {
                 FhirDateTime dateTime = new FhirDateTime(completeDate.Year, completeDate.Month, completeDate.Day);
-                Child.BirthDate = dateTime.ToString();
+                Subject.BirthDate = dateTime.ToString();
                 // Make sure the PatientBirthTime is not present because we have no time data.
-                Child.BirthDateElement.RemoveExtension(VR.ExtensionURL.PatientBirthTime);
+                Subject.BirthDateElement.RemoveExtension(VR.ExtensionURL.PatientBirthTime);
             }
             // Remove the now extraneous PartialDateTime.
-            Child.BirthDateElement.RemoveExtension(VRExtensionURLs.PartialDateTime);
+            Subject.BirthDateElement.RemoveExtension(VRExtensionURLs.PartialDateTime);
             return;
         }
 
@@ -224,19 +224,19 @@ namespace BFDR
         {
             get
             {
-                return GetDateElementNoTime(Child?.BirthDateElement, VR.ExtensionURL.PartialDateTimeMonthVR);
+                return GetDateElementNoTime(Subject?.BirthDateElement, VR.ExtensionURL.PartialDateTimeMonthVR);
             }
             set
             {
                 string time = this.BirthTime;
-                if (Child.BirthDateElement == null)
+                if (Subject.BirthDateElement == null)
                 {
-                    AddBirthDateToPatient(Child, false);
+                    AddBirthDateToPatient(Subject, false);
                 }
-                Date newDate = SetMonth(value, Child.BirthDateElement);
+                Date newDate = SetMonth(value, Subject.BirthDateElement);
                 if (newDate != null)
                 {
-                    Child.BirthDateElement = newDate;
+                    Subject.BirthDateElement = newDate;
                 }
                 this.BirthTime = time;
             }
@@ -256,19 +256,19 @@ namespace BFDR
         {
             get
             {
-                return GetDateElementNoTime(Child?.BirthDateElement, VR.ExtensionURL.PartialDateTimeDayVR);
+                return GetDateElementNoTime(Subject?.BirthDateElement, VR.ExtensionURL.PartialDateTimeDayVR);
             }
             set
             {
                 string time = this.BirthTime;
-                if (Child.BirthDateElement == null)
+                if (Subject.BirthDateElement == null)
                 {
-                    AddBirthDateToPatient(Child, false);
+                    AddBirthDateToPatient(Subject, false);
                 }
-                Date newDate = SetDay(value, Child.BirthDateElement);
+                Date newDate = SetDay(value, Subject.BirthDateElement);
                 if (newDate != null)
                 {
-                    Child.BirthDateElement = newDate;
+                    Subject.BirthDateElement = newDate;
                 }
                 this.BirthTime = time;
             }
@@ -289,48 +289,48 @@ namespace BFDR
         {
             get
             {
-                if (Child == null || Child.BirthDateElement == null)
+                if (Subject == null || Subject.BirthDateElement == null)
                 {
                     return null;
                 }
                 // First check for a time in the patient.birthDate PatientBirthTime extension.
-                if (Child.BirthDateElement.Extension.Any(ext => ext.Url == VR.ExtensionURL.PatientBirthTime))
+                if (Subject.BirthDateElement.Extension.Any(ext => ext.Url == VR.ExtensionURL.PatientBirthTime))
                 {
-                    FhirDateTime dateTime = (FhirDateTime)Child.BirthDateElement.Extension.Find(ext => ext.Url == VR.ExtensionURL.PatientBirthTime).Value;
+                    FhirDateTime dateTime = (FhirDateTime)Subject.BirthDateElement.Extension.Find(ext => ext.Url == VR.ExtensionURL.PatientBirthTime).Value;
                     return GetTimeFragment(dateTime);
                 }
                 // If it's not there, check for a PartialDateTime.
-                return this.GetPartialTime(this.Child.BirthDateElement.GetExtension(PartialDateTimeUrl));
+                return this.GetPartialTime(this.Subject.BirthDateElement.GetExtension(PartialDateTimeUrl));
             }
             set
             {
-                if (Child == null)
+                if (Subject == null)
                 {
                     return;
                 }
-                if (Child.BirthDateElement == null)
+                if (Subject.BirthDateElement == null)
                 {
-                    AddBirthDateToPatient(Child, true);
+                    AddBirthDateToPatient(Subject, true);
                 }
                 // If the date is complete, then the birth time should be included in the patientBirthTime extension.
                 if (value != "-1" && DateIsComplete(this.DateOfBirth))
                 {
                     FhirDateTime dateTime = new FhirDateTime(this.DateOfBirth + "T" + value);
-                    Child.BirthDateElement.SetExtension(VR.ExtensionURL.PatientBirthTime, dateTime);
+                    Subject.BirthDateElement.SetExtension(VR.ExtensionURL.PatientBirthTime, dateTime);
                     return;
                 }
                 // If the date is incomplete, then the birth time should be included in the partialDateTime Time extension.
-                Child.BirthDateElement.RemoveExtension(VR.ExtensionURL.PatientBirthTime);
-                if (!Child.BirthDateElement.Extension.Any(ext => ext.Url == VRExtensionURLs.PartialDateTime))
+                Subject.BirthDateElement.RemoveExtension(VR.ExtensionURL.PatientBirthTime);
+                if (!Subject.BirthDateElement.Extension.Any(ext => ext.Url == VRExtensionURLs.PartialDateTime))
                 {
-                    Child.BirthDateElement.SetExtension(VRExtensionURLs.PartialDateTime, new Extension());
+                    Subject.BirthDateElement.SetExtension(VRExtensionURLs.PartialDateTime, new Extension());
                 }
-                if (!Child.BirthDateElement.Extension.Find(ext => ext.Url == VRExtensionURLs.PartialDateTime).Extension.Any(ext => ext.Url == PartialDateTimeTimeUrl))
+                if (!Subject.BirthDateElement.Extension.Find(ext => ext.Url == VRExtensionURLs.PartialDateTime).Extension.Any(ext => ext.Url == PartialDateTimeTimeUrl))
                 {
-                    Child.BirthDateElement.GetExtension(VRExtensionURLs.PartialDateTime).SetExtension(PartialDateTimeTimeUrl, new Extension());
+                    Subject.BirthDateElement.GetExtension(VRExtensionURLs.PartialDateTime).SetExtension(PartialDateTimeTimeUrl, new Extension());
                 }
                 // Child.BirthDateElement.GetExtension(VRExtensionURLs.PartialDateTimeVR).SetExtension(PartialDateTimeTimeUrl, new Time(value));
-                SetPartialTime(Child.BirthDateElement.GetExtension(VRExtensionURLs.PartialDateTime), value);
+                SetPartialTime(Subject.BirthDateElement.GetExtension(VRExtensionURLs.PartialDateTime), value);
             }
         }
 
@@ -359,16 +359,16 @@ namespace BFDR
         {
             get
             {
-                if (this.Child == null || this.Child.BirthDateElement == null)
+                if (this.Subject == null || this.Subject.BirthDateElement == null)
                 {
                     return null;
                 }
-                return this.Child.BirthDate;
+                return this.Subject.BirthDate;
             }
             set
             {
                 string time = this.BirthTime;
-                this.Child.BirthDateElement = ConvertToDate(value);
+                this.Subject.BirthDateElement = ConvertToDate(value);
                 this.BirthTime = time;
             }
         }
@@ -423,9 +423,9 @@ namespace BFDR
         {
             get
             {
-                if (Child != null)
+                if (Subject != null)
                 {
-                    Extension sex = Child.GetExtension(VR.OtherExtensionURL.BirthSex);
+                    Extension sex = Subject.GetExtension(VR.OtherExtensionURL.BirthSex);
                     if (sex != null && sex.Value != null && sex.Value as CodeableConcept != null)
                     {
                         return CodeableConceptToDict((CodeableConcept)sex.Value);
@@ -435,12 +435,12 @@ namespace BFDR
             }
             set
             {
-                Child.Extension.RemoveAll(ext => ext.Url == VR.OtherExtensionURL.BirthSex);
-                if (IsDictEmptyOrDefault(value) && Child.Extension == null)
+                Subject.Extension.RemoveAll(ext => ext.Url == VR.OtherExtensionURL.BirthSex);
+                if (IsDictEmptyOrDefault(value) && Subject.Extension == null)
                 {
                     return;
                 }
-                Child.SetExtension(VR.OtherExtensionURL.BirthSex, DictToCodeableConcept(value));
+                Subject.SetExtension(VR.OtherExtensionURL.BirthSex, DictToCodeableConcept(value));
             }
         }
 
@@ -488,11 +488,11 @@ namespace BFDR
         {
             get
             {
-                return Child?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Given?.ToArray() ?? new string[0];
+                return Subject?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Given?.ToArray() ?? new string[0];
             }
             set
             {
-                updateGivenHumanName(value, Child.Name);
+                updateGivenHumanName(value, Subject.Name);
             }
         }
 
@@ -580,11 +580,11 @@ namespace BFDR
         {
             get
             {
-                return Child?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Family;
+                return Subject?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Family;
             }
             set
             {
-                HumanName name = Child.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
+                HumanName name = Subject.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
                 if (name != null && !String.IsNullOrEmpty(value))
                 {
                     name.Family = value;
@@ -596,7 +596,7 @@ namespace BFDR
                         Use = HumanName.NameUse.Official,
                         Family = value
                     };
-                    Child.Name.Add(name);
+                    Subject.Name.Add(name);
                 }
             }
         }
@@ -723,7 +723,7 @@ namespace BFDR
         {
             get
             {
-                return Child?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Suffix.FirstOrDefault();
+                return Subject?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Suffix.FirstOrDefault();
             }
             set
             {
@@ -731,7 +731,7 @@ namespace BFDR
                 {
                     return;
                 }
-                HumanName name = Child.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
+                HumanName name = Subject.Name.SingleOrDefault(n => n.Use == HumanName.NameUse.Official);
                 if (name != null)
                 {
                     string[] suffix = { value };
@@ -743,7 +743,7 @@ namespace BFDR
                     name.Use = HumanName.NameUse.Official;
                     string[] suffix = { value };
                     name.Suffix = suffix;
-                    Child.Name.Add(name);
+                    Subject.Name.Add(name);
                 }
             }
         }
@@ -955,11 +955,11 @@ namespace BFDR
         {
             get
             {
-                return GetPlaceOfBirth(Child);
+                return GetPlaceOfBirth(Subject);
             }
             set
             {
-                SetPlaceOfBirth(Child, value);
+                SetPlaceOfBirth(Subject, value);
             }
         }
 
@@ -1350,13 +1350,13 @@ namespace BFDR
         {
             get
             {
-                return Child?.Identifier?.Find(id => id.Type.Coding.Any(idCoding => idCoding.System == CodeSystems.HL7_identifier_type && idCoding.Code == "MR"))?.Value;
+                return Subject?.Identifier?.Find(id => id.Type.Coding.Any(idCoding => idCoding.System == CodeSystems.HL7_identifier_type && idCoding.Code == "MR"))?.Value;
             }
             set
             {
-                if (Child.Identifier.Any(id => id.Type.Coding.Any(idCoding => idCoding.System == CodeSystems.HL7_identifier_type && idCoding.Code == "MR")))
+                if (Subject.Identifier.Any(id => id.Type.Coding.Any(idCoding => idCoding.System == CodeSystems.HL7_identifier_type && idCoding.Code == "MR")))
                 {
-                    Child.Identifier.Find(id => id.Type.Coding.Any(idCoding => idCoding.System == CodeSystems.HL7_identifier_type && idCoding.Code == "MR")).Value = value;
+                    Subject.Identifier.Find(id => id.Type.Coding.Any(idCoding => idCoding.System == CodeSystems.HL7_identifier_type && idCoding.Code == "MR")).Value = value;
                 }
                 else
                 {
@@ -1373,7 +1373,7 @@ namespace BFDR
                         Type = medicalRecordNumber,
                         Value = value
                     };
-                    Child.Identifier.Add(identifier);
+                    Subject.Identifier.Add(identifier);
                 }
             }
         }
@@ -1506,17 +1506,17 @@ namespace BFDR
         {
             get
             {
-                if (Child != null && Child.MultipleBirth != null)
+                if (Subject != null && Subject.MultipleBirth != null)
                 {
-                    if (Child.MultipleBirth as FhirBoolean != null)
+                    if (Subject.MultipleBirth as FhirBoolean != null)
                     {
                         return null;
                     }
-                    else if (Child.MultipleBirth as Hl7.Fhir.Model.Integer != null && (Child.MultipleBirth as Hl7.Fhir.Model.Integer).Value != null)
+                    else if (Subject.MultipleBirth as Hl7.Fhir.Model.Integer != null && (Subject.MultipleBirth as Hl7.Fhir.Model.Integer).Value != null)
                     {
-                        return (Child.MultipleBirth as Hl7.Fhir.Model.Integer).Value;
+                        return (Subject.MultipleBirth as Hl7.Fhir.Model.Integer).Value;
                     }
-                    else if (Child.MultipleBirth.Extension.Find(ext => ext.Url == ExtensionURL.DataAbsentReason) != null)
+                    else if (Subject.MultipleBirth.Extension.Find(ext => ext.Url == ExtensionURL.DataAbsentReason) != null)
                     {
                         return -1;
                     }
@@ -1529,17 +1529,17 @@ namespace BFDR
                 int? plurality = Plurality;
                 if (value == null)
                 {
-                    Child.MultipleBirth = new FhirBoolean(false);
+                    Subject.MultipleBirth = new FhirBoolean(false);
                 }
                 else if (value == -1)
                 {
-                    Child.MultipleBirth = new Hl7.Fhir.Model.Integer();
+                    Subject.MultipleBirth = new Hl7.Fhir.Model.Integer();
                     Extension missingValueReason = new Extension(ExtensionURL.DataAbsentReason, new Code("unknown"));
-                    Child.MultipleBirth.Extension.Add(missingValueReason);
+                    Subject.MultipleBirth.Extension.Add(missingValueReason);
                 }
                 else
                 {
-                    Child.MultipleBirth = new Hl7.Fhir.Model.Integer(value);
+                    Subject.MultipleBirth = new Hl7.Fhir.Model.Integer(value);
                 }
                 Plurality = plurality;
                 PluralityEditFlag = pluralityEditFlag;
@@ -1567,9 +1567,9 @@ namespace BFDR
         {
             get
             {
-                if (Child != null && Child.MultipleBirth != null)
+                if (Subject != null && Subject.MultipleBirth != null)
                 {
-                    Extension pluralityEditFlag = Child.MultipleBirth.Extension.Find(ext => ext.Url == VRExtensionURLs.BypassEditFlag);
+                    Extension pluralityEditFlag = Subject.MultipleBirth.Extension.Find(ext => ext.Url == VRExtensionURLs.BypassEditFlag);
                     if (pluralityEditFlag != null && pluralityEditFlag.Value != null && pluralityEditFlag.Value as CodeableConcept != null)
                     {
                         return CodeableConceptToDict((CodeableConcept)pluralityEditFlag.Value);
@@ -1579,12 +1579,12 @@ namespace BFDR
             }
             set
             {
-                if (Child.MultipleBirth == null)
+                if (Subject.MultipleBirth == null)
                 {
-                    Child.MultipleBirth = new FhirBoolean(false);
+                    Subject.MultipleBirth = new FhirBoolean(false);
                 }
-                Child.MultipleBirth.Extension.RemoveAll(ext => ext.Url == VRExtensionURLs.BypassEditFlag);
-                Child.MultipleBirth.Extension.Add(new Extension(VRExtensionURLs.BypassEditFlag, DictToCodeableConcept(value)));
+                Subject.MultipleBirth.Extension.RemoveAll(ext => ext.Url == VRExtensionURLs.BypassEditFlag);
+                Subject.MultipleBirth.Extension.Add(new Extension(VRExtensionURLs.BypassEditFlag, DictToCodeableConcept(value)));
             }
         }
 
@@ -1635,9 +1635,9 @@ namespace BFDR
         {
             get
             {
-                if (Child != null && Child.MultipleBirth != null)
+                if (Subject != null && Subject.MultipleBirth != null)
                 {
-                    Extension plurality = Child.MultipleBirth.Extension.Find(ext => ext.Url == ExtensionURL.Plurality);
+                    Extension plurality = Subject.MultipleBirth.Extension.Find(ext => ext.Url == ExtensionURL.Plurality);
                     if (plurality != null)
                     {
                         if (plurality.Value as PositiveInt != null && (plurality.Value as PositiveInt).Value != null)
@@ -1654,11 +1654,11 @@ namespace BFDR
             }
             set
             {
-                if (Child.MultipleBirth == null)
+                if (Subject.MultipleBirth == null)
                 {
-                    Child.MultipleBirth = new FhirBoolean(false);
+                    Subject.MultipleBirth = new FhirBoolean(false);
                 }
-                Child.MultipleBirth.Extension.RemoveAll(ext => ext.Url == ExtensionURL.Plurality);
+                Subject.MultipleBirth.Extension.RemoveAll(ext => ext.Url == ExtensionURL.Plurality);
                 if (value == null)
                 {
                     return;
@@ -1668,12 +1668,12 @@ namespace BFDR
                     Extension plurality = new Extension(ExtensionURL.Plurality, new PositiveInt());
                     Extension missingValueReason = new Extension(ExtensionURL.DataAbsentReason, new Code("unknown"));
                     plurality.Extension.Add(missingValueReason);
-                    Child.MultipleBirth.Extension.Add(plurality);
+                    Subject.MultipleBirth.Extension.Add(plurality);
                 }
                 else
                 {
                     Extension plurality = new Extension(ExtensionURL.Plurality, new PositiveInt(value));
-                    Child.MultipleBirth.Extension.Add(plurality);
+                    Subject.MultipleBirth.Extension.Add(plurality);
                 }
             }
         }
@@ -2807,7 +2807,7 @@ namespace BFDR
             }
             int? age = null;
 
-            Extension parentAge = Child?.Extension.Find(ext => IsParentAgeAtBirthExt(ext, role));
+            Extension parentAge = Subject?.Extension.Find(ext => IsParentAgeAtBirthExt(ext, role));
             if (parentAge != null)
             {
                 Extension ageExt = parentAge.Extension.Find(ext => ext.Url.Equals("reportedAge"));
@@ -2858,7 +2858,7 @@ namespace BFDR
                 throw new System.ArgumentException($"Role '{role}' is not a member of the VR Role value set");
             }
 
-            Child.Extension.RemoveAll(ext => IsParentAgeAtBirthExt(ext, role));
+            Subject.Extension.RemoveAll(ext => IsParentAgeAtBirthExt(ext, role));
             Extension parentAgeAtBirth = new Extension(VRExtensionURLs.ReportedParentAgeAtDelivery, null);
             CodeableConcept parentRole = new CodeableConcept(roleCode["system"], roleCode["code"], roleCode["display"]);
             parentAgeAtBirth.Extension.Add(new Extension(VR.OtherExtensionURL.ParentRole, parentRole));
@@ -2867,7 +2867,7 @@ namespace BFDR
                 Quantity ageInYears = new Quantity((decimal)value, "a");
                 parentAgeAtBirth.Extension.Add(new Extension("reportedAge", ageInYears));
             }
-            Child.Extension.Add(parentAgeAtBirth);
+            Subject.Extension.Add(parentAgeAtBirth);
         }
 
         /// <summary>Mother's Age at Delivery</summary>
@@ -3225,7 +3225,7 @@ namespace BFDR
                 component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, NvssEthnicity.Mexican, NvssEthnicity.MexicanDisplay, null);
                 component.Value = DictToCodeableConcept(value);
                 obs.Component.Add(component);
-                obs.Subject = new ResourceReference("urn:uuid:" + Child.Id);
+                obs.Subject = new ResourceReference("urn:uuid:" + Subject.Id);
             }
         }
 
@@ -3304,7 +3304,7 @@ namespace BFDR
                 component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, NvssEthnicity.PuertoRican, NvssEthnicity.PuertoRicanDisplay, null);
                 component.Value = DictToCodeableConcept(value);
                 obs.Component.Add(component);
-                obs.Subject = new ResourceReference("urn:uuid:" + Child.Id);
+                obs.Subject = new ResourceReference("urn:uuid:" + Subject.Id);
             }
         }
 
@@ -3383,7 +3383,7 @@ namespace BFDR
                 component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, NvssEthnicity.Cuban, NvssEthnicity.CubanDisplay, null);
                 component.Value = DictToCodeableConcept(value);
                 obs.Component.Add(component);
-                obs.Subject = new ResourceReference("urn:uuid:" + Child.Id);
+                obs.Subject = new ResourceReference("urn:uuid:" + Subject.Id);
             }
         }
 
@@ -3695,7 +3695,7 @@ namespace BFDR
                 component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, NvssEthnicity.Mexican, NvssEthnicity.MexicanDisplay, null);
                 component.Value = DictToCodeableConcept(value);
                 obs.Component.Add(component);
-                obs.Subject = new ResourceReference("urn:uuid:" + Child.Id);
+                obs.Subject = new ResourceReference("urn:uuid:" + Subject.Id);
             }
         }
 
@@ -3774,7 +3774,7 @@ namespace BFDR
                 component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, NvssEthnicity.PuertoRican, NvssEthnicity.PuertoRicanDisplay, null);
                 component.Value = DictToCodeableConcept(value);
                 obs.Component.Add(component);
-                obs.Subject = new ResourceReference("urn:uuid:" + Child.Id);
+                obs.Subject = new ResourceReference("urn:uuid:" + Subject.Id);
             }
         }
 
@@ -3853,7 +3853,7 @@ namespace BFDR
                 component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, NvssEthnicity.Cuban, NvssEthnicity.CubanDisplay, null);
                 component.Value = DictToCodeableConcept(value);
                 obs.Component.Add(component);
-                obs.Subject = new ResourceReference("urn:uuid:" + Child.Id);
+                obs.Subject = new ResourceReference("urn:uuid:" + Subject.Id);
             }
         }
 
@@ -3933,7 +3933,7 @@ namespace BFDR
                 component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, NvssEthnicity.Other, NvssEthnicity.OtherDisplay, null);
                 component.Value = DictToCodeableConcept(value);
                 obs.Component.Add(component);
-                obs.Subject = new ResourceReference("urn:uuid:" + Child.Id);
+                obs.Subject = new ResourceReference("urn:uuid:" + Subject.Id);
             }
         }
 
@@ -4007,7 +4007,7 @@ namespace BFDR
                 component.Code = new CodeableConcept(CodeSystems.ComponentCodeVR, NvssEthnicity.Literal, NvssEthnicity.LiteralDisplay, null);
                 component.Value = new FhirString(value);
                 obs.Component.Add(component);
-                obs.Subject = new ResourceReference("urn:uuid:" + Child.Id);
+                obs.Subject = new ResourceReference("urn:uuid:" + Subject.Id);
             }
         }
 
@@ -4891,7 +4891,7 @@ namespace BFDR
         {
             // TODO replace codes with constants once BFDR value sets are autogenerated
             get => GetWeight("8339-4");
-            set => SetWeight("8339-4", value, "g", NEWBORN_INFORMATION_SECTION, Child.Id);
+            set => SetWeight("8339-4", value, "g", NEWBORN_INFORMATION_SECTION, Subject.Id);
         }
 
         private Dictionary<string, string> GetWeightEditFlag(string code)
@@ -5080,7 +5080,7 @@ namespace BFDR
         public Dictionary<string, string> BirthWeightEditFlag
         {
             get => GetWeightEditFlag("8339-4");
-            set => SetWeightEditFlag("8339-4", value, NEWBORN_INFORMATION_SECTION, Child.Id);
+            set => SetWeightEditFlag("8339-4", value, NEWBORN_INFORMATION_SECTION, Subject.Id);
         }
 
         /// <summary>Birth Weight at Delivery Edit Flag Helper.</summary>
@@ -5096,7 +5096,7 @@ namespace BFDR
         public string BirthWeightEditFlagHelper
         {
             get => GetWeightEditFlagHelper("8339-4");
-            set => SetWeightEditFlagHelper("8339-4", value, NEWBORN_INFORMATION_SECTION, Child.Id);
+            set => SetWeightEditFlagHelper("8339-4", value, NEWBORN_INFORMATION_SECTION, Subject.Id);
         }
 
         /// TODO: Required field in FHIR, needs BLANK placeholder
@@ -5380,7 +5380,7 @@ namespace BFDR
                 obs.Code = new CodeableConcept(VR.CodeSystems.LOINC, code);
                 obs.Value = new Hl7.Fhir.Model.Integer(value);
                 obs.Subject = new ResourceReference($"urn:uuid:{Mother.Id}");
-                obs.Focus.Add(new ResourceReference($"urn:uuid:{Child.Id}"));
+                obs.Focus.Add(new ResourceReference($"urn:uuid:{Subject.Id}"));
                 AddReferenceToComposition(obs.Id, MOTHER_PRENATAL_SECTION);
                 Bundle.AddResourceEntry(obs, "urn:uuid:" + obs.Id);
             }
@@ -5525,7 +5525,7 @@ namespace BFDR
                     obs.Subject = new ResourceReference($"urn:uuid:{Father.Id}");
                     AddReferenceToComposition(obs.Id, FATHER_INFORMATION_SECTION);
                 }
-                obs.Focus.Add(new ResourceReference($"urn:uuid:{Child.Id}"));
+                obs.Focus.Add(new ResourceReference($"urn:uuid:{Subject.Id}"));
                 Bundle.AddResourceEntry(obs, "urn:uuid:" + obs.Id);
             }
             if (!String.IsNullOrWhiteSpace(value))
@@ -6209,7 +6209,7 @@ namespace BFDR
             }
             set
             {
-                Observation obs = GetOrCreateObservation("69044-6", CodeSystems.LOINC, "Mother Prenatal", BFDR.ProfileURL.ObservationDateOfFirstPrenatalCareVisit, MOTHER_PRENATAL_SECTION, Child.Id);
+                Observation obs = GetOrCreateObservation("69044-6", CodeSystems.LOINC, "Mother Prenatal", BFDR.ProfileURL.ObservationDateOfFirstPrenatalCareVisit, MOTHER_PRENATAL_SECTION, Subject.Id);
                 obs.Value = ConvertToDateTime(value);
             }
         }
@@ -6280,7 +6280,7 @@ namespace BFDR
             }
             set
             {
-                Observation obs = GetOrCreateObservation("69044-6", CodeSystems.LOINC, "Mother Prenatal", BFDR.ProfileURL.ObservationDateOfFirstPrenatalCareVisit, MOTHER_PRENATAL_SECTION, Child.Id);
+                Observation obs = GetOrCreateObservation("69044-6", CodeSystems.LOINC, "Mother Prenatal", BFDR.ProfileURL.ObservationDateOfFirstPrenatalCareVisit, MOTHER_PRENATAL_SECTION, Subject.Id);
                 if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
                 {
                     obs.Value = new FhirDateTime();
@@ -6313,7 +6313,7 @@ namespace BFDR
             }
             set
             {
-                Observation obs = GetOrCreateObservation("69044-6", CodeSystems.LOINC, "Mother Prenatal", BFDR.ProfileURL.ObservationDateOfFirstPrenatalCareVisit, MOTHER_PRENATAL_SECTION, Child.Id);
+                Observation obs = GetOrCreateObservation("69044-6", CodeSystems.LOINC, "Mother Prenatal", BFDR.ProfileURL.ObservationDateOfFirstPrenatalCareVisit, MOTHER_PRENATAL_SECTION, Subject.Id);
                 if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
                 {
                     obs.Value = new FhirDateTime();
@@ -6346,7 +6346,7 @@ namespace BFDR
             }
             set
             {
-                Observation obs = GetOrCreateObservation("69044-6", CodeSystems.LOINC, "Mother Prenatal", BFDR.IGURL.ObservationDateOfFirstPrenatalCareVisit, MOTHER_PRENATAL_SECTION, Child.Id);
+                Observation obs = GetOrCreateObservation("69044-6", CodeSystems.LOINC, "Mother Prenatal", BFDR.IGURL.ObservationDateOfFirstPrenatalCareVisit, MOTHER_PRENATAL_SECTION, Subject.Id);
                 if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
                 {
                     obs.Value = new FhirDateTime();
@@ -6974,7 +6974,7 @@ namespace BFDR
         public int? ApgarScoreFiveMinutes
         {
             get => GetIntegerObservationValue("9274-2");
-            set => SetIntegerObservationValue("9274-2", "5 minute Apgar Score", value, NEWBORN_INFORMATION_SECTION, BFDR.ProfileURL.ObservationApgarScore, Child.Id);
+            set => SetIntegerObservationValue("9274-2", "5 minute Apgar Score", value, NEWBORN_INFORMATION_SECTION, BFDR.ProfileURL.ObservationApgarScore, Subject.Id);
         }
 
         /// <summary>APGAR score at 10 mins.</summary>
@@ -6991,7 +6991,7 @@ namespace BFDR
         public int? ApgarScoreTenMinutes
         {
             get => GetIntegerObservationValue("9271-8");
-            set => SetIntegerObservationValue("9271-8", "10 minute Apgar Score", value, NEWBORN_INFORMATION_SECTION, BFDR.ProfileURL.ObservationApgarScore, Child.Id);
+            set => SetIntegerObservationValue("9271-8", "10 minute Apgar Score", value, NEWBORN_INFORMATION_SECTION, BFDR.ProfileURL.ObservationApgarScore, Subject.Id);
         }
 
 


### PR DESCRIPTION
This PR:
- Implements fixes for Child/DecendentFetus issues. FetalDeathRecords do not have a Child profile, so "Child" has been renamed to "Subject" at the NatalityRecord level and acts as a field for both Child and DecedentFetus, depending on the record type. There are new overriden RestoreReferences() and InitializeCompositionAndSubject() methods that handle setting this Subject field accordingly. A similar function is performed for the Composition as well.
- - There could be a different approach with overriden "GetSubjectProfile()" and "GetCompositionProfile()" methods which would remove the need for overriding "RestoreRefeferences()" again and remove the need for "InitializeCompositionAndSubject()". Let me know if this could be a better approach, I just wasn't sure if that could end up spiraling into a million methods as we add more references that need populating.
- This PR also includes IJE implementation and tests for Date of Registration, which is identical with the BirthRecord version.