### PR TITLE
Nvss 632 father birthplace

### DIFF
--- a/projects/BFDR.Tests/FetalDeathRecord_Should.cs
+++ b/projects/BFDR.Tests/FetalDeathRecord_Should.cs
@@ -1499,5 +1499,37 @@ namespace BFDR.Tests
       Assert.Equal(" ",ije.MAGE_BYPASS);
       Assert.Equal("1", ije.FAGE_BYPASS);
     }
+
+    [Fact]
+    public void TestImportFatherBirthplace()
+    {
+      // Test FHIR record import.
+      FetalDeathRecord firstRecord = new(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/FetalDeathReport.json")));
+      string firstDescription = firstRecord.ToDescription();
+      // Test conversion via FromDescription.
+      FetalDeathRecord secondRecord = VitalRecord.FromDescription<FetalDeathRecord>(firstDescription);
+      // Test IJE Conversion.
+      IJEFetalDeath ije = new(secondRecord);
+
+      Assert.Equal(firstRecord.FatherPlaceOfBirth, secondRecord.FatherPlaceOfBirth);
+      // Country
+      Assert.Equal("US", firstRecord.FatherPlaceOfBirth["addressCountry"]);
+      Assert.Equal(firstRecord.FatherPlaceOfBirth["addressCountry"], ije.FBPLACE_CNT_C);
+      // State
+      Assert.Equal("MA", firstRecord.FatherPlaceOfBirth["addressState"]);
+      Assert.Equal(firstRecord.FatherPlaceOfBirth["addressState"], ije.FBPLACD_ST_TER_C);
+      // set after parse
+      firstRecord.FatherPlaceOfBirth = new Dictionary<string, string>
+      {
+        ["addressState"] = "NY",
+        ["addressCounty"] = "Queens",
+        ["addressCity"] = "New York",
+        ["addressCountry"] = "US"
+      };
+      Assert.Equal("NY", firstRecord.FatherPlaceOfBirth["addressState"]);
+      Assert.Equal("Queens", firstRecord.FatherPlaceOfBirth["addressCounty"]);
+      Assert.Equal("New York", firstRecord.FatherPlaceOfBirth["addressCity"]);
+      Assert.Equal("US", firstRecord.FatherPlaceOfBirth["addressCountry"]);
+    }
   }
 }

--- a/projects/BFDR.Tests/fixtures/json/FetalDeathReport.json
+++ b/projects/BFDR.Tests/fixtures/json/FetalDeathReport.json
@@ -2,23 +2,23 @@
   "resourceType": "Bundle",
   "id": "bundle-jurisdiction-fetal-death-not-named",
   "meta": {
-    "profile": [
-      "http://hl7.org/fhir/us/bfdr/StructureDefinition/Bundle-document-fetal-death-report"
-    ]
+      "profile": [
+          "http://hl7.org/fhir/us/bfdr/StructureDefinition/Bundle-document-fetal-death-report"
+      ]
   },
   "identifier": {
-    "extension": [
-      {
-        "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/CertificateNumber",
-        "valueString": "9876"
-      },
-      {
-        "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/AuxiliaryStateIdentifier1",
-        "valueString": "11111-11111"
-      }
-    ],
-    "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-ije-vr",
-    "value": "2019NJ009876"
+      "extension": [
+          {
+              "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/CertificateNumber",
+              "valueString": "9876"
+          },
+          {
+              "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/AuxiliaryStateIdentifier1",
+              "valueString": "11111-11111"
+          }
+      ],
+      "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-ije-vr",
+      "value": "2019NJ009876"
   },
   "type": "document",
   "timestamp": "2019-10-15T08:51:14.637+00:00",
@@ -2739,7 +2739,10 @@
           {
             "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-relatedperson-birthplace-vr",
             "valueAddress": {
-              "state": "NY"
+              "city": "Bedford",
+              "district": "Middlesex",
+              "state": "MA",
+              "country": "US"
             }
           }
         ],

--- a/projects/BFDR/IJEFetalDeath.cs
+++ b/projects/BFDR/IJEFetalDeath.cs
@@ -4093,12 +4093,14 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
+                return Dictionary_Geo_Get("FBPLACD_ST_TER_C", "FatherPlaceOfBirth", "address", "state", true);
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    Dictionary_Set("FBPLACD_ST_TER_C", "FatherPlaceOfBirth", "addressState", value);
+                }
             }
         }
 
@@ -4108,12 +4110,14 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
+                return Dictionary_Geo_Get("FBPLACE_CNT_C", "FatherPlaceOfBirth", "address", "country", true);
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    Dictionary_Set("FBPLACE_CNT_C", "FatherPlaceOfBirth", "addressCountry", value);
+                }
             }
         }
 
@@ -4153,12 +4157,11 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
+                return IJEData.Instance.StateCodeToStateName(FBPLACD_ST_TER_C);
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                FBPLACD_ST_TER_C = IJEData.Instance.StateNameToStateCode(value);
             }
         }
 
@@ -4168,12 +4171,11 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
+                return IJEData.Instance.CountryCodeToCountryName(FBPLACE_CNT_C);
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                FBPLACE_CNT_C = IJEData.Instance.CountryNameToCountryCode(value);
             }
         }
 


### PR DESCRIPTION
## Summary

Father birthplace fields - does not include father dob bypass edit flag, which is included in the [DOB PR](https://github.com/nightingaleproject/vital-records-dotnet/pull/123).