### PR TITLE
feat(bfdr): implement fetal death cause or condition

### DIFF
--- a/projects/BFDR.Tests/FetalDeathRecord_Should.cs
+++ b/projects/BFDR.Tests/FetalDeathRecord_Should.cs
@@ -125,5 +125,65 @@ namespace BFDR.Tests
       Assert.Equal("0", deathRecord3.NumberOfPreviousCesareansEditFlagHelper);
       Assert.Equal(cc2, deathRecord3.NumberOfPreviousCesareansEditFlag);
     }
+
+    [Fact]
+    public void ParseFetalDeathCauseOrCondition()
+    { 
+      FetalDeathRecord record = new(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/FetalDeathReport.json")));
+      Assert.True(record.PrematureRuptureOfMembranes);
+      Assert.False(record.AbruptioPlacenta);
+      Assert.False(record.PlacentalInsufficiency);
+      Assert.False(record.ProlapsedCord);
+      Assert.False(record.ChorioamnionitisCOD);
+      Assert.False(record.OtherComplicationsOfPlacentaCordOrMembranes);
+      Assert.False(record.InitiatingCauseOrConditionUnknown);
+      Assert.Null(record.MaternalConditionsDiseasesLiteral);
+
+      //set after parse
+      record.PrematureRuptureOfMembranes = false; 
+      Assert.False(record.PrematureRuptureOfMembranes);
+      record.ProlapsedCord = true; 
+      Assert.True(record.ProlapsedCord);
+      record.MaternalConditionsDiseasesLiteral = "Complication of Placenta Cord";
+      Assert.Equal("Complication of Placenta Cord", record.MaternalConditionsDiseasesLiteral);
+
+      IJEFetalDeath ije = new(record);
+      Assert.Equal("N", ije.COD18a1);
+      Assert.Equal("Y", ije.COD18a4);
+      Assert.Equal("Complication of Placenta Cord", ije.COD18a8.Trim());
+    }
+
+    [Fact]
+    public void Set_FetalDeathCauseOrCondition()
+    {
+      Assert.False(SetterFetalDeathRecord.PrematureRuptureOfMembranes);
+      SetterFetalDeathRecord.PrematureRuptureOfMembranes = true;
+      Assert.True(SetterFetalDeathRecord.PrematureRuptureOfMembranes);
+
+      SetterFetalDeathRecord.AbruptioPlacenta = false;
+      Assert.False(SetterFetalDeathRecord.AbruptioPlacenta);
+
+      Assert.False(SetterFetalDeathRecord.PlacentalInsufficiency);
+      SetterFetalDeathRecord.PlacentalInsufficiency = true;
+      Assert.True(SetterFetalDeathRecord.PlacentalInsufficiency);
+
+      SetterFetalDeathRecord.ProlapsedCord = true;
+      Assert.True(SetterFetalDeathRecord.ProlapsedCord);
+
+      SetterFetalDeathRecord.ChorioamnionitisCOD = true;
+      Assert.True(SetterFetalDeathRecord.ChorioamnionitisCOD);
+
+      Assert.False(SetterFetalDeathRecord.OtherComplicationsOfPlacentaCordOrMembranes);
+      SetterFetalDeathRecord.OtherComplicationsOfPlacentaCordOrMembranes = true;
+      Assert.True(SetterFetalDeathRecord.OtherComplicationsOfPlacentaCordOrMembranes);
+
+      Assert.False(SetterFetalDeathRecord.InitiatingCauseOrConditionUnknown);
+      SetterFetalDeathRecord.InitiatingCauseOrConditionUnknown = true;
+      Assert.True(SetterFetalDeathRecord.InitiatingCauseOrConditionUnknown);
+
+      Assert.Null(SetterFetalDeathRecord.MaternalConditionsDiseasesLiteral);
+      SetterFetalDeathRecord.MaternalConditionsDiseasesLiteral = "Complication of Placenta Cord";
+      Assert.Equal("Complication of Placenta Cord", SetterFetalDeathRecord.MaternalConditionsDiseasesLiteral);
+    }
   }
 }

--- a/projects/BFDR/BFDR.xml
+++ b/projects/BFDR/BFDR.xml
@@ -62,6 +62,30 @@
         <member name="M:BFDR.FetalDeathRecord.InitializeCompositionAndSubject">
             <inheritdoc/>
         </member>
