### PR TITLE
fix(vr): added support for blank 8s in ije

### DIFF
--- a/projects/BFDR.CLI/BFDR.CLI.csproj
+++ b/projects/BFDR.CLI/BFDR.CLI.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\BFDR\BFDR.csproj" />
-    <ProjectReference Include="..\BFDR.Messaging\BFDRMessaging.csproj" />
+    <ProjectReference Include="..\BFDR.Messaging\BFDR.Messaging.csproj" />
     <ProjectReference Include="..\VitalRecord\VitalRecord.csproj" />
   </ItemGroup>
 </Project>

--- a/projects/BFDR.Tests/BFDR.Tests.csproj
+++ b/projects/BFDR.Tests/BFDR.Tests.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BFDR\BFDR.csproj" />
-    <ProjectReference Include="..\BFDR.Messaging\BFDRMessaging.csproj" />
+    <ProjectReference Include="..\BFDR.Messaging\BFDR.Messaging.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Update="fixtures/json/BasicBirthRecord.json" CopyToOutputDirectory="PreserveNewest" />

--- a/projects/BFDR.Tests/NatalityData_Should.cs
+++ b/projects/BFDR.Tests/NatalityData_Should.cs
@@ -831,9 +831,9 @@ namespace BFDR.Tests
     {
       BirthRecord fhir = new BirthRecord();
       IJEBirth ije = new IJEBirth(fhir);
-      Assert.Equal("    ", ije.DOFP_YR);
-      Assert.Equal("  ", ije.DOFP_MO);
-      Assert.Equal("  ", ije.DOFP_DY);
+      Assert.Equal("8888", ije.DOFP_YR);
+      Assert.Equal("88", ije.DOFP_MO);
+      Assert.Equal("88", ije.DOFP_DY);
       ije.DOFP_DY = "24";
       Assert.Equal("    ", ije.DOFP_YR);
       Assert.Equal("  ", ije.DOFP_MO);
@@ -913,7 +913,7 @@ namespace BFDR.Tests
       BirthRecord fhir = new BirthRecord();
       IJEBirth ije = new IJEBirth(fhir);
       Assert.Equal("  ", ije.APGAR5);
-      Assert.Equal("  ", ije.APGAR10);
+      Assert.Equal("88", ije.APGAR10);
       ije.APGAR5 = "99";
       ije.APGAR10 = "15";
       Assert.Equal("99", ije.APGAR5);

--- a/projects/BFDR.Tests/NatalityData_Should.cs
+++ b/projects/BFDR.Tests/NatalityData_Should.cs
@@ -962,5 +962,15 @@ namespace BFDR.Tests
       Assert.Equal("7134703", ije3.INF_MED_REC_NUM);
       Assert.Equal("2286144", ije3.MOM_MED_REC_NUM);
     }
+
+    [Fact]
+    public void BlankEights() {
+      IJEBirth ije = new()
+      {
+          YOPO = "8888"
+      };
+      Assert.Equal("    ", ije.YOPO);
+      Assert.Null(ije.ToRecord().DateOfLastOtherPregnancyOutcomeYear);
+    }
   }
 }

--- a/projects/BFDR.Tests/NatalityData_Should.cs
+++ b/projects/BFDR.Tests/NatalityData_Should.cs
@@ -967,10 +967,36 @@ namespace BFDR.Tests
     public void BlankEights() {
       IJEBirth ije = new()
       {
-          YOPO = "8888"
+          YOPO = "2020",
+          MOPO = "04",
+          DOFP_DY = "05",
+          DOFP_MO = "07",
+          DOFP_YR = "2021",
+          APGAR10 = "09"
       };
+
+      Assert.Equal("2020", ije.YOPO);
+      Assert.Equal("04", ije.MOPO);
+      Assert.Equal("09", ije.APGAR10);
+      Assert.Equal("05", ije.DOFP_DY);
+      Assert.Equal("07", ije.DOFP_MO);
+      Assert.Equal("2021", ije.DOFP_YR);
+
+      ije.YOPO = "8888";
+      ije.DOFP_DY = "88";
+      ije.APGAR10 = "88";
       Assert.Equal("    ", ije.YOPO);
       Assert.Null(ije.ToRecord().DateOfLastOtherPregnancyOutcomeYear);
+      Assert.Equal("  ", ije.MOPO);
+      Assert.Null(ije.ToRecord().DateOfLastOtherPregnancyOutcomeMonth);
+      Assert.Equal("  ", ije.APGAR10);
+      Assert.Null(ije.ToRecord().ApgarScoreTenMinutes);
+      Assert.Equal("  ", ije.DOFP_DY);
+      Assert.Null(ije.ToRecord().FirstPrenatalCareVisitDay);
+      Assert.Equal("  ", ije.DOFP_MO);
+      Assert.Null(ije.ToRecord().FirstPrenatalCareVisitMonth);
+      Assert.Equal("    ", ije.DOFP_YR);
+      Assert.Null(ije.ToRecord().FirstPrenatalCareVisitYear);
     }
   }
 }

