### PR TITLE
627 sex plurality set order

### DIFF
--- a/projects/BFDR.Tests/FetalDeathRecord_Should.cs
+++ b/projects/BFDR.Tests/FetalDeathRecord_Should.cs
@@ -1381,16 +1381,16 @@ namespace BFDR.Tests
       // Time of Delivery
       Assert.Equal("18:23:00", firstRecord.DeliveryTime);
       Assert.Equal(firstRecord.DeliveryTime, secondRecord.DeliveryTime);
-      // // Sex
-      // Assert.Equal("F", firstRecord.BirthSex["code"]);
-      // Assert.Equal(firstRecord.BirthSex, secondRecord.BirthSex);
-      // Assert.Equal("F", firstRecord.BirthSexHelper);
-      // Assert.Equal(firstRecord.BirthSex["code"], secondRecord.BirthSexHelper);
-      // // Plurality
-      // Assert.Equal(1, firstRecord.Plurality); //TODO: check IG examples are correct
-      // // Set Order
-      // Assert.Equal(1, firstRecord.SetOrder);
-      // Assert.Equal(firstRecord.SetOrder, secondRecord.SetOrder);
+      // Sex
+      Assert.Equal("F", firstRecord.FetalDeathSex["code"]);
+      Assert.Equal(firstRecord.FetalDeathSex, secondRecord.FetalDeathSex);
+      Assert.Equal("F", firstRecord.FetalDeathSexHelper);
+      Assert.Equal(firstRecord.FetalDeathSex["code"], secondRecord.FetalDeathSexHelper);
+      // Plurality
+      Assert.Equal(4, firstRecord.FetalDeathPlurality); 
+      // Set Order
+      Assert.Equal(3, firstRecord.FetalDeathSetOrder);
+      Assert.Equal(firstRecord.FetalDeathSetOrder, secondRecord.FetalDeathSetOrder);
       // // Mother's Age
       //  Assert.Equal(34, firstRecord.MotherReportedAgeAtDelivery); 
       // // Father's Age
@@ -1812,6 +1812,44 @@ namespace BFDR.Tests
       Assert.Equal("Main", ije.STNAME.Trim());
       Assert.Equal("St", ije.STDESIG.Trim());
       Assert.Equal("5 E Main St Berlin, NH", ije.ADDRESS.Trim());
+    }
+
+    [Fact]
+    public void Set_Plurality()
+    {
+      Assert.Null(SetterFetalDeathRecord.FetalDeathSetOrder);
+      Assert.Null(SetterFetalDeathRecord.FetalDeathPlurality);
+      Assert.Equal("", SetterFetalDeathRecord.FetalDeathPluralityEditFlag["code"]);
+      SetterFetalDeathRecord.FetalDeathSetOrder = null;
+      Assert.Null(SetterFetalDeathRecord.FetalDeathSetOrder);
+      SetterFetalDeathRecord.FetalDeathSetOrder = 3;
+      Assert.Equal(3, SetterFetalDeathRecord.FetalDeathSetOrder);
+      Assert.Null(SetterFetalDeathRecord.FetalDeathPlurality);
+      Assert.Equal("", SetterFetalDeathRecord.FetalDeathPluralityEditFlag["code"]);
+      SetterFetalDeathRecord.FetalDeathPlurality = 4;
+      Assert.Equal(3, SetterFetalDeathRecord.FetalDeathSetOrder);
+      Assert.Equal(4, SetterFetalDeathRecord.FetalDeathPlurality);
+      Assert.Equal("", SetterFetalDeathRecord.FetalDeathPluralityEditFlag["code"]);
+      SetterFetalDeathRecord.FetalDeathSetOrder = -1;
+      Assert.Equal(-1, SetterFetalDeathRecord.FetalDeathSetOrder);
+      Assert.Equal(4, SetterFetalDeathRecord.FetalDeathPlurality);
+      Assert.Equal("", SetterFetalDeathRecord.FetalDeathPluralityEditFlag["code"]);
+      SetterFetalDeathRecord.FetalDeathSetOrder = null;
+      Assert.Null(SetterFetalDeathRecord.FetalDeathSetOrder);
+      Assert.Equal(4, SetterFetalDeathRecord.FetalDeathPlurality);
+      Assert.Equal("", SetterFetalDeathRecord.FetalDeathPluralityEditFlag["code"]);
+      var coding = new Dictionary<string, string>();
+      coding.Add("code", "queriedCorrect");
+      coding.Add("system", "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-vr-edit-flags");
+      SetterFetalDeathRecord.FetalDeathPluralityEditFlag = coding;
+      Assert.Null(SetterFetalDeathRecord.FetalDeathSetOrder);
+      Assert.Equal(4, SetterFetalDeathRecord.FetalDeathPlurality);
+      Assert.Equal("queriedCorrect", SetterFetalDeathRecord.FetalDeathPluralityEditFlag["code"]);
+      SetterFetalDeathRecord.FetalDeathPlurality = 2;
+      SetterFetalDeathRecord.FetalDeathSetOrder = 1;
+      Assert.Equal(1, SetterFetalDeathRecord.FetalDeathSetOrder);
+      Assert.Equal(2, SetterFetalDeathRecord.FetalDeathPlurality);
+      Assert.Equal("queriedCorrect", SetterFetalDeathRecord.FetalDeathPluralityEditFlag["code"]);
     }
   }
 }