+        <member name="P:BFDR.FetalDeathRecord.PrematureRuptureOfMembranes">
+            <summary>Initiating cause/condition, Rupture of membranes prior to onset of labor.</summary>
+        </member>
+        <member name="P:BFDR.FetalDeathRecord.AbruptioPlacenta">
+            <summary>Initiating cause/condition, Abruptio placenta.</summary>
+        </member>
+        <member name="P:BFDR.FetalDeathRecord.PlacentalInsufficiency">
+            <summary>Initiating cause/condition, Placental insufficiency.</summary>
+        </member>
+        <member name="P:BFDR.FetalDeathRecord.ProlapsedCord">
+            <summary>Initiating cause/condition, Prolapsed cord.</summary>
+        </member>
+        <member name="P:BFDR.FetalDeathRecord.ChorioamnionitisCOD">
+            <summary>Initiating cause/condition, Chorioamnionitis.</summary>
+        </member>
+        <member name="P:BFDR.FetalDeathRecord.OtherComplicationsOfPlacentaCordOrMembranes">
+            <summary>Initiating cause/condition, Other complications of placenta, cord, or membranes.</summary>
+        </member>
+        <member name="P:BFDR.FetalDeathRecord.InitiatingCauseOrConditionUnknown">
+            <summary>Initiating cause/condition, Unknown.</summary>
+        </member>
+        <member name="P:BFDR.FetalDeathRecord.MaternalConditionsDiseasesLiteral">
+            <summary>Initiating cause/condition, Maternal conditions/diseases literal.</summary>
+        </member>
         <member name="T:BFDR.IJEBirth">
             <summary>A "wrapper" class to convert between a FHIR based <c>BirthRecord</c> and
             a record in IJE Natality format. Each property of this class corresponds exactly
@@ -1194,6 +1218,16 @@
         <member name="M:BFDR.IJEFetalDeath.ToRecord">
             <summary>FHIR based vital record.</summary>
             Hides the IJE ToRecord method that returns a VitalRecord instead of a DeathRecord
+        </member>
+        <member name="M:BFDR.IJEFetalDeath.YesNo_PresenceToIJE(System.Boolean)">
+            <summary>Converts the FHIR representation of presence-only fields to the IJE equivalent.</summary>
+            <param name="fieldValue">the value of the field</param>
+            <returns>Y (yes), N (no)</returns>
+        </member>
+        <member name="M:BFDR.IJEFetalDeath.YesNo_IJEToPresence(System.String,System.Func{System.Boolean,System.Boolean})">
+            <summary>Converts the IJE representation of presence-only fields to the FHIR equivalent.</summary>
+            <param name="value">Y (yes), N (no)</param>
+            <param name="field">a function that will set a field in the FHIR record</param>
         </member>
         <member name="P:BFDR.IJEFetalDeath.FDOD_YR">
             <summary>Date of Delivery (Fetus)--Year</summary>
@@ -4866,6 +4900,9 @@
         </member>
         <member name="F:BFDR.FHIRSubject.Subject.Newborn">
             <summary>The newborn</summary>
+        </member>
+        <member name="F:BFDR.FHIRSubject.Subject.DecedentFetus">
+            <summary>The decedent fetus</summary>
         </member>
         <member name="F:BFDR.FHIRSubject.subject">
             <summary>The subject of the field</summary>

--- a/projects/BFDR/FetalDeathRecord.cs
+++ b/projects/BFDR/FetalDeathRecord.cs
@@ -13,6 +13,8 @@ namespace BFDR
     /// </summary>
     public partial class FetalDeathRecord : NatalityRecord
     {
+        private const string FETUS_SECTION = "76400-1";
+
         /// <summary>Default constructor that creates a new, empty FetalDeathRecord.</summary>
         public FetalDeathRecord() : base() {}
 
@@ -63,6 +65,117 @@ namespace BFDR
             };
             Composition.Type = new CodeableConcept(CodeSystems.LOINC, "71230-7", "Fetal Death Report", null);
             Composition.Title = "Fetal Death Report";
