### PR TITLE
fix(canary): fix project csproj project references

### DIFF
--- a/projects/Canary/ClientApp/src/components/Navigation.js
+++ b/projects/Canary/ClientApp/src/components/Navigation.js
@@ -92,7 +92,7 @@ export function Navigation(props) {
               VRDR {window.VRDR_VERSION};
             </small>
             <small>
-              BFDR pre-2.0
+              BFDR {window.BFDR_VERSION};
             </small>
           </span>
         </Menu.Item>

--- a/projects/Canary/ClientApp/src/index.js
+++ b/projects/Canary/ClientApp/src/index.js
@@ -14,6 +14,7 @@ window.VERSION = '4.0.10';
 window.VERSION_DATE = 'August 15, 2023';
 window.VRDR_VERSION = '4.1.8';
 window.VRDR_VERSION_DATE = 'August 15, 2023'; 
+window.BFDR_VERSION = 'v1.0.0-preview';
 
 const container = document.getElementById('root');
 const root = createRoot(container);


### PR DESCRIPTION
- Fix canary failing build due to incorrect project references
- Updated the BFDR version displayed in Canary