--- a/projects/BFDR.Tests/fixtures/json/FetalDeathReport.json
+++ b/projects/BFDR.Tests/fixtures/json/FetalDeathReport.json
@@ -235,12 +235,20 @@
         },
         "text": {
           "status": "extensions",
-          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Patient_patient-decedent-fetus-not-named\"> </a><p><b>Generated Narrative: Patient</b><a name=\"patient-decedent-fetus-not-named\"> </a><a name=\"hcpatient-decedent-fetus-not-named\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Patient &quot;patient-decedent-fetus-not-named&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Patient-decedent-fetus.html\">Patient - Decedent Fetus</a></p></div><p><b>US Core Birth Sex Extension</b>: F</p><p><b>Birth Place</b>: Ann Arbor MI 48103 </p><blockquote><p><b>Reported Parent Age At Delivery Vital Records</b></p><blockquote><p><b>url</b></p><code>reportedAge</code></blockquote><p><b>value</b>: 34 a<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM code a = 'a')</span></p><blockquote><p><b>url</b></p><code>motherOrFather</code></blockquote><p><b>value</b>: mother <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-v3-RoleCode.html\">RoleCode</a>#MTH)</span></p></blockquote><blockquote><p><b>Reported Parent Age At Delivery Vital Records</b></p><blockquote><p><b>url</b></p><code>reportedAge</code></blockquote><p><b>value</b>: 35 a<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM code a = 'a')</span></p><blockquote><p><b>url</b></p><code>motherOrFather</code></blockquote><p><b>value</b>: father <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-v3-RoleCode.html\">RoleCode</a>#FTH)</span></p></blockquote><p><b>identifier</b>: Medical Record Number/9932702 (use: USUAL)</p><p><b>name</b>: null (OFFICIAL)</p><p><b>gender</b>: female</p><p><b>birthDate</b>: 2019-01-09</p><p><b>multipleBirth</b>: 3</p></div>"
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Patient_patient-decedent-fetus-not-named\"> </a><p><b>Generated Narrative: Patient</b><a name=\"patient-decedent-fetus-not-named\"> </a><a name=\"hcpatient-decedent-fetus-not-named\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Patient &quot;patient-decedent-fetus-not-named&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Patient-decedent-fetus.html\">Patient - Decedent Fetus</a></p></div><p><b>US Core Birth Sex Extension</b>: F</p><p><b>Birth Place</b>: Ann Arbor MI 48103 </p><blockquote><p><b>Reported Parent Age At Delivery Vital Records</b></p><blockquote><p><b>url</b></p><code>reportedAge</code></blockquote><p><b>value</b>: 34 a<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM code a = 'a')</span></p><blockquote><p><b>url</b></p><code>motherOrFather</code></blockquote><p><b>value</b>: mother <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-v3-RoleCode.html\">RoleCode</a>#MTH)</span></p></blockquote><blockquote><p><b>Reported Parent Age At Delivery Vital Records</b></p><blockquote><p><b>url</b></p><code>reportedAge</code></blockquote><p><b>value</b>: 35 a<span style=\"background: LightGoldenRodYellow\"> (Details: UCUM code a = 'a')</span></p><blockquote><p><b>url</b></p><code>motherOrFather</code></blockquote><p><b>value</b>: father <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-v3-RoleCode.html\">RoleCode</a>#FTH)</span></p></blockquote><p><b>identifier</b>: Medical Record Number/9932702 (use: USUAL)</p><p><b>name</b>: null (OFFICIAL)</p><p><b>gender</b>: female</p><p><b>birthDate</b>: 2019-01-09</p><p><b>multipleBirth</b>: 3</p></div>"
         },
         "extension": [
           {
             "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
-            "valueCode": "F"
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/administrative-gender",
+                  "code": "F",
+                  "display": "Female"
+                }
+              ]
+            }
           },
           {
             "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
@@ -340,7 +348,15 @@
             }
           ]
         },