+        }
+
+        //
+        // Fetal Death Cause or Condition Section
+        //
+
+        /// <summary>Initiating cause/condition, Rupture of membranes prior to onset of labor.</summary>
+        [Property("Rupture of Membranes Prior to Onset of Labor", Property.Types.Bool, "Initiating Cause/Condition",
+                  "Initiating Cause/Condition, Rupture of Membranes Prior to Onset of Labor", true, IGURL.ConditionFetalDeathCauseOrCondition, true, 100)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "76060-3", code: "44223004", section: FETUS_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.DecedentFetus)]
+        public bool PrematureRuptureOfMembranes
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Initiating cause/condition, Abruptio placenta.</summary>
+        [Property("Abruptio Placenta", Property.Types.Bool, "Initiating Cause/Condition",
+                  "Initiating Cause/Condition, Abruptio Placenta", true, IGURL.ConditionFetalDeathCauseOrCondition, true, 100)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "76060-3", code: "415105001", section: FETUS_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.DecedentFetus)]
+        public bool AbruptioPlacenta
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Initiating cause/condition, Placental insufficiency.</summary>
+        [Property("Placental Insufficiency", Property.Types.Bool, "Initiating Cause/Condition",
+                  "Initiating Cause/Condition, Placental Insufficiency", true, IGURL.ConditionFetalDeathCauseOrCondition, true, 100)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "76060-3", code: "237292005", section: FETUS_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.DecedentFetus)]
+        public bool PlacentalInsufficiency
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Initiating cause/condition, Prolapsed cord.</summary>
+        [Property("Prolapsed Cord", Property.Types.Bool, "Initiating Cause/Condition",
+                  "Initiating Cause/Condition, Prolapsed Cord", true, IGURL.ConditionFetalDeathCauseOrCondition, true, 100)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "76060-3", code: "270500004", section: FETUS_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.DecedentFetus)]
+        public bool ProlapsedCord
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Initiating cause/condition, Chorioamnionitis.</summary>
+        [Property("Chorioamnionitis", Property.Types.Bool, "Initiating Cause/Condition",
+                  "Initiating Cause/Condition, Chorioamnionitis", true, IGURL.ConditionFetalDeathCauseOrCondition, true, 100)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "76060-3", code: "11612004", section: FETUS_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.DecedentFetus)]
+        public bool ChorioamnionitisCOD
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Initiating cause/condition, Other complications of placenta, cord, or membranes.</summary>
+        [Property("Other Complications of Placenta, Cord, or Membranes", Property.Types.Bool, "Initiating Cause/Condition",
+                  "Initiating Cause/Condition, Other Complications of Placenta, Cord, or Membranes", true, IGURL.ConditionFetalDeathCauseOrCondition, true, 100)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "76060-3", code: "membranes", section: FETUS_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.DecedentFetus)]
+        public bool OtherComplicationsOfPlacentaCordOrMembranes
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Initiating cause/condition, Unknown.</summary>
+        [Property("Unknown Initiating Cause or Condition", Property.Types.Bool, "Initiating Cause/Condition",
+                  "Initiating Cause/Condition, Unknown", true, IGURL.ConditionFetalDeathCauseOrCondition, true, 100)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "76060-3", code: "UNK", section: FETUS_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.DecedentFetus)]
+        public bool InitiatingCauseOrConditionUnknown
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Initiating cause/condition, Maternal conditions/diseases literal.</summary>
+        [Property("Maternal Conditions Diseases Literal", Property.Types.String, "Initiating Cause/Condition",
+                  "Initiating Cause/Condition, Maternal Conditions Diseases Literal", true, IGURL.ConditionFetalDeathCauseOrCondition, true, 100)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "76060-3", code: "maternalconditions", section: FETUS_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.DecedentFetus)]
+        public string MaternalConditionsDiseasesLiteral
+        {
+            get
+            {
+                Condition cond = GetCondition("maternalconditions");
+                if (cond != null && cond.Code != null && cond.Code.Text != null)
+                {
+                    return cond.Code.Text.ToString();
+                }
+                return null;
+            }
+            set
+            {
+                if (String.IsNullOrWhiteSpace(value))
+                {
+                    return;
+                }
+                Condition cond = GetCondition("maternalconditions");
+                if (cond == null){
+                    cond = (Condition)CreateEntry(GetFHIRPathAttribute(), SubjectId());
+                }
+                cond.Code.Text = value;
+            }
         }
     }
 }