--- a/projects/BFDR.Tests/NatalityData_Should.cs
+++ b/projects/BFDR.Tests/NatalityData_Should.cs
@@ -972,7 +972,9 @@ namespace BFDR.Tests
           DOFP_DY = "05",
           DOFP_MO = "07",
           DOFP_YR = "2021",
-          APGAR10 = "09"
+          APGAR10 = "09",
+          MLLB = "08",
+          YLLB = "2017"
       };
 
       Assert.Equal("2020", ije.YOPO);
@@ -981,22 +983,29 @@ namespace BFDR.Tests
       Assert.Equal("05", ije.DOFP_DY);
       Assert.Equal("07", ije.DOFP_MO);
       Assert.Equal("2021", ije.DOFP_YR);
+      Assert.Equal("08", ije.MLLB);
+      Assert.Equal("2017", ije.YLLB);
 
       ije.YOPO = "8888";
       ije.DOFP_DY = "88";
       ije.APGAR10 = "88";
-      Assert.Equal("    ", ije.YOPO);
+      ije.MLLB = "88";
+      Assert.Equal("8888", ije.YOPO);
       Assert.Null(ije.ToRecord().DateOfLastOtherPregnancyOutcomeYear);
-      Assert.Equal("  ", ije.MOPO);
+      Assert.Equal("88", ije.MOPO);
       Assert.Null(ije.ToRecord().DateOfLastOtherPregnancyOutcomeMonth);
-      Assert.Equal("  ", ije.APGAR10);
+      Assert.Equal("88", ije.APGAR10);
       Assert.Null(ije.ToRecord().ApgarScoreTenMinutes);
-      Assert.Equal("  ", ije.DOFP_DY);
+      Assert.Equal("88", ije.DOFP_DY);
       Assert.Null(ije.ToRecord().FirstPrenatalCareVisitDay);
-      Assert.Equal("  ", ije.DOFP_MO);
+      Assert.Equal("88", ije.DOFP_MO);
       Assert.Null(ije.ToRecord().FirstPrenatalCareVisitMonth);
-      Assert.Equal("    ", ije.DOFP_YR);
+      Assert.Equal("8888", ije.DOFP_YR);
       Assert.Null(ije.ToRecord().FirstPrenatalCareVisitYear);
+      Assert.Equal("88", ije.MLLB);
+      Assert.Null(ije.ToRecord().DateOfLastLiveBirthMonth);
+      Assert.Equal("8888", ije.YLLB);
+      Assert.Null(ije.ToRecord().DateOfLastLiveBirthYear);
     }
   }
 }

--- a/projects/BFDR/IJEBirth.cs
+++ b/projects/BFDR/IJEBirth.cs
@@ -2261,11 +2261,11 @@ namespace BFDR
         {
             get
             {
-                return NumericAllowingUnknown_Get("DOFP_MO", "FirstPrenatalCareVisitMonth");
+                return NumericAllowingUnknownAndAbsence_Get("DOFP_MO", "FirstPrenatalCareVisitMonth", "69044-6");
             }
             set
             {
-                NumericAllowingUnknown_Set("DOFP_MO", "FirstPrenatalCareVisitMonth", value);
+                NumericAllowingUnknownAndAbsence_Set("DOFP_MO", "FirstPrenatalCareVisitMonth", value, "69044-6");
             }
         }
 
@@ -2275,11 +2275,11 @@ namespace BFDR
         {
             get
             {
-                return NumericAllowingUnknown_Get("DOFP_DY", "FirstPrenatalCareVisitDay");
+                return NumericAllowingUnknownAndAbsence_Get("DOFP_DY", "FirstPrenatalCareVisitDay", "69044-6");
             }
             set
             {
-                NumericAllowingUnknown_Set("DOFP_DY", "FirstPrenatalCareVisitDay", value);
+                NumericAllowingUnknownAndAbsence_Set("DOFP_DY", "FirstPrenatalCareVisitDay", value, "69044-6");
             }
         }
 