-        "multipleBirthInteger": 3
+        "multipleBirthInteger": 3,
+        "_multipleBirthInteger": {
+          "extension" : [
+          {
+            "url" : "http://hl7.org/fhir/StructureDefinition/patient-multipleBirthTotal",
+            "valuePositiveInt": 4
+          }
+          ]
+        }
       }
     },
     {
@@ -468,7 +484,7 @@
         },
         "text": {
           "status": "extensions",
-          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Patient_patient-mother-carmen-teresa-lee\"> </a><p><b>Generated Narrative: Patient</b><a name=\"patient-mother-carmen-teresa-lee\"> </a><a name=\"hcpatient-mother-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Patient &quot;patient-mother-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"https://build.fhir.org/ig/HL7/vr-common-library//StructureDefinition-Patient-mother-vr.html\">Patient - Mother Vital Records</a></p></div><blockquote><p><b>US Core Race Extension</b></p><blockquote><p><b>url</b></p><code>ombCategory</code></blockquote><p><b>value</b>: Black or African American (Details: urn:oid:2.16.840.1.113883.6.238 code 2054-5 = 'Black or African American', stated as 'Black or African American')</p><blockquote><p><b>url</b></p><code>text</code></blockquote><p><b>value</b>: Black or African America</p></blockquote><blockquote><p><b>US Core Ethnicity Extension</b></p><blockquote><p><b>url</b></p><code>ombCategory</code></blockquote><p><b>value</b>: Hispanic or Latino (Details: urn:oid:2.16.840.1.113883.6.238 code 2135-2 = 'Hispanic or Latino', stated as 'Hispanic or Latino')</p><blockquote><p><b>url</b></p><code>text</code></blockquote><p><b>value</b>: Hispanic or Latino</p></blockquote><p><b>US Core Birth Sex Extension</b>: F</p><p><b>Birth Place</b>: PR </p><p><b>identifier</b>: Medical Record Number/9992702 (use: USUAL)</p><p><b>name</b>: Carmen Teresa Lee (OFFICIAL), Carmen Teresa Santos (MAIDEN)</p><p><b>gender</b>: female</p><p><b>birthDate</b>: 1986-02-15</p><p><b>address</b>: 3670 Miller Road Ann Arbor MI 48103 US (HOME)</p><h3>Links</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Other</b></td><td><b>Type</b></td></tr><tr><td style=\"display: none\">*</td><td><a href=\"#RelatedPerson_relatedperson-mother-carmen-teresa-lee\">See above (RelatedPerson/relatedperson-mother-carmen-teresa-lee)</a></td><td>seealso</td></tr></table></div>"
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Patient_patient-mother-carmen-teresa-lee\"> </a><p><b>Generated Narrative: Patient</b><a name=\"patient-mother-carmen-teresa-lee\"> </a><a name=\"hcpatient-mother-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Patient &quot;patient-mother-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"https://build.fhir.org/ig/HL7/vr-common-library//StructureDefinition-Patient-mother-vr.html\">Patient - Mother Vital Records</a></p></div><blockquote><p><b>US Core Race Extension</b></p><blockquote><p><b>url</b></p><code>ombCategory</code></blockquote><p><b>value</b>: Black or African American (Details: urn:oid:2.16.840.1.113883.6.238 code 2054-5 = 'Black or African American', stated as 'Black or African American')</p><blockquote><p><b>url</b></p><code>text</code></blockquote><p><b>value</b>: Black or African America</p></blockquote><blockquote><p><b>US Core Ethnicity Extension</b></p><blockquote><p><b>url</b></p><code>ombCategory</code></blockquote><p><b>value</b>: Hispanic or Latino (Details: urn:oid:2.16.840.1.113883.6.238 code 2135-2 = 'Hispanic or Latino', stated as 'Hispanic or Latino')</p><blockquote><p><b>url</b></p><code>text</code></blockquote><p><b>value</b>: Hispanic or Latino</p></blockquote><p><b>US Core Birth Sex Extension</b>: F</p><p><b>Birth Place</b>: PR </p><p><b>identifier</b>: Medical Record Number/9992702 (use: USUAL)</p><p><b>name</b>: Carmen Teresa Lee (OFFICIAL), Carmen Teresa Santos (MAIDEN)</p><p><b>gender</b>: female</p><p><b>birthDate</b>: 1986-02-15</p><p><b>address</b>: 3670 Miller Road Ann Arbor MI 48103 US (HOME)</p><h3>Links</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Other</b></td><td><b>Type</b></td></tr><tr><td style=\"display: none\">*</td><td><a href=\"#RelatedPerson_relatedperson-mother-carmen-teresa-lee\">See above (RelatedPerson/relatedperson-mother-carmen-teresa-lee)</a></td><td>seealso</td></tr></table></div>"
         },
         "extension": [
           {

--- a/projects/BFDR/BFDR.xml
+++ b/projects/BFDR/BFDR.xml
@@ -536,6 +536,68 @@
             <para>Console.WriteLine($"Decedent Fetus Time of Birth: {ExampleFetalDeathRecord.DeliveryTime}");</para>
             </example>
         </member>
+        <member name="P:BFDR.FetalDeathRecord.FetalDeathSex">
+            <summary>Decedent Fetus's BirthSex at fetal death.</summary>
+            <value>The decedent fetus's BirthSex at time of fetal death</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleFetalDeathRecord.FetalDeathSex = "female;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Sex at Time of Fetal Death: {ExampleFetalDeathRecord.FetalDeathSex}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.FetalDeathRecord.FetalDeathSexHelper">
+            <summary>Decedent Fetus's Sex at Fetal Death Helper.</summary>
+            <value>The decedent fetus's sex at time of fetal death</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleFetalDeathRecord.FetalDeathSexHelper = "female;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Sex at Time of Fetal Death: {ExampleFetalDeathRecord.FetalDeathSexHelper}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.FetalDeathRecord.FetalDeathSetOrder">
+            <summary>Multiple birth set order</summary>
+            <value>The order that the decedent fetus was born if a multiple birth or null if it was a single birth</value>
+            <example>
+            <para>ExampleFetalDeathRecord.FetalDeathSetOrder = null; // single birth</para>
+            <para>ExampleFetalDeathRecord.FetalDeathSetOrder = -1; // unknow whether single or multiple birth</para>
+            <para>ExampleFetalDeathRecord.FetalDeathSetOrder = 1; // multiple birth, born first</para>
+            </example>
+        </member>
+        <member name="P:BFDR.FetalDeathRecord.FetalDeathPluralityEditFlag">
+            <summary>Multiple birth set order edit flag</summary>
+            <value>the multiple birth set order edit flag</value>
+            <example>
+            <para>// Setter:</para>
+            <para>Dictionary&lt;string, string&gt; route = new Dictionary&lt;string, string&gt;();</para>
+            <para>route.Add("code", "queriedCorrect");</para>
+            <para>route.Add("system", "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-vr-edit-flags");</para>
+            <para>route.Add("display", "Queried, and Correct");</para>
+            <para>ExampleFetalDeathRecord.FetalDeathPluralityEditFlag = route;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Multiple birth set order edit flag: {ExampleFetalDeathRecord.FetalDeathPluralityEditFlag}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.FetalDeathRecord.FetalDeathPluralityEditFlagHelper">
+            <summary>Multiple birth set order edit flag helper</summary>
+            <value>the multiple birth set order edit flag</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleFetalDeathRecord.FetalDeathPluralityEditFlagHelper = "queriedCorrect";</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Multiple birth set order edit flag: {ExampleFetalDeathRecord.FetalDeathPluralityEditFlagHelper}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.FetalDeathRecord.FetalDeathPlurality">
+            <summary>Multiple birth plurality</summary>
+            <value>Where a patient is a part of a multiple birth, this is the total number of births that occurred in this pregnancy.</value>
+            <example>
+            <para>ExampleFetalDeathRecord.FetalDeathPlurality = null; // single birth</para>
+            <para>ExampleFetalDeathRecord.FetalDeathPlurality = -1; // unknown number of births birth</para>
+            <para>ExampleFetalDeathRecord.FetalDeathPlurality = 2; // two births for this pregnancy</para>
+            </example>
+        </member>
         <member name="T:BFDR.IJEBirth">
             <summary>A "wrapper" class to convert between a FHIR based <c>BirthRecord</c> and
             a record in IJE Natality format. Each property of this class corresponds exactly

--- a/projects/BFDR/BFDR.xml
+++ b/projects/BFDR/BFDR.xml
@@ -111,6 +111,68 @@
             <para>Console.WriteLine($"Child Time of Birth: {ExampleBirthRecord.BirthTime}");</para>
             </example>
         </member>
+        <member name="P:BFDR.BirthRecord.BirthSex">
+            <summary>Child's BirthSex at Birth.</summary>
+            <value>The child's BirthSex at time of birth</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.BirthSex = "female;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Sex at Time of Birth: {ExampleBirthRecord.BirthSex}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.BirthSexHelper">
+            <summary>Child's Sex at Birth Helper.</summary>
+            <value>The child's sex at time of birth</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.BirthSexHelper = "female;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Sex at Time of Birth: {ExampleBirthRecord.BirthSexHelper}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.SetOrder">
+            <summary>Multiple birth set order</summary>
+            <value>The order that the child was born if a multiple birth or null if it was a single birth</value>
+            <example>
+            <para>ExampleBirthRecord.SetOrder = null; // single birth</para>
+            <para>ExampleBirthRecord.SetOrder = -1; // unknow whether single or multiple birth</para>
+            <para>ExampleBirthRecord.SetOrder = 1; // multiple birth, born first</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.PluralityEditFlag">
+            <summary>Multiple birth set order edit flag</summary>
+            <value>the multiple birth set order edit flag</value>
+            <example>
+            <para>// Setter:</para>
+            <para>Dictionary&lt;string, string&gt; route = new Dictionary&lt;string, string&gt;();</para>
+            <para>route.Add("code", "queriedCorrect");</para>
+            <para>route.Add("system", "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-vr-edit-flags");</para>
+            <para>route.Add("display", "Queried, and Correct");</para>
+            <para>ExampleBirthRecord.PluralityEditFlag = route;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Multiple birth set order edit flag: {ExampleBirthRecord.PluralityEditFlag}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.PluralityEditFlagHelper">
+            <summary>Multiple birth set order edit flag helper</summary>
+            <value>the multiple birth set order edit flag</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.PluralityEditFlagHelper = "queriedCorrect";</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Multiple birth set order edit flag: {ExampleBirthRecord.PluralityEditFlagHelper}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.Plurality">
+            <summary>Multiple birth plurality</summary>
+            <value>Where a patient is a part of a multiple birth, this is the total number of births that occurred in this pregnancy.</value>
+            <example>
+            <para>ExampleBirthRecord.Plurality = null; // single birth</para>
+            <para>ExampleBirthRecord.Plurality = -1; // unknown number of births birth</para>
+            <para>ExampleBirthRecord.Plurality = 2; // two births for this pregnancy</para>
+            </example>
+        </member>
         <member name="T:BFDR.FetalDeathRecord">
             <summary>Class <c>FetalDeathRecord</c> is a class designed to help consume and produce fetal death
             records that follow the HL7 FHIR Vital Records FetalDeath Reporting Implementation Guide, as described
@@ -3195,25 +3257,30 @@
             <para>Console.WriteLine($"Child Date of Birth: {ExampleBirthRecord.DateOfBirth}");</para>
             </example>
         </member>
-        <member name="P:BFDR.NatalityRecord.BirthSex">
-            <summary>Child's BirthSex at Birth.</summary>
-            <value>The child's BirthSex at time of birth</value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleBirthRecord.BirthSex = "female;</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Sex at Time of Birth: {ExampleBirthRecord.BirthSex}");</para>
-            </example>
+        <member name="M:BFDR.NatalityRecord.GetBirthSex">
+            <summary>
+             Getter method for child or decedent fetus birth/delivery sex.
+            </summary>
+            <returns>BirthSex codeable concept as dictionary</returns>
         </member>
-        <member name="P:BFDR.NatalityRecord.BirthSexHelper">
-            <summary>Child's Sex at Birth Helper.</summary>
-            <value>The child's sex at time of birth</value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleBirthRecord.BirthSexHelper = "female;</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Sex at Time of Birth: {ExampleBirthRecord.BirthSexHelper}");</para>
-            </example>
+        <member name="M:BFDR.NatalityRecord.SetBirthSex(System.Collections.Generic.Dictionary{System.String,System.String})">
+            <summary>
+             Setter method for child or decedent fetus birth/delivery sex.
+            </summary>
+            <param name="value">The birth/delivery sex.</param>
+        </member>
+        <member name="M:BFDR.NatalityRecord.GetBirthSexHelper">
+            <summary>
+             Helper method for getting child or decedent fetus birth/delivery sex.
+            </summary>      
+            <returns>BirthSex code as string</returns>
+        </member>
+        <member name="M:BFDR.NatalityRecord.SetBirthSexHelper(System.String,System.String)">
+            <summary>
+             Helper method for setting child or decedent fetus birth/delivery sex.
+            </summary>
+            <param name="field">The field name to set.</param>       
+            <param name="value">The birth/delivery sex.</param>        
         </member>
         <member name="P:BFDR.NatalityRecord.ChildGivenNames">
             <summary>Child's Legal Name - Given. Middle name should be the last entry.</summary>
@@ -3550,47 +3617,53 @@
             <para>Console.WriteLine($"Father's SocialSecurityNumber: {ExampleBirthRecord.FatherSocialSecurityNumber}");</para>
             </example>
         </member>
-        <member name="P:BFDR.NatalityRecord.SetOrder">
-            <summary>Multiple birth set order</summary>
-            <value>The order that the child was born if a multiple birth or null if it was a single birth</value>
-            <example>
-            <para>ExampleBirthRecord.SetOrder = null; // single birth</para>
-            <para>ExampleBirthRecord.SetOrder = -1; // unknow whether single or multiple birth</para>
-            <para>ExampleBirthRecord.SetOrder = 1; // multiple birth, born first</para>
-            </example>
+        <member name="M:BFDR.NatalityRecord.GetSetOrder">
+            <summary>
+             Getter method for child or decedent fetus set order.
+            </summary>
+            <returns>Integer representing set order or -1 if dataAbsent</returns>
         </member>
-        <member name="P:BFDR.NatalityRecord.PluralityEditFlag">
-            <summary>Multiple birth set order edit flag</summary>
-            <value>the multiple birth set order edit flag</value>
-            <example>
-            <para>// Setter:</para>
-            <para>Dictionary&lt;string, string&gt; route = new Dictionary&lt;string, string&gt;();</para>
-            <para>route.Add("code", "queriedCorrect");</para>
-            <para>route.Add("system", "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-vr-edit-flags");</para>
-            <para>route.Add("display", "Queried, and Correct");</para>
-            <para>ExampleBirthRecord.PluralityEditFlag = route;</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Multiple birth set order edit flag: {ExampleBirthRecord.PluralityEditFlag}");</para>
-            </example>
+        <member name="M:BFDR.NatalityRecord.SetSetOrder(System.Nullable{System.Int32})">
+            <summary>
+             Setter method for child or decedent fetus set order.
+            </summary>
+            <param name="value">The birth year.</param>        
         </member>
-        <member name="P:BFDR.NatalityRecord.PluralityEditFlagHelper">
-            <summary>Multiple birth set order edit flag helper</summary>
-            <value>the multiple birth set order edit flag</value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleBirthRecord.PluralityEditFlagHelper = "queriedCorrect";</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Multiple birth set order edit flag: {ExampleBirthRecord.PluralityEditFlagHelper}");</para>
-            </example>
+        <member name="M:BFDR.NatalityRecord.GetPluralityEditFlag">
+            <summary>
+             Getter method for child or decedent fetus plurality edit flag.
+            </summary>   
+            <returns>Plurality edit flag codeable concept as Dictionary</returns>
         </member>
-        <member name="P:BFDR.NatalityRecord.Plurality">
-            <summary>Multiple birth plurality</summary>
-            <value>Where a patient is a part of a multiple birth, this is the total number of births that occurred in this pregnancy.</value>
-            <example>
-            <para>ExampleBirthRecord.Plurality = null; // single birth</para>
-            <para>ExampleBirthRecord.Plurality = -1; // unknown number of births birth</para>
-            <para>ExampleBirthRecord.Plurality = 2; // two births for this pregnancy</para>
-            </example>
+        <member name="M:BFDR.NatalityRecord.SetPluralityEditFlag(System.Collections.Generic.Dictionary{System.String,System.String})">
+            <summary>
+             Setter method for child or decedent fetus plurality edit flag.
+            </summary>
+            <param name="value">The birth year.</param> 
+        </member>
+        <member name="M:BFDR.NatalityRecord.GetPluralityEditFlagHelper">
+            <summary>
+             Helper method for getting child or decedent fetus plurality edit flag.
+            </summary>    
+            <returns>Plurality edit flag code as string</returns>
+        </member>
+        <member name="M:BFDR.NatalityRecord.SetPluralityEditFlagHelper(System.String)">
+            <summary>
+             Helper method for setting child or decedent fetus plurality edit flag.
+            </summary>
+            <param name="value">The birth year.</param>         
+        </member>
+        <member name="M:BFDR.NatalityRecord.GetPlurality">
+            <summary>
+             Gettter method for child or decedent fetus plurality.
+            </summary>     
+            <returns>Integer representing Plurality or -1 if dataAbsent</returns>
+        </member>
+        <member name="M:BFDR.NatalityRecord.SetPlurality(System.Nullable{System.Int32})">
+            <summary>
+             Setter method for child or decedent fetus plurality.
+            </summary>
+            <param name="value">The birth year.</param>   
         </member>
         <member name="P:BFDR.NatalityRecord.NoCongenitalAnomaliesOfTheNewborn">
             <summary>No Congenital Anomalies of the Newborn.</summary>

--- a/projects/BFDR/BirthRecord.cs
+++ b/projects/BFDR/BirthRecord.cs
@@ -193,5 +193,108 @@ namespace BFDR
             get => GetBirthTime();
             set => SetBirthTime(value);
         }
+
+        /// <summary>Child's BirthSex at Birth.</summary>
+        /// <value>The child's BirthSex at time of birth</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.BirthSex = "female;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Sex at Time of Birth: {ExampleBirthRecord.BirthSex}");</para>
+        /// </example>
+        [Property("Sex At Birth", Property.Types.Dictionary, "Child Demographics", "Child's Sex at Birth.", true, VR.IGURL.Child, true, 12)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient).extension.where(url='" + OtherExtensionURL.BirthSex + "')", "")]
+        public Dictionary<string, string> BirthSex
+        {
+            get => GetBirthSex();
+            set => SetBirthSex(value);
+        }
+
+        /// <summary>Child's Sex at Birth Helper.</summary>
+        /// <value>The child's sex at time of birth</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.BirthSexHelper = "female;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Sex at Time of Birth: {ExampleBirthRecord.BirthSexHelper}");</para>
+        /// </example>
+        [Property("Sex At Birth Helper", Property.Types.String, "Child Demographics", "Child's Sex at Birth.", false, VR.IGURL.Child, true, 12)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient).extension.where(url='" + OtherExtensionURL.BirthSex + "')", "")]
+        public string BirthSexHelper
+        {
+            get => GetBirthSexHelper();
+            set => SetBirthSexHelper("BirthSex", value);
+        }
+        /// <summary>Multiple birth set order</summary>
+        /// <value>The order that the child was born if a multiple birth or null if it was a single birth</value>
+        /// <example>
+        /// <para>ExampleBirthRecord.SetOrder = null; // single birth</para>
+        /// <para>ExampleBirthRecord.SetOrder = -1; // unknow whether single or multiple birth</para>
+        /// <para>ExampleBirthRecord.SetOrder = 1; // multiple birth, born first</para>
+        /// </example>
+        [Property("SetOrder", Property.Types.Int32, "Child Demographics", "Child Demographics, Set Order", true, VR.IGURL.Child, true, 208)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "multipleBirth")]
+        public int? SetOrder
+        {
+            get => GetSetOrder();
+            set => SetSetOrder(value);
+        }
+
+        /// <summary>Multiple birth set order edit flag</summary>
+        /// <value>the multiple birth set order edit flag</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>Dictionary&lt;string, string&gt; route = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>route.Add("code", "queriedCorrect");</para>
+        /// <para>route.Add("system", "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-vr-edit-flags");</para>
+        /// <para>route.Add("display", "Queried, and Correct");</para>
+        /// <para>ExampleBirthRecord.PluralityEditFlag = route;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Multiple birth set order edit flag: {ExampleBirthRecord.PluralityEditFlag}");</para>
+        /// </example>
+        [Property("PluralityEditFlag", Property.Types.Dictionary, "Child Demographics", "Child Demographics, Plurality Edit Flag", true, VR.IGURL.Child, true, 211)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient).multipleBirth.extension.where(url = 'http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag')", "")]
+        public Dictionary<string, string> PluralityEditFlag
+        {
+            get => GetPluralityEditFlag();
+            set => SetPluralityEditFlag(value);
+        }
+
+        /// <summary>Multiple birth set order edit flag helper</summary>
+        /// <value>the multiple birth set order edit flag</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.PluralityEditFlagHelper = "queriedCorrect";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Multiple birth set order edit flag: {ExampleBirthRecord.PluralityEditFlagHelper}");</para>
+        /// </example>
+        [Property("PluralityEditFlagHelper", Property.Types.String, "Child Demographics", "Child Demographics, Plurality Edit Flag", false, VR.IGURL.Child, true, 211)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient).multipleBirth.extension.where(url = 'http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag')", "")]
+        public string PluralityEditFlagHelper
+        {
+            get => GetPluralityEditFlagHelper();
+            set => SetPluralityEditFlagHelper(value);
+        }
+
+        /// <summary>Multiple birth plurality</summary>
+        /// <value>Where a patient is a part of a multiple birth, this is the total number of births that occurred in this pregnancy.</value>
+        /// <example>
+        /// <para>ExampleBirthRecord.Plurality = null; // single birth</para>
+        /// <para>ExampleBirthRecord.Plurality = -1; // unknown number of births birth</para>
+        /// <para>ExampleBirthRecord.Plurality = 2; // two births for this pregnancy</para>
+        /// </example>
+        [Property("Plurality", Property.Types.Int32, "Child Demographics", "Child Demographics, Plurality", true, VR.IGURL.Child, true, 207)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient).multipleBirth.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/patient-multipleBirthTotal')", "")]
+        public int? Plurality
+        {
+            get => GetPlurality();
+            set => SetPlurality(value);
+        }
     }
 }

