### PR TITLE
feat(vr): update version number for vr release

### DIFF
--- a/projects/VitalRecord.Messaging/VitalRecord.Messaging.csproj
+++ b/projects/VitalRecord.Messaging/VitalRecord.Messaging.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>VitalRecord.Messaging</PackageId>
-    <Version>1.0.0-preview.2</Version>
+    <Version>1.0.1-preview</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>VR</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/projects/VitalRecord.Messaging/VitalRecord.Messaging.csproj
+++ b/projects/VitalRecord.Messaging/VitalRecord.Messaging.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageId>VitalRecord.Messaging</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.0.0-preview.2</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>VR</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/projects/VitalRecord/CHANGELOG.md
+++ b/projects/VitalRecord/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
 <a name="1.0.1-preview"></a>
-## [1.0.0-preview.2](https://github.com/nightingaleproject/vital-records-dotnet/commit/76944eb9ba1fcb010e96bcab6313ede7ad78e8f3) (2024-05-12)
+## [1.0.1-preview](https://github.com/nightingaleproject/vital-records-dotnet/commit/76944eb9ba1fcb010e96bcab6313ede7ad78e8f3) (2024-05-12)
 
 ### Feautures
 * add support for natality bfdr-library and canary integration ([c54b85a](https://github.com/nightingaleproject/vital-records-dotnet/commit/c54b85a4a29c51e363adc092d4d8b2ed5d764ec4))

--- a/projects/VitalRecord/CHANGELOG.md
+++ b/projects/VitalRecord/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
-<a name="1.0.0-preview.2"></a>
+<a name="1.0.1-preview"></a>
 ## [1.0.0-preview.2](https://github.com/nightingaleproject/vital-records-dotnet/commit/76944eb9ba1fcb010e96bcab6313ede7ad78e8f3) (2024-05-12)
 
 ### Feautures

--- a/projects/VitalRecord/CHANGELOG.md
+++ b/projects/VitalRecord/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
+
+<a name="1.0.0-preview.2"></a>
+## [1.0.0-preview.2](https://github.com/nightingaleproject/vital-records-dotnet/commit/76944eb9ba1fcb010e96bcab6313ede7ad78e8f3) (2024-05-12)
+
+### Feautures
+* add support for natality bfdr-library and canary integration ([c54b85a](https://github.com/nightingaleproject/vital-records-dotnet/commit/c54b85a4a29c51e363adc092d4d8b2ed5d764ec4))

--- a/projects/VitalRecord/VitalRecord.csproj
+++ b/projects/VitalRecord/VitalRecord.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-preview.2</Version>
+    <Version>1.0.1-preview</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>VR</RootNamespace>
     <DocumentationFile>VitalRecord.xml</DocumentationFile>

--- a/projects/VitalRecord/VitalRecord.csproj
+++ b/projects/VitalRecord/VitalRecord.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.0.0-preview.2</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>VR</RootNamespace>
     <DocumentationFile>VitalRecord.xml</DocumentationFile>


### PR DESCRIPTION
Update the vr version number for a new nuget package release. This new version will be used by the NVSS FHIR API in the upcoming June 2024 test event.