@@ -2289,11 +2289,11 @@ namespace BFDR
         {
             get
             {
-                return NumericAllowingUnknown_Get("DOFP_YR", "FirstPrenatalCareVisitYear");
+                return NumericAllowingUnknownAndAbsence_Get("DOFP_YR", "FirstPrenatalCareVisitYear", "69044-6");
             }
             set
             {
-                NumericAllowingUnknown_Set("DOFP_YR", "FirstPrenatalCareVisitYear", value);
+                NumericAllowingUnknownAndAbsence_Set("DOFP_YR", "FirstPrenatalCareVisitYear", value, "69044-6");
             }
         }
 
@@ -2561,11 +2561,11 @@ namespace BFDR
         {
             get
             {
-                return NumericAllowingUnknown_Get("MLLB", "DateOfLastLiveBirthMonth");
+                return NumericAllowingUnknownAndAbsence_Get("MLLB", "DateOfLastLiveBirthMonth", "68499-3");
             }
             set
             {
-                NumericAllowingUnknown_Set("MLLB", "DateOfLastLiveBirthMonth", value);
+                NumericAllowingUnknownAndAbsence_Set("MLLB", "DateOfLastLiveBirthMonth", value, "68499-3");
             }
         }
 
@@ -2575,11 +2575,11 @@ namespace BFDR
         {
             get
             {
-                return NumericAllowingUnknown_Get("YLLB", "DateOfLastLiveBirthYear");
+                return NumericAllowingUnknownAndAbsence_Get("YLLB", "DateOfLastLiveBirthYear", "68499-3");
             }
             set
             {
-                NumericAllowingUnknown_Set("YLLB", "DateOfLastLiveBirthYear", value);
+                NumericAllowingUnknownAndAbsence_Set("YLLB", "DateOfLastLiveBirthYear", value, "68499-3");
             }
         }
 
@@ -2589,11 +2589,11 @@ namespace BFDR
         {
             get
             {
-                return NumericAllowingUnknown_Get("MOPO", "DateOfLastOtherPregnancyOutcomeMonth");
+                return NumericAllowingUnknownAndAbsence_Get("MOPO", "DateOfLastOtherPregnancyOutcomeMonth", "68500-8");
             }
             set
             {
-                NumericAllowingUnknown_Set("MOPO", "DateOfLastOtherPregnancyOutcomeMonth", value);
+                NumericAllowingUnknownAndAbsence_Set("MOPO", "DateOfLastOtherPregnancyOutcomeMonth", value, "68500-8");
             }
         }
 
@@ -2603,11 +2603,11 @@ namespace BFDR
         {
             get
             {
-                return NumericAllowingUnknown_Get("YOPO", "DateOfLastOtherPregnancyOutcomeYear");
+                return NumericAllowingUnknownAndAbsence_Get("YOPO", "DateOfLastOtherPregnancyOutcomeYear", "68500-8");
             }
             set
             {
-                NumericAllowingUnknown_Set("YOPO", "DateOfLastOtherPregnancyOutcomeYear", value);
+                NumericAllowingUnknownAndAbsence_Set("YOPO", "DateOfLastOtherPregnancyOutcomeYear", value, "68500-8");
             }
         }
 
@@ -3276,8 +3276,8 @@ namespace BFDR
         [IJEField(206, 875, 2, "Apgar Score at 10 Minutes", "APGAR10", 1)]
         public string APGAR10
         {
-            get => NumericAllowingUnknown_Get("APGAR10", "ApgarScoreTenMinutes");
-            set => NumericAllowingUnknown_Set("APGAR10", "ApgarScoreTenMinutes", value);
+            get => NumericAllowingUnknownAndAbsence_Get("APGAR10", "ApgarScoreTenMinutes", "9271-8");
+            set => NumericAllowingUnknownAndAbsence_Set("APGAR10", "ApgarScoreTenMinutes", value, "9271-8");
         }
 
         /// <summary>Plurality</summary>