--- a/projects/BFDR/IJEFetalDeath.cs
+++ b/projects/BFDR/IJEFetalDeath.cs
@@ -73,6 +73,40 @@ namespace BFDR
 
         /////////////////////////////////////////////////////////////////////////////////
         //
+        // Class helper methods for getting and settings IJE fields.
+        //
+        /////////////////////////////////////////////////////////////////////////////////
+        /// <summary>Converts the FHIR representation of presence-only fields to the IJE equivalent.</summary>
+        /// <param name="fieldValue">the value of the field</param>
+        /// <returns>Y (yes), N (no)</returns>
+        private string YesNo_PresenceToIJE(bool fieldValue)
+        {
+            if (fieldValue)
+            {
+                return "Y";
+            }
+            else 
+            {
+                return "N";
+            }
+        }
+        /// <summary>Converts the IJE representation of presence-only fields to the FHIR equivalent.</summary>
+        /// <param name="value">Y (yes), N (no)</param>
+        /// <param name="field">a function that will set a field in the FHIR record</param>
+        private void YesNo_IJEToPresence(string value, Func<bool, bool> field)
+        {
+            if (value.Equals("Y"))
+            {
+                field(true);
+            }
+            else 
+            {
+                field(false);
+            }
+        }
+
+        /////////////////////////////////////////////////////////////////////////////////
+        //
         // Class Properties that provide getters and setters for each of the IJE
         // FetalDeath fields.
         //
@@ -2673,120 +2707,64 @@ namespace BFDR
         [IJEField(180, 587, 1, "Initiating cause/condition - Rupture of membranes prior to onset of labor", "COD18a1", 1)]
         public string COD18a1
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location: 
-            }
+            get => YesNo_PresenceToIJE(record.PrematureRuptureOfMembranes);
+            set => YesNo_IJEToPresence(value, (v) => record.PrematureRuptureOfMembranes = v);
         }
 
         /// <summary>Initiating cause/condition - Abruptio placenta</summary>
         [IJEField(181, 588, 1, "Initiating cause/condition - Abruptio placenta", "COD18a2", 1)]
         public string COD18a2
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location: 
-            }
+            get => YesNo_PresenceToIJE(record.AbruptioPlacenta);
+            set => YesNo_IJEToPresence(value, (v) => record.AbruptioPlacenta = v);
         }
 
         /// <summary>Initiating cause/condition - Placental insufficiency</summary>
         [IJEField(182, 589, 1, "Initiating cause/condition - Placental insufficiency", "COD18a3", 1)]
         public string COD18a3
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location: 
-            }
+            get => YesNo_PresenceToIJE(record.PlacentalInsufficiency);
+            set => YesNo_IJEToPresence(value, (v) => record.PlacentalInsufficiency = v);
         }
 
         /// <summary>Initiating cause/condition - Prolapsed cord</summary>
         [IJEField(183, 590, 1, "Initiating cause/condition - Prolapsed cord", "COD18a4", 1)]
         public string COD18a4
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location: 
-            }
+            get => YesNo_PresenceToIJE(record.ProlapsedCord);
+            set => YesNo_IJEToPresence(value, (v) => record.ProlapsedCord = v);
         }
 
         /// <summary>Initiating cause/condition - Chorioamnionitis</summary>
         [IJEField(184, 591, 1, "Initiating cause/condition - Chorioamnionitis", "COD18a5", 1)]
         public string COD18a5
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location: 
-            }
+            get => YesNo_PresenceToIJE(record.ChorioamnionitisCOD);
+            set => YesNo_IJEToPresence(value, (v) => record.ChorioamnionitisCOD = v);
         }
 
         /// <summary>Initiating cause/condition - Other complications of placenta, cord, or membranes</summary>
         [IJEField(185, 592, 1, "Initiating cause/condition - Other complications of placenta, cord, or membranes", "COD18a6", 1)]
         public string COD18a6
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location: 
-            }
+            get => YesNo_PresenceToIJE(record.OtherComplicationsOfPlacentaCordOrMembranes);
+            set => YesNo_IJEToPresence(value, (v) => record.OtherComplicationsOfPlacentaCordOrMembranes = v);
         }
 
         /// <summary>Initiating cause/condition - Unknown</summary>
         [IJEField(186, 593, 1, "Initiating cause/condition - Unknown", "COD18a7", 1)]
         public string COD18a7
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location: 
-            }
+            get => YesNo_PresenceToIJE(record.InitiatingCauseOrConditionUnknown);
+            set => YesNo_IJEToPresence(value, (v) => record.InitiatingCauseOrConditionUnknown = v);
         }
 
         /// <summary>Initiating cause/condition - Maternal conditions/diseases literal</summary>
         [IJEField(187, 594, 60, "Initiating cause/condition - Maternal conditions/diseases literal", "COD18a8", 1)]
         public string COD18a8
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location: 
-            }
+            get => LeftJustified_Get("COD18a8", "MaternalConditionsDiseasesLiteral");
+            set => LeftJustified_Set("COD18a8", "MaternalConditionsDiseasesLiteral", value);
         }
 
         /// <summary>Initiating cause/condition - Other complications of placenta, cord, or membranes literal</summary>