--- a/projects/BFDR/FetalDeathRecord.cs
+++ b/projects/BFDR/FetalDeathRecord.cs
@@ -1239,27 +1239,8 @@ namespace BFDR
         [FHIRPath("Bundle.entry.resource.where($this is Patient).extension.where(url='" + OtherExtensionURL.BirthSex + "')", "")]
         public Dictionary<string, string> FetalDeathSex
         {
-            get
-            {
-                if (Subject != null)
-                {
-                    Extension sex = Subject.GetExtension(VR.OtherExtensionURL.BirthSex);
-                    if (sex != null && sex.Value != null && sex.Value as CodeableConcept != null)
-                    {
-                        return CodeableConceptToDict((CodeableConcept)sex.Value);
-                    }
-                }
-                return EmptyCodeableDict();
-            }
-            set
-            {
-                Subject.Extension.RemoveAll(ext => ext.Url == VR.OtherExtensionURL.BirthSex);
-                if (IsDictEmptyOrDefault(value) && Subject.Extension == null)
-                {
-                    return;
-                }
-                Subject.SetExtension(VR.OtherExtensionURL.BirthSex, DictToCodeableConcept(value));
-            }
+            get => GetBirthSex();
+            set => SetBirthSex(value);
         }
 
         /// <summary>Decedent Fetus's Sex at Fetal Death Helper.</summary>