--- a/projects/BFDR/NatalityRecord_submissionProperties.cs
+++ b/projects/BFDR/NatalityRecord_submissionProperties.cs
@@ -4333,6 +4333,12 @@ namespace BFDR
             }
             set
             {
+                // According to the IJE spreadsheet, if one element in the Date of First Prenatal Care Visit date is set to 88, then this means there was explicitly "no care" provided. This means the other Date of First Prenatal Care Visit date elements should also be considered as "no care" since they combine to make one field. In this case, there should be no date data at all since it explicitly never happened, it should not exist in FHIR and should return null. However, the IG doesn't yet have a complete explicit protocol for this case.
+                if (value == 88)
+                {
+                    RemoveObservation("68500-8");
+                    return;
+                }
                 Observation obs = GetOrCreateObservation("68500-8", CodeSystems.LOINC, "Last Other Pregnancy Outcome", BFDR.ProfileURL.ObservationDateOfLastOtherPregnancyOutcome, DATE_OF_LAST_OTHER_PREGNANCY_OUTCOME, Mother.Id);
                 if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
                 {
@@ -4372,6 +4378,12 @@ namespace BFDR
             }
             set
             {
+                // According to the IJE spreadsheet, if one element in the Date of First Prenatal Care Visit date is set to 88, then this means there was explicitly "no care" provided. This means the other Date of First Prenatal Care Visit date elements should also be considered as "no care" since they combine to make one field. In this case, there should be no date data at all since it explicitly never happened, it should not exist in FHIR and should return null. However, the IG doesn't yet have a complete explicit protocol for this case.
+                if (value == 8888)
+                {
+                    RemoveObservation("68500-8");
+                    return;
+                }
                 Observation obs = GetOrCreateObservation("68500-8", CodeSystems.LOINC, BFDR.ProfileURL.ObservationDateOfLastOtherPregnancyOutcome, DATE_OF_LAST_OTHER_PREGNANCY_OUTCOME, Mother.Id);
                 if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
                 {
@@ -6280,6 +6292,12 @@ namespace BFDR
             }
             set
             {
+                // According to the IJE spreadsheet, if one element in the Date of First Prenatal Care Visit date is set to 88, then this means there was explicitly "no care" provided. This means the other Date of First Prenatal Care Visit date elements should also be considered as "no care" since they combine to make one field. In this case, there should be no date data at all since it explicitly never happened, it should not exist in FHIR and should return null. However, the IG doesn't yet have a complete explicit protocol for this case.
+                if (value == 8888)
+                {
+                    RemoveObservation("69044-6");
+                    return;
+                }
                 Observation obs = GetOrCreateObservation("69044-6", CodeSystems.LOINC, "Mother Prenatal", BFDR.ProfileURL.ObservationDateOfFirstPrenatalCareVisit, MOTHER_PRENATAL_SECTION, Child.Id);
                 if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
                 {
@@ -6313,6 +6331,12 @@ namespace BFDR
             }
             set
             {
+                // According to the IJE spreadsheet, if one element in the Date of First Prenatal Care Visit date is set to 88, then this means there was explicitly "no care" provided. This means the other Date of First Prenatal Care Visit date elements should also be considered as "no care" since they combine to make one field. In this case, there should be no date data at all since it explicitly never happened, it should not exist in FHIR and should return null. However, the IG doesn't yet have a complete explicit protocol for this case.
+                if (value == 88)
+                {
+                    RemoveObservation("69044-6");
+                    return;
+                }
                 Observation obs = GetOrCreateObservation("69044-6", CodeSystems.LOINC, "Mother Prenatal", BFDR.ProfileURL.ObservationDateOfFirstPrenatalCareVisit, MOTHER_PRENATAL_SECTION, Child.Id);
                 if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
                 {
@@ -6346,6 +6370,12 @@ namespace BFDR
             }
             set
             {
+                // According to the IJE spreadsheet, if one element in the Date of First Prenatal Care Visit date is set to 88, then this means there was explicitly "no care" provided. This means the other Date of First Prenatal Care Visit date elements should also be considered as "no care" since they combine to make one field. In this case, there should be no date data at all since it explicitly never happened, it should not exist in FHIR and should return null. However, the IG doesn't yet have a complete explicit protocol for this case.
+                if (value == 88)
+                {
+                    RemoveObservation("69044-6");
+                    return;
+                }
                 Observation obs = GetOrCreateObservation("69044-6", CodeSystems.LOINC, "Mother Prenatal", BFDR.IGURL.ObservationDateOfFirstPrenatalCareVisit, MOTHER_PRENATAL_SECTION, Child.Id);
                 if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
                 {
@@ -6991,7 +7021,16 @@ namespace BFDR
         public int? ApgarScoreTenMinutes
         {
             get => GetIntegerObservationValue("9271-8");
-            set => SetIntegerObservationValue("9271-8", "10 minute Apgar Score", value, NEWBORN_INFORMATION_SECTION, BFDR.ProfileURL.ObservationApgarScore, Child.Id);
+            set
+            {
+                if (value == 88)
+                {
+                    // For APGAR10, an IJE value of 88 corresponds to an explicit absence of an Apgar Score 10 Minutes in FHIR.
+                    RemoveObservation("9271-8");
+                    return;
+                }
+                SetIntegerObservationValue("9271-8", "10 minute Apgar Score", value, NEWBORN_INFORMATION_SECTION, BFDR.ProfileURL.ObservationApgarScore, Child.Id);
+            }
         }
 
 

--- a/projects/BFDR/NatalityRecord_submissionProperties.cs
+++ b/projects/BFDR/NatalityRecord_submissionProperties.cs
@@ -4333,7 +4333,7 @@ namespace BFDR
             }
             set
             {
-                // According to the IJE spreadsheet, if one element in the Date of First Prenatal Care Visit date is set to 88, then this means there was explicitly "no care" provided. This means the other Date of First Prenatal Care Visit date elements should also be considered as "no care" since they combine to make one field. In this case, there should be no date data at all since it explicitly never happened, it should not exist in FHIR and should return null. However, the IG doesn't yet have a complete explicit protocol for this case.
+                // According to the IJE spreadsheet, if one element in the DateOfLastOtherPregnancyOutcomeYear date is set to 88, then this means there was explicitly "no care" provided. This means the other DateOfLastOtherPregnancyOutcomeYear date elements should also be considered as "no care" since they combine to make one field. In this case, there should be no date data at all since it explicitly never happened, it should not exist in FHIR and should return null. However, the IG doesn't yet have a complete explicit protocol for this case.
                 if (value == 88)
                 {
                     RemoveObservation("68500-8");
@@ -4378,7 +4378,7 @@ namespace BFDR
             }
             set
             {
-                // According to the IJE spreadsheet, if one element in the Date of First Prenatal Care Visit date is set to 88, then this means there was explicitly "no care" provided. This means the other Date of First Prenatal Care Visit date elements should also be considered as "no care" since they combine to make one field. In this case, there should be no date data at all since it explicitly never happened, it should not exist in FHIR and should return null. However, the IG doesn't yet have a complete explicit protocol for this case.
+                // According to the IJE spreadsheet, if one element in the DateOfLastOtherPregnancyOutcomeYear date is set to 8888, then this means there was explicitly "no care" provided. This means the other DateOfLastOtherPregnancyOutcome date elements should also be considered as explicitly absent since they combine to make one field. In this case, there should be no date data at all since it explicitly never happened, it should not exist in FHIR and should return null. However, the IG doesn't yet have a complete explicit protocol for this case.
                 if (value == 8888)
                 {
                     RemoveObservation("68500-8");
@@ -7025,7 +7025,7 @@ namespace BFDR
             {
                 if (value == 88)
                 {
-                    // For APGAR10, an IJE value of 88 corresponds to an explicit absence of an Apgar Score 10 Minutes in FHIR.
+                    // For APGAR10, an IJE value of "88" corresponds to an explicit absence of an Apgar Score 10 Minutes in FHIR since this measurement explicitly never occurred.
                     RemoveObservation("9271-8");
                     return;
                 }

--- a/projects/BFDR/NatalityRecord_submissionProperties.cs
+++ b/projects/BFDR/NatalityRecord_submissionProperties.cs
@@ -2464,7 +2464,7 @@ namespace BFDR
                 {
                     return;
                 }
-                Observation obs = GetOrCreateObservation("68497-7", CodeSystems.LOINC, BFDR.ProfileURL.ObservationNumberPrenatalVisits, MEDICAL_INFORMATION_SECTION, Mother.Id);
+                Observation obs = GetOrCreateObservation("68497-7", CodeSystems.LOINC, BFDR.ProfileURL.ObservationNumberPreviousCesareans, MEDICAL_INFORMATION_SECTION, Mother.Id);
                 obs.Value = new Hl7.Fhir.Model.Integer(value);
             }
         }
@@ -6991,10 +6991,7 @@ namespace BFDR
         public int? ApgarScoreTenMinutes
         {
             get => GetIntegerObservationValue("9271-8");
-            set
-            {
-                SetIntegerObservationValue("9271-8", "10 minute Apgar Score", value, NEWBORN_INFORMATION_SECTION, BFDR.ProfileURL.ObservationApgarScore, Child.Id);
-            }
+            set => SetIntegerObservationValue("9271-8", "10 minute Apgar Score", value, NEWBORN_INFORMATION_SECTION, BFDR.ProfileURL.ObservationApgarScore, Child.Id);
         }
 
 

--- a/projects/BFDR/NatalityRecord_submissionProperties.cs
+++ b/projects/BFDR/NatalityRecord_submissionProperties.cs
@@ -6639,7 +6639,7 @@ namespace BFDR
         public string PaternityAcknowledgementSignedHelper
         {
             get => GetObservationValueHelper();
-            set => SetObservationValueHelper(value, VR.ValueSets.YesNoNotApplicable.Codes);
+            set => SetObservationValueHelper(value, VR.ValueSets.YesNoUnknownNotApplicable.Codes);
         }
 
         /// <summary>Mother Transferred</summary>

--- a/projects/BFDR/NatalityRecord_submissionProperties.cs
+++ b/projects/BFDR/NatalityRecord_submissionProperties.cs
@@ -4333,12 +4333,6 @@ namespace BFDR
             }
             set
             {
-                // According to the IJE spreadsheet, if one element in the DateOfLastOtherPregnancyOutcomeYear date is set to 88, then this means there was explicitly "no care" provided. This means the other DateOfLastOtherPregnancyOutcomeYear date elements should also be considered as "no care" since they combine to make one field. In this case, there should be no date data at all since it explicitly never happened, it should not exist in FHIR and should return null. However, the IG doesn't yet have a complete explicit protocol for this case.
-                if (value == 88)
-                {
-                    RemoveObservation("68500-8");
-                    return;
-                }
                 Observation obs = GetOrCreateObservation("68500-8", CodeSystems.LOINC, "Last Other Pregnancy Outcome", BFDR.ProfileURL.ObservationDateOfLastOtherPregnancyOutcome, DATE_OF_LAST_OTHER_PREGNANCY_OUTCOME, Mother.Id);
                 if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
                 {
@@ -4378,12 +4372,6 @@ namespace BFDR
             }
             set
             {
-                // According to the IJE spreadsheet, if one element in the DateOfLastOtherPregnancyOutcomeYear date is set to 8888, then this means there was explicitly "no care" provided. This means the other DateOfLastOtherPregnancyOutcome date elements should also be considered as explicitly absent since they combine to make one field. In this case, there should be no date data at all since it explicitly never happened, it should not exist in FHIR and should return null. However, the IG doesn't yet have a complete explicit protocol for this case.
-                if (value == 8888)
-                {
-                    RemoveObservation("68500-8");
-                    return;
-                }
                 Observation obs = GetOrCreateObservation("68500-8", CodeSystems.LOINC, BFDR.ProfileURL.ObservationDateOfLastOtherPregnancyOutcome, DATE_OF_LAST_OTHER_PREGNANCY_OUTCOME, Mother.Id);
                 if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
                 {
@@ -6292,12 +6280,6 @@ namespace BFDR
             }
             set
             {
-                // According to the IJE spreadsheet, if one element in the Date of First Prenatal Care Visit date is set to 88, then this means there was explicitly "no care" provided. This means the other Date of First Prenatal Care Visit date elements should also be considered as "no care" since they combine to make one field. In this case, there should be no date data at all since it explicitly never happened, it should not exist in FHIR and should return null. However, the IG doesn't yet have a complete explicit protocol for this case.
-                if (value == 8888)
-                {
-                    RemoveObservation("69044-6");
-                    return;
-                }
                 Observation obs = GetOrCreateObservation("69044-6", CodeSystems.LOINC, "Mother Prenatal", BFDR.ProfileURL.ObservationDateOfFirstPrenatalCareVisit, MOTHER_PRENATAL_SECTION, Child.Id);
                 if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
                 {
@@ -6331,12 +6313,6 @@ namespace BFDR
             }
             set
             {
-                // According to the IJE spreadsheet, if one element in the Date of First Prenatal Care Visit date is set to 88, then this means there was explicitly "no care" provided. This means the other Date of First Prenatal Care Visit date elements should also be considered as "no care" since they combine to make one field. In this case, there should be no date data at all since it explicitly never happened, it should not exist in FHIR and should return null. However, the IG doesn't yet have a complete explicit protocol for this case.
-                if (value == 88)
-                {
-                    RemoveObservation("69044-6");
-                    return;
-                }
                 Observation obs = GetOrCreateObservation("69044-6", CodeSystems.LOINC, "Mother Prenatal", BFDR.ProfileURL.ObservationDateOfFirstPrenatalCareVisit, MOTHER_PRENATAL_SECTION, Child.Id);
                 if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
                 {
@@ -6370,12 +6346,6 @@ namespace BFDR
             }
             set
             {
-                // According to the IJE spreadsheet, if one element in the Date of First Prenatal Care Visit date is set to 88, then this means there was explicitly "no care" provided. This means the other Date of First Prenatal Care Visit date elements should also be considered as "no care" since they combine to make one field. In this case, there should be no date data at all since it explicitly never happened, it should not exist in FHIR and should return null. However, the IG doesn't yet have a complete explicit protocol for this case.
-                if (value == 88)
-                {
-                    RemoveObservation("69044-6");
-                    return;
-                }
                 Observation obs = GetOrCreateObservation("69044-6", CodeSystems.LOINC, "Mother Prenatal", BFDR.IGURL.ObservationDateOfFirstPrenatalCareVisit, MOTHER_PRENATAL_SECTION, Child.Id);
                 if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
                 {
@@ -7023,12 +6993,6 @@ namespace BFDR
             get => GetIntegerObservationValue("9271-8");
             set
             {
-                if (value == 88)
-                {
-                    // For APGAR10, an IJE value of "88" corresponds to an explicit absence of an Apgar Score 10 Minutes in FHIR since this measurement explicitly never occurred.
-                    RemoveObservation("9271-8");
-                    return;
-                }
                 SetIntegerObservationValue("9271-8", "10 minute Apgar Score", value, NEWBORN_INFORMATION_SECTION, BFDR.ProfileURL.ObservationApgarScore, Child.Id);
             }
         }

--- a/projects/VitalRecord/IJE.cs
+++ b/projects/VitalRecord/IJE.cs
@@ -115,6 +115,16 @@ namespace VR
             return Truncate(valueString, info.Length).PadLeft(info.Length, '0');
         }
 
+        protected string NumericAllowingUnknownAndAbsence_Get(string ijeFieldName, string fhirFieldName, string obsCodeToRemove)
+        {
+            IJEField info = FieldInfo(ijeFieldName);
+            if(!Record.GetBundle().Entry.Any(e => e.Resource is Observation obs && obs.Code.Coding.Any(coding => coding.Code == obsCodeToRemove)))
+            {
+                return new String('8', info.Length); // Set to explicitly absent.
+            }
+            return NumericAllowingUnknown_Get(ijeFieldName, fhirFieldName);
+        }
+
         /// <summary>Set a value on the VitalRecord that is a numeric string with the option of being set to all 9s on the IJE side and -1 on the
         /// FHIR side to represent'unknown' and blank on the IJE side and null on the FHIR side to represent unspecified</summary>
         protected void NumericAllowingUnknown_Set(string ijeFieldName, string fhirFieldName, string value)
@@ -132,6 +142,17 @@ namespace VR
             {
                 Record.GetType().GetProperty(fhirFieldName).SetValue(Record, Convert.ToInt32(value));
             }
+        }
+
+        protected void NumericAllowingUnknownAndAbsence_Set(string ijeFieldName, string fhirFieldName, string value, string obsCodeToRemove)
+        {
+            IJEField info = FieldInfo(ijeFieldName);
+            if (value == new string('8', info.Length))
+            {
+                Record.GetBundle().Entry.RemoveAll(e => e.Resource is Observation obs && obs.Code.Coding.Any(coding => coding.Code == obsCodeToRemove));
+                return;
+            }
+            NumericAllowingUnknown_Set(ijeFieldName, fhirFieldName, value);
         }
 
         /// <summary>Get a value on the VitalRecord whose IJE type is a left justified string.</summary>
@@ -200,7 +221,7 @@ namespace VR
                 {
                     Record.GetType().GetProperty(fhirFieldName).SetValue(Record, false);
                 }
-                // U, 8, or blank results in no data in FHIR
+                // U or blank results in no data in FHIR
             }
         }
 

--- a/projects/VitalRecord/IJE.cs
+++ b/projects/VitalRecord/IJE.cs
@@ -120,7 +120,7 @@ namespace VR
         protected void NumericAllowingUnknown_Set(string ijeFieldName, string fhirFieldName, string value)
         {
             IJEField info = FieldInfo(ijeFieldName);
-            if (value == new string(' ', info.Length))
+            if (value == new string(' ', info.Length) || value == new string('8', info.Length))
             {
                 Record.GetType().GetProperty(fhirFieldName).SetValue(Record, null);
             }
@@ -200,7 +200,7 @@ namespace VR
                 {
                     Record.GetType().GetProperty(fhirFieldName).SetValue(Record, false);
                 }
-                // U or blank results in no data in FHIR
+                // U, 8, or blank results in no data in FHIR
             }
         }
 
@@ -226,7 +226,7 @@ namespace VR
         protected void TimeAllowingUnknown_Set(string ijeFieldName, string fhirFieldName, string value)
         {
             IJEField info = FieldInfo(ijeFieldName);
-            if (value == new string(' ', info.Length))
+            if (value == new string(' ', info.Length) || value == new string('8', info.Length))
             {
                 this.Record.GetType().GetProperty(fhirFieldName).SetValue(this.Record, null);
             }

--- a/projects/VitalRecord/IJE.cs
+++ b/projects/VitalRecord/IJE.cs
@@ -120,7 +120,7 @@ namespace VR
         protected void NumericAllowingUnknown_Set(string ijeFieldName, string fhirFieldName, string value)
         {
             IJEField info = FieldInfo(ijeFieldName);
-            if (value == new string(' ', info.Length) || value == new string('8', info.Length))
+            if (value == new string(' ', info.Length))
             {
                 Record.GetType().GetProperty(fhirFieldName).SetValue(Record, null);
             }
@@ -226,7 +226,7 @@ namespace VR
         protected void TimeAllowingUnknown_Set(string ijeFieldName, string fhirFieldName, string value)
         {
             IJEField info = FieldInfo(ijeFieldName);
-            if (value == new string(' ', info.Length) || value == new string('8', info.Length))
+            if (value == new string(' ', info.Length))
             {
                 this.Record.GetType().GetProperty(fhirFieldName).SetValue(this.Record, null);
             }

--- a/projects/VitalRecord/VitalRecord.xml
+++ b/projects/VitalRecord/VitalRecord.xml
@@ -5444,6 +5444,10 @@
             <summary>Helper to support vital record property getter helper methods for values stored in Observations.</summary>
             <param name="code">the code to identify the type of Observation</param>
         </member>
+        <member name="M:VR.VitalRecord.RemoveObservation(System.String)">
+            <summary>Helper to support vital record property getter helper methods for removing Observations.</summary>
+            <param name="code">the code to identify the type of Observation</param>
+        </member>
         <member name="M:VR.VitalRecord.GetOrCreateObservation(System.String,System.String,System.String,System.String,System.String,System.String,System.String)">
             <summary>Helper to support vital record property setter helper methods for values stored in Observations.</summary>
             <param name="code">the code to specify the type of Observation</param>

--- a/projects/VitalRecord/VitalRecord_util.cs
+++ b/projects/VitalRecord/VitalRecord_util.cs
@@ -108,6 +108,13 @@ namespace VR
             return null;
         }
 
+        /// <summary>Helper to support vital record property getter helper methods for removing Observations.</summary>
+        /// <param name="code">the code to identify the type of Observation</param>
+        protected void RemoveObservation(string code)
+        {
+            Bundle.Entry.RemoveAll(e => e.Resource is Observation obs && CodeableConceptToDict(obs.Code)["code"] == code);
+        }
+
         /// <summary>Helper to support vital record property setter helper methods for values stored in Observations.</summary>
         /// <param name="code">the code to specify the type of Observation</param>
         /// <param name="codeSystem">the code system of the code specifying the type of Observation</param>


### PR DESCRIPTION
This PR adds support for blank "8"s in IJE. In IJE, for the relevant fields: (DOFP_XX, XOPO, APGAR10)

- An all "8"s input, according to the IJE spreadsheet, explicitly means that the event in question never happened. It doesn't mean "blank".
- For these fields, the IG doesn't have an explicit protocol for how to handle all "8"s, but the general consensus seems to be that it should mean an explicit absence of the field in FHIR. Thus, if a field is set to "8"s, it (and any associated data elements) is simply removed from the FHIR record. It never happened; thus it should not be present in FHIR.
- There may need to be updates to this if the IG makes an explicit protocol for these "8" fields. There may even need to be logic to ensure that all values of a date are set to "8" before removing it from FHIR.
- Now, there's the issue of differentiating between an explicitly absent or blank FHIR field upon empty record creation.

Also removes validation of PartialDateTimes since, in the new VR IG, a partial date time no longer needs to have every extension element present (i.e. partialDateMonth has a [0..1] instead of [1..1] cardinality)
Also makes a quick fix to PaternityAcknowledgementSignedHelper.