### PR TITLE
ci(bfdr): add code coverage

### DIFF
--- a/.github/workflows/bfdr-test.yml
+++ b/.github/workflows/bfdr-test.yml
@@ -44,6 +44,24 @@ jobs:
     - name: Test CLI commands
       run: ./BFDR.Tests/run_tests.sh
     - name: Test
+      run: dotnet test bfdr-dotnet.sln
+  coverage:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./projects
+    permissions: write-all
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ matrix.dotnet-version }}
+    - name: Install dependencies
+      run: dotnet restore bfdr-dotnet.sln
+    - name: Build
+      run: dotnet build bfdr-dotnet.sln --configuration Release --no-restore
+    - name: Test
       run: dotnet test bfdr-dotnet.sln --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
     - name: Code Coverage Report
       uses: irongut/CodeCoverageSummary@v1.3.0

--- a/.github/workflows/bfdr-test.yml
+++ b/.github/workflows/bfdr-test.yml
@@ -30,6 +30,7 @@ jobs:
     strategy:
       matrix:
         dotnet-version: [2.1.815, 3.1.408, 6.0.100]
+    permissions: write-all
     steps:
     - uses: actions/checkout@v4
     - name: Setup .NET
@@ -40,5 +41,25 @@ jobs:
       run: dotnet restore bfdr-dotnet.sln
     - name: Build
       run: dotnet build bfdr-dotnet.sln --configuration Release --no-restore
-    - name: Test
+    - name: Test CLI commands
       run: ./BFDR.Tests/run_tests.sh
+    - name: Test
+      run: dotnet test bfdr-dotnet.sln --configuration Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
+    - name: Code Coverage Report
+      uses: irongut/CodeCoverageSummary@v1.3.0
+      with:
+        filename: projects/coverage/**/coverage.cobertura.xml
+        badge: true
+        fail_below_min: false
+        format: markdown
+        hide_branch_rate: false
+        hide_complexity: true
+        indicators: true
+        output: both
+        thresholds: '50 75'
+    - name: Add Coverage PR Comment
+      uses: marocchino/sticky-pull-request-comment@v2
+      if: github.event_name == 'pull_request'
+      with:
+        recreate: true
+        path: code-coverage-results.md

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,9 @@ _TeamCity*
 coverage*.json
 coverage*.xml
 coverage*.info
+# and report generation for BFDR tests
+projects/BFDR.Tests/tools
+projects/BFDR.Tests/.config/dotnet-tools.json
 
 # Visual Studio code coverage results
 *.coverage

--- a/README.md
+++ b/README.md
@@ -145,3 +145,13 @@ The content of the commit message body should contain:
 - manual project version advancements (in *.csproj) for any/all applicable projects with each commit
 - publish to NuGet automatically following version bump
 - [Task](https://taskfile.dev/) is enabled during devcontainer build
+
+## Code Coverage Report
+Pull requests will automatically include code coverage checks. To get a full report locally, install the [coverlet.collector](https://github.com/coverlet-coverage/coverlet) to generate a code coverage xml file (you may additionally install coverlet.msbuild as well). To generate a readable report, install [ReportGenerator](https://github.com/danielpalme/ReportGenerator):
+
+- `dotnet tool install -g dotnet-reportgenerator-globaltool` to install report generator global tool (accessible across projects)
+- `dotnet tool install dotnet-reportgenerator-globaltool --tool-path tools` for installing the same package in a "tools" directory within a project
+- `dotnet new tool-manifest` to create a tool manifest file within a project
+- `dotnet tool install dotnet-reportgenerator-globaltool` for installing without `-g` global flag, configuring it within a project
+
+To generate the report, coverlet must first evaluate code coverage (`dotnet test /p:CollectCoverage=true`) and use XPlat coverage tool to track execution (`dotnet test --collect:"XPlat Code Coverage"`). The generated coverage.cobertura.xml file can then be used to create a readable html report using ReportGenerator (`dotnet reportgenerator "-reports:coverage.cobertura.xml" "-targetdir:coveragereport" -reporttypes:Html` - `-reports:coverage.cobertura.xml` indicates the path to the xml coverage information and `-targetdir:coveragereport` indicates where the generated report will appear).

--- a/projects/BFDR.Tests/BFDR.Tests.csproj
+++ b/projects/BFDR.Tests/BFDR.Tests.csproj
@@ -7,8 +7,13 @@
     <!-- <GenerateProgramFile>false</GenerateProgramFile> -->
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="ReportGenerator" Version="5.3.5" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/projects/BFDR.Tests/run_tests.sh
+++ b/projects/BFDR.Tests/run_tests.sh
@@ -2,8 +2,8 @@
 set -e
 
 # Run the C# test suite
-echo "* dotnet test BFDR.Tests/BFDR.Tests.csproj"
-dotnet test BFDR.Tests/BFDR.Tests.csproj
+# echo "* dotnet test BFDR.Tests/BFDR.Tests.csproj"
+# dotnet test BFDR.Tests/BFDR.Tests.csproj
 
 # Make sure we can read and parse a JSON file
 echo "* dotnet run --project BFDR.CLI 2ije BFDR.Tests/fixtures/json/BasicBirthRecord.json"


### PR DESCRIPTION
## Summary

- add documentation for full code coverage report generation (local) 
- add GH workflow for coverage overview in pull requests


In general we want free, open source tools that confirm test coverage when creating PRs and give us the ability to look deeper at coverage locally. The [CodeCoverageSummary](https://github.com/irongut/CodeCoverageSummary) generated in this PR was fairly straightforward to set up and is configurable. This means we can set a threshold for coverage to meet without the causing the action to fail (and whether or not it can trigger a failure at all). 

For looking closer at the coverage itself, it is useful to have a user-friendly html render of coverage information. [Coverlet ](https://github.com/coverlet-coverage/coverlet)first generates an xml file that contains relevant coverage information, and [ReportGenerator](https://github.com/danielpalme/ReportGenerator?tab=readme-ov-file) then converts it into navigable html. The report includes cyclomatic complexity, [CRAP score](https://testing.googleblog.com/2011/02/this-code-is-crap.html), line coverage and branch coverage. You can easily see which lines are coverable, covered, and uncovered across tested files. Coverlet seems to be widely used ([410.3M downloads](https://www.nuget.org/packages/coverlet.collector/3.1.1) on NuGet), well [documented](https://github.com/coverlet-coverage/coverlet/tree/master/Documentation), and can be configured as a global tool. ReportGenerator is flexible and can be used to generate reports from various formats, including for our use case.

There is sometimes a slight discrepancy between what coverlet and the GH action coverage summary find, but it looks to be small.

See `readme` for information on running the full code coverage report locally. Rendered HTML should look like this:

![Screenshot 2024-06-30 at 9 39 33 PM](https://github.com/nightingaleproject/vital-records-dotnet/assets/35311744/e568005c-9e34-42d3-ae84-c634d8b734f2)