@@ -1274,21 +1255,8 @@ namespace BFDR
         [FHIRPath("Bundle.entry.resource.where($this is Patient).extension.where(url='" + OtherExtensionURL.BirthSex + "')", "")]
         public string FetalDeathSexHelper
         {
-            get
-            {
-                if (FetalDeathSex.ContainsKey("code") && !String.IsNullOrWhiteSpace(FetalDeathSex["code"]))
-                {
-                    return FetalDeathSex["code"];
-                }
-                return null;
-            }
-            set
-            {
-                if (!String.IsNullOrWhiteSpace(value))
-                {
-                    SetCodeValue("FetalDeathSex", value, VR.ValueSets.SexAssignedAtBirth.Codes);
-                }
-            }
+            get => GetBirthSexHelper();
+            set => SetBirthSexHelper("FetalDeathSex", value);
         }
 
         /// <summary>Multiple birth set order</summary>
@@ -1302,46 +1270,8 @@ namespace BFDR
         [FHIRPath("Bundle.entry.resource.where($this is Patient)", "multipleBirth")]
         public int? FetalDeathSetOrder
         {
-            get
-            {
-                if (Subject != null && Subject.MultipleBirth != null)
-                {
-                    if (Subject.MultipleBirth as FhirBoolean != null)
-                    {
-                        return null;
-                    }
-                    else if (Subject.MultipleBirth as Hl7.Fhir.Model.Integer != null && (Subject.MultipleBirth as Hl7.Fhir.Model.Integer).Value != null)
-                    {
-                        return (Subject.MultipleBirth as Hl7.Fhir.Model.Integer).Value;
-                    }
-                    else if (Subject.MultipleBirth.Extension.Find(ext => ext.Url == ExtensionURL.DataAbsentReason) != null)
-                    {
-                        return -1;
-                    }
-                }
-                return null;
-            }
-            set
-            {
-                Dictionary<string, string> pluralityEditFlag = PluralityEditFlag;
-                int? plurality = Plurality;
-                if (value == null)
-                {
-                    Subject.MultipleBirth = new FhirBoolean(false);
-                }
-                else if (value == -1)
-                {
-                    Subject.MultipleBirth = new Hl7.Fhir.Model.Integer();
-                    Extension missingValueReason = new Extension(ExtensionURL.DataAbsentReason, new Code("unknown"));
-                    Subject.MultipleBirth.Extension.Add(missingValueReason);
-                }
-                else
-                {
-                    Subject.MultipleBirth = new Hl7.Fhir.Model.Integer(value);
-                }
-                Plurality = plurality;
-                PluralityEditFlag = pluralityEditFlag;
-            }
+            get => GetSetOrder();
+            set => SetSetOrder(value);
         }
 
         /// <summary>Multiple birth set order edit flag</summary>