--- a/projects/BFDR/NatalityRecord_fieldsAndCreateMethods.cs
+++ b/projects/BFDR/NatalityRecord_fieldsAndCreateMethods.cs
@@ -175,7 +175,9 @@ namespace BFDR
             /// <summary>The mother</summary>
             Mother,
             /// <summary>The newborn</summary>
-            Newborn
+            Newborn,
+            /// <summary>The decedent fetus</summary>
+            DecedentFetus
         }
         /// <summary>The subject of the field</summary>
         public Subject subject;

--- a/projects/VitalRecord/VitalRecord.xml
+++ b/projects/VitalRecord/VitalRecord.xml
@@ -6005,6 +6005,10 @@
             <summary>Helper to support vital record property getter helper methods for values stored in Observations.</summary>
             <param name="code">the code to identify the type of Observation</param>
         </member>
+        <member name="M:VR.VitalRecord.GetCondition(System.String)">
+            <summary>Helper to support vital record property getter helper methods for values stored in Conditions.</summary>
+            <param name="code">the code to identify the type of Condition</param>
+        </member>
         <member name="M:VR.VitalRecord.GetOrCreateObservation(System.String,System.String,System.String,System.String,System.String,System.String,System.String)">
             <summary>Helper to support vital record property setter helper methods for values stored in Observations.</summary>
             <param name="code">the code to specify the type of Observation</param>

--- a/projects/VitalRecord/VitalRecord_util.cs
+++ b/projects/VitalRecord/VitalRecord_util.cs
@@ -94,7 +94,6 @@ namespace VR
             }
         }
 
-
         /// <summary>Helper to support vital record property getter helper methods for values stored in Observations.</summary>
         /// <param name="code">the code to identify the type of Observation</param>
         protected Observation GetObservation(string code)
@@ -104,6 +103,19 @@ namespace VR
             {
                 Observation observation = (Observation)entry.Resource;
                 return observation;
+            }
+            return null;
+        }
+
+        /// <summary>Helper to support vital record property getter helper methods for values stored in Conditions.</summary>
+        /// <param name="code">the code to identify the type of Condition</param>
+        protected Condition GetCondition(string code)
+        {
+            var entry = Bundle.Entry.Where(e => e.Resource is Condition obs && CodeableConceptToDict(obs.Code)["code"] == code).FirstOrDefault();
+            if (entry != null)
+            {
+                Condition cond = (Condition)entry.Resource;
+                return cond;
             }
             return null;
         }


### PR DESCRIPTION
COD18a1 through COD18a7 are Y/N depending on presence of code
COD18a8 is a literal text/blank

I added two class helper methods, YesNo_PresenceToIJE and YesNo_IJEToPresence, which are similar to PresenceToIJE and IJEToPresence but do not require a corresponding none-of-the-above field (these don't exist for cause of death) and are limited to only Y/N (no Unknown) per the IJE_File_Layouts. 

I also added a helper to VitalRecord_util called GetCondition which is a modification of GetObservation but for condition resources instead.