@@ -1363,27 +1293,8 @@ namespace BFDR
         [FHIRPath("Bundle.entry.resource.where($this is Patient).multipleBirth.extension.where(url = 'http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag')", "")]
         public Dictionary<string, string> FetalDeathPluralityEditFlag
         {
-            get
-            {
-                if (Subject != null && Subject.MultipleBirth != null)
-                {
-                    Extension pluralityEditFlag = Subject.MultipleBirth.Extension.Find(ext => ext.Url == VRExtensionURLs.BypassEditFlag);
-                    if (pluralityEditFlag != null && pluralityEditFlag.Value != null && pluralityEditFlag.Value as CodeableConcept != null)
-                    {
-                        return CodeableConceptToDict((CodeableConcept)pluralityEditFlag.Value);
-                    }
-                }
-                return EmptyCodeableDict();
-            }
-            set
-            {
-                if (Subject.MultipleBirth == null)
-                {
-                    Subject.MultipleBirth = new FhirBoolean(false);
-                }
-                Subject.MultipleBirth.Extension.RemoveAll(ext => ext.Url == VRExtensionURLs.BypassEditFlag);
-                Subject.MultipleBirth.Extension.Add(new Extension(VRExtensionURLs.BypassEditFlag, DictToCodeableConcept(value)));
-            }
+            get => GetPluralityEditFlag();
+            set => SetPluralityEditFlag(value);
         }
 
         /// <summary>Multiple birth set order edit flag helper</summary>
@@ -1398,27 +1309,9 @@ namespace BFDR
         [FHIRPath("Bundle.entry.resource.where($this is Patient).multipleBirth.extension.where(url = 'http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag')", "")]
         public string FetalDeathPluralityEditFlagHelper
         {
-            get
-            {
-                if (PluralityEditFlag.ContainsKey("code"))
-                {
-                    string code = PluralityEditFlag["code"];
-                    if (!String.IsNullOrWhiteSpace(code))
-                    {
-                        return code;
-                    }
-                }
-                return null;
-            }
-            set
-            {
-                if (!String.IsNullOrEmpty(value))
-                {
-                    SetCodeValue("PluralityEditFlag", value, VR.ValueSets.PluralityEditFlags.Codes);
-                }
-            }
+            get => GetPluralityEditFlagHelper();
+            set => SetPluralityEditFlagHelper(value);
         }
-
 
         /// <summary>Multiple birth plurality</summary>
         /// <value>Where a patient is a part of a multiple birth, this is the total number of births that occurred in this pregnancy.</value>
@@ -1431,49 +1324,8 @@ namespace BFDR
         [FHIRPath("Bundle.entry.resource.where($this is Patient).multipleBirth.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/patient-multipleBirthTotal')", "")]
         public int? FetalDeathPlurality
         {
-            get
-            {
-                if (Subject != null && Subject.MultipleBirth != null)
-                {
-                    Extension plurality = Subject.MultipleBirth.Extension.Find(ext => ext.Url == ExtensionURL.Plurality);
-                    if (plurality != null)
-                    {
-                        if (plurality.Value as PositiveInt != null && (plurality.Value as PositiveInt).Value != null)
-                        {
-                            return (plurality.Value as PositiveInt).Value;
-                        }
-                        else if (plurality.Extension.Find(ext => ext.Url == ExtensionURL.DataAbsentReason) != null)
-                        {
-                            return -1;
-                        }
-                    }
-                }
-                return null;
-            }
-            set
-            {
-                if (Subject.MultipleBirth == null)
-                {
-                    Subject.MultipleBirth = new FhirBoolean(false);
-                }
-                Subject.MultipleBirth.Extension.RemoveAll(ext => ext.Url == ExtensionURL.Plurality);
-                if (value == null)
-                {
-                    return;
-                }
-                else if (value == -1)
-                {
-                    Extension plurality = new Extension(ExtensionURL.Plurality, new PositiveInt());
-                    Extension missingValueReason = new Extension(ExtensionURL.DataAbsentReason, new Code("unknown"));
-                    plurality.Extension.Add(missingValueReason);
-                    Subject.MultipleBirth.Extension.Add(plurality);
-                }
-                else
-                {
-                    Extension plurality = new Extension(ExtensionURL.Plurality, new PositiveInt(value));
-                    Subject.MultipleBirth.Extension.Add(plurality);
-                }
-            }
+            get => GetPlurality();
+            set => SetPlurality(value);
         }
     }
 }

--- a/projects/BFDR/FetalDeathRecord.cs
+++ b/projects/BFDR/FetalDeathRecord.cs
@@ -1223,5 +1223,257 @@ namespace BFDR
             get => GetBirthTime();
             set => SetBirthTime(value);
         }
+
+        /// <summary>Decedent Fetus's BirthSex at fetal death.</summary>
+        /// <value>The decedent fetus's BirthSex at time of fetal death</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleFetalDeathRecord.FetalDeathSex = "female;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Sex at Time of Fetal Death: {ExampleFetalDeathRecord.FetalDeathSex}");</para>
+        /// </example>
+        [Property("Decedent Fetus Sex At Birth", Property.Types.Dictionary, "Fetus Demographics", "Decedent Fetus's Sex at Birth.", true, BFDR.ProfileURL.PatientDecedentFetus, true, 12)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient).extension.where(url='" + OtherExtensionURL.BirthSex + "')", "")]
+        public Dictionary<string, string> FetalDeathSex
+        {
+            get
+            {
+                if (Subject != null)
+                {
+                    Extension sex = Subject.GetExtension(VR.OtherExtensionURL.BirthSex);
+                    if (sex != null && sex.Value != null && sex.Value as CodeableConcept != null)
+                    {
+                        return CodeableConceptToDict((CodeableConcept)sex.Value);
+                    }
+                }
+                return EmptyCodeableDict();
+            }
+            set
+            {
+                Subject.Extension.RemoveAll(ext => ext.Url == VR.OtherExtensionURL.BirthSex);
+                if (IsDictEmptyOrDefault(value) && Subject.Extension == null)
+                {
+                    return;
+                }
+                Subject.SetExtension(VR.OtherExtensionURL.BirthSex, DictToCodeableConcept(value));
+            }
+        }
+
+        /// <summary>Decedent Fetus's Sex at Fetal Death Helper.</summary>
+        /// <value>The decedent fetus's sex at time of fetal death</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleFetalDeathRecord.FetalDeathSexHelper = "female;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Sex at Time of Fetal Death: {ExampleFetalDeathRecord.FetalDeathSexHelper}");</para>
+        /// </example>
+        [Property("Decedent Fetus Sex At Birth Helper", Property.Types.String, "Fetus Demographics", "Decedent Fetus's Sex at Birth.", false, BFDR.ProfileURL.PatientDecedentFetus, true, 12)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient).extension.where(url='" + OtherExtensionURL.BirthSex + "')", "")]
+        public string FetalDeathSexHelper
+        {
+            get
+            {
+                if (FetalDeathSex.ContainsKey("code") && !String.IsNullOrWhiteSpace(FetalDeathSex["code"]))
+                {
+                    return FetalDeathSex["code"];
+                }
+                return null;
+            }
+            set
+            {
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("FetalDeathSex", value, VR.ValueSets.SexAssignedAtBirth.Codes);
+                }
+            }
+        }
+
+        /// <summary>Multiple birth set order</summary>
+        /// <value>The order that the decedent fetus was born if a multiple birth or null if it was a single birth</value>
+        /// <example>
+        /// <para>ExampleFetalDeathRecord.FetalDeathSetOrder = null; // single birth</para>
+        /// <para>ExampleFetalDeathRecord.FetalDeathSetOrder = -1; // unknow whether single or multiple birth</para>
+        /// <para>ExampleFetalDeathRecord.FetalDeathSetOrder = 1; // multiple birth, born first</para>
+        /// </example>
+        [Property("FetalDeathSetOrder", Property.Types.Int32, "Fetus Demographics", "Fetus Demographics, Set Order", true, BFDR.ProfileURL.PatientDecedentFetus, true, 208)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "multipleBirth")]
+        public int? FetalDeathSetOrder
+        {
+            get
+            {
+                if (Subject != null && Subject.MultipleBirth != null)
+                {
+                    if (Subject.MultipleBirth as FhirBoolean != null)
+                    {
+                        return null;
+                    }
+                    else if (Subject.MultipleBirth as Hl7.Fhir.Model.Integer != null && (Subject.MultipleBirth as Hl7.Fhir.Model.Integer).Value != null)
+                    {
+                        return (Subject.MultipleBirth as Hl7.Fhir.Model.Integer).Value;
+                    }
+                    else if (Subject.MultipleBirth.Extension.Find(ext => ext.Url == ExtensionURL.DataAbsentReason) != null)
+                    {
+                        return -1;
+                    }
+                }
+                return null;
+            }
+            set
+            {
+                Dictionary<string, string> pluralityEditFlag = PluralityEditFlag;
+                int? plurality = Plurality;
+                if (value == null)
+                {
+                    Subject.MultipleBirth = new FhirBoolean(false);
+                }
+                else if (value == -1)
+                {
+                    Subject.MultipleBirth = new Hl7.Fhir.Model.Integer();
+                    Extension missingValueReason = new Extension(ExtensionURL.DataAbsentReason, new Code("unknown"));
+                    Subject.MultipleBirth.Extension.Add(missingValueReason);
+                }
+                else
+                {
+                    Subject.MultipleBirth = new Hl7.Fhir.Model.Integer(value);
+                }
+                Plurality = plurality;
+                PluralityEditFlag = pluralityEditFlag;
+            }
+        }
+
+        /// <summary>Multiple birth set order edit flag</summary>
+        /// <value>the multiple birth set order edit flag</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>Dictionary&lt;string, string&gt; route = new Dictionary&lt;string, string&gt;();</para>
+        /// <para>route.Add("code", "queriedCorrect");</para>
+        /// <para>route.Add("system", "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-vr-edit-flags");</para>
+        /// <para>route.Add("display", "Queried, and Correct");</para>
+        /// <para>ExampleFetalDeathRecord.FetalDeathPluralityEditFlag = route;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Multiple birth set order edit flag: {ExampleFetalDeathRecord.FetalDeathPluralityEditFlag}");</para>
+        /// </example>
+        [Property("FetalDeathPluralityEditFlag", Property.Types.Dictionary, "Fetus Demographics", "Fetus Demographics, Plurality Edit Flag", true, BFDR.ProfileURL.PatientDecedentFetus, true, 211)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient).multipleBirth.extension.where(url = 'http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag')", "")]
+        public Dictionary<string, string> FetalDeathPluralityEditFlag
+        {
+            get
+            {
+                if (Subject != null && Subject.MultipleBirth != null)
+                {
+                    Extension pluralityEditFlag = Subject.MultipleBirth.Extension.Find(ext => ext.Url == VRExtensionURLs.BypassEditFlag);
+                    if (pluralityEditFlag != null && pluralityEditFlag.Value != null && pluralityEditFlag.Value as CodeableConcept != null)
+                    {
+                        return CodeableConceptToDict((CodeableConcept)pluralityEditFlag.Value);
+                    }
+                }
+                return EmptyCodeableDict();
+            }
+            set
+            {
+                if (Subject.MultipleBirth == null)
+                {
+                    Subject.MultipleBirth = new FhirBoolean(false);
+                }
+                Subject.MultipleBirth.Extension.RemoveAll(ext => ext.Url == VRExtensionURLs.BypassEditFlag);
+                Subject.MultipleBirth.Extension.Add(new Extension(VRExtensionURLs.BypassEditFlag, DictToCodeableConcept(value)));
+            }
+        }
+
+        /// <summary>Multiple birth set order edit flag helper</summary>
+        /// <value>the multiple birth set order edit flag</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleFetalDeathRecord.FetalDeathPluralityEditFlagHelper = "queriedCorrect";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Multiple birth set order edit flag: {ExampleFetalDeathRecord.FetalDeathPluralityEditFlagHelper}");</para>
+        /// </example>
+        [Property("FetalDeathPluralityEditFlagHelper", Property.Types.String, "Fetus Demographics", "Fetus Demographics, Plurality Edit Flag", false, BFDR.ProfileURL.PatientDecedentFetus, true, 211)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient).multipleBirth.extension.where(url = 'http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag')", "")]
+        public string FetalDeathPluralityEditFlagHelper
+        {
+            get
+            {
+                if (PluralityEditFlag.ContainsKey("code"))
+                {
+                    string code = PluralityEditFlag["code"];
+                    if (!String.IsNullOrWhiteSpace(code))
+                    {
+                        return code;
+                    }
+                }
+                return null;
+            }
+            set
+            {
+                if (!String.IsNullOrEmpty(value))
+                {
+                    SetCodeValue("PluralityEditFlag", value, VR.ValueSets.PluralityEditFlags.Codes);
+                }
+            }
+        }
+
+
+        /// <summary>Multiple birth plurality</summary>
+        /// <value>Where a patient is a part of a multiple birth, this is the total number of births that occurred in this pregnancy.</value>
+        /// <example>
+        /// <para>ExampleFetalDeathRecord.FetalDeathPlurality = null; // single birth</para>
+        /// <para>ExampleFetalDeathRecord.FetalDeathPlurality = -1; // unknown number of births birth</para>
+        /// <para>ExampleFetalDeathRecord.FetalDeathPlurality = 2; // two births for this pregnancy</para>
+        /// </example>
+        [Property("FetalDeathPlurality", Property.Types.Int32, "Fetus Demographics", "Fetus Demographics, Plurality", true, BFDR.ProfileURL.PatientDecedentFetus, true, 207)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient).multipleBirth.extension.where(url = 'http://hl7.org/fhir/StructureDefinition/patient-multipleBirthTotal')", "")]
+        public int? FetalDeathPlurality
+        {
+            get
+            {
+                if (Subject != null && Subject.MultipleBirth != null)
+                {
+                    Extension plurality = Subject.MultipleBirth.Extension.Find(ext => ext.Url == ExtensionURL.Plurality);
+                    if (plurality != null)
+                    {
+                        if (plurality.Value as PositiveInt != null && (plurality.Value as PositiveInt).Value != null)
+                        {
+                            return (plurality.Value as PositiveInt).Value;
+                        }
+                        else if (plurality.Extension.Find(ext => ext.Url == ExtensionURL.DataAbsentReason) != null)
+                        {
+                            return -1;
+                        }
+                    }
+                }
+                return null;
+            }
+            set
+            {
+                if (Subject.MultipleBirth == null)
+                {
+                    Subject.MultipleBirth = new FhirBoolean(false);
+                }
+                Subject.MultipleBirth.Extension.RemoveAll(ext => ext.Url == ExtensionURL.Plurality);
+                if (value == null)
+                {
+                    return;
+                }
+                else if (value == -1)
+                {
+                    Extension plurality = new Extension(ExtensionURL.Plurality, new PositiveInt());
+                    Extension missingValueReason = new Extension(ExtensionURL.DataAbsentReason, new Code("unknown"));
+                    plurality.Extension.Add(missingValueReason);
+                    Subject.MultipleBirth.Extension.Add(plurality);
+                }
+                else
+                {
+                    Extension plurality = new Extension(ExtensionURL.Plurality, new PositiveInt(value));
+                    Subject.MultipleBirth.Extension.Add(plurality);
+                }
+            }
+        }
     }
 }

--- a/projects/BFDR/IJEFetalDeath.cs
+++ b/projects/BFDR/IJEFetalDeath.cs
@@ -223,12 +223,11 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
+                return Get_MappingFHIRToIJE(VR.Mappings.BirthSexChild.FHIRToIJE, "FetalDeathSex", "FSEX");
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                Set_MappingIJEToFHIR(VR.Mappings.BirthSexChild.IJEToFHIR, "FSEX", "FetalDeathSex", value);
             }
         }
 
@@ -2430,12 +2429,11 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
+                return NumericAllowingUnknown_Get("PLUR", "FetalDeathPlurality");
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                NumericAllowingUnknown_Set("PLUR", "FetalDeathPlurality", value);
             }
         }
 
@@ -2445,12 +2443,11 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
+                return NumericAllowingUnknown_Get("SORD", "FetalDeathSetOrder");
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                NumericAllowingUnknown_Set("SORD", "FetalDeathSetOrder", value);
             }
         }
 
@@ -2489,12 +2486,11 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
+                return Get_MappingFHIRToIJE(VR.Mappings.PluralityEditFlags.FHIRToIJE, "FetalDeathPluralityEditFlag", "PLUR_BYPASS").PadLeft(1, ' ');
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                Set_MappingIJEToFHIR(VR.Mappings.PluralityEditFlags.IJEToFHIR, "PLUR_BYPASS", "FetalDeathPluralityEditFlag", value);
             }
         }
 

--- a/projects/BFDR/IJEFetalDeath.cs
+++ b/projects/BFDR/IJEFetalDeath.cs
@@ -223,11 +223,11 @@ namespace BFDR
         {
             get
             {
-                return Get_MappingFHIRToIJE(VR.Mappings.BirthSexChild.FHIRToIJE, "FetalDeathSex", "FSEX");
+                return Get_MappingFHIRToIJE(VR.Mappings.BirthSexFetus.FHIRToIJE, "FetalDeathSex", "FSEX");
             }
             set
             {
-                Set_MappingIJEToFHIR(VR.Mappings.BirthSexChild.IJEToFHIR, "FSEX", "FetalDeathSex", value);
+                Set_MappingIJEToFHIR(VR.Mappings.BirthSexFetus.IJEToFHIR, "FSEX", "FetalDeathSex", value);
             }
         }
 


### PR DESCRIPTION
Implements Sex, Plurality, Set Order, Plurality Edit Flag. Code was shared between Natality and Fetal Death, except for different Patients (Child versus Decedent Fetus), so I refactored the code into getter and setter methods that could be used for both BirthRecord and FetalDeathRecord. 