### PR TITLE
fix(bfdr): align fetal death software with IG

### DIFF
--- a/projects/BFDR.Tests/BirthRecord_Should.cs
+++ b/projects/BFDR.Tests/BirthRecord_Should.cs
@@ -846,6 +846,18 @@ namespace BFDR.Tests
       // Child's Surname Suffix
       record.ChildSuffix = "III";
       Assert.Equal("III", record.ChildSuffix);
+
+      // test missing family name
+      Assert.Equal("Quinn", record.ChildFamilyName);
+      Assert.Null(record.GetFamilyNameAbsentDataReason());
+      record.ChildFamilyName = ""; //set family name to empty 
+      Assert.Equal("", record.ChildFamilyName);
+      Assert.Equal("temp-unknown", record.GetFamilyNameAbsentDataReason());
+      record.ChildFamilyName = null; //set family name to null 
+      Assert.Null(record.ChildFamilyName);
+      Assert.Equal("temp-unknown", record.GetFamilyNameAbsentDataReason());
+      IJEBirth ije2 = new(record);
+      Assert.Equal("", ije2.KIDLNAME.Trim(' '));
     }
 
     [Fact]

--- a/projects/BFDR.Tests/FetalDeathRecord_Should.cs
+++ b/projects/BFDR.Tests/FetalDeathRecord_Should.cs
@@ -70,38 +70,38 @@ namespace BFDR.Tests
     public void SetAutopsyPerformedIndicator()
     {
         Dictionary<string, string> cc = new Dictionary<string, string>();
-        cc.Add("code", VR.ValueSets.YesNoUnknown.Codes[1, 0]);
-        cc.Add("system", VR.ValueSets.YesNoUnknown.Codes[1, 2]);
-        cc.Add("display", VR.ValueSets.YesNoUnknown.Codes[1, 1]);
+        cc.Add("code", BFDR.ValueSets.PerformedNotPerformedPlanned.Codes[1, 0]);
+        cc.Add("system", BFDR.ValueSets.PerformedNotPerformedPlanned.Codes[1, 2]);
+        cc.Add("display", BFDR.ValueSets.PerformedNotPerformedPlanned.Codes[1, 1]);
         SetterFetalDeathRecord.AutopsyPerformedIndicator = cc;
-        Assert.Equal("Y", SetterFetalDeathRecord.AutopsyPerformedIndicator["code"]);
-        Assert.Equal(VR.CodeSystems.YesNo, SetterFetalDeathRecord.AutopsyPerformedIndicator["system"]);
-        Assert.Equal("Yes", SetterFetalDeathRecord.AutopsyPerformedIndicator["display"]);
-        Assert.Equal("Y", SetterFetalDeathRecord.AutopsyPerformedIndicatorHelper);
-        SetterFetalDeathRecord.AutopsyPerformedIndicatorHelper = "N";
-        Assert.Equal("N", SetterFetalDeathRecord.AutopsyPerformedIndicator["code"]);
-        Assert.Equal(VR.CodeSystems.YesNo, SetterFetalDeathRecord.AutopsyPerformedIndicator["system"]);
-        Assert.Equal("No", SetterFetalDeathRecord.AutopsyPerformedIndicator["display"]);
-        Assert.Equal("N", SetterFetalDeathRecord.AutopsyPerformedIndicatorHelper);
-        SetterFetalDeathRecord.AutopsyPerformedIndicatorHelper = "UNK";
-        Assert.Equal("UNK", SetterFetalDeathRecord.AutopsyPerformedIndicator["code"]);
-        Assert.Equal(VR.CodeSystems.NullFlavor_HL7_V3, SetterFetalDeathRecord.AutopsyPerformedIndicator["system"]);
-        Assert.Equal("unknown", SetterFetalDeathRecord.AutopsyPerformedIndicator["display"]);
-        Assert.Equal("UNK", SetterFetalDeathRecord.AutopsyPerformedIndicatorHelper);
+        Assert.Equal("262008008", SetterFetalDeathRecord.AutopsyPerformedIndicator["code"]);
+        Assert.Equal(VR.CodeSystems.SCT, SetterFetalDeathRecord.AutopsyPerformedIndicator["system"]);
+        Assert.Equal("Not Performed", SetterFetalDeathRecord.AutopsyPerformedIndicator["display"]);
+        Assert.Equal("262008008", SetterFetalDeathRecord.AutopsyPerformedIndicatorHelper);
+        SetterFetalDeathRecord.AutopsyPerformedIndicatorHelper = "398166005";
+        Assert.Equal("398166005", SetterFetalDeathRecord.AutopsyPerformedIndicator["code"]);
+        Assert.Equal(VR.CodeSystems.SCT, SetterFetalDeathRecord.AutopsyPerformedIndicator["system"]);
+        Assert.Equal("Performed", SetterFetalDeathRecord.AutopsyPerformedIndicator["display"]);
+        Assert.Equal("398166005", SetterFetalDeathRecord.AutopsyPerformedIndicatorHelper);
+        SetterFetalDeathRecord.AutopsyPerformedIndicatorHelper = "397943006";
+        Assert.Equal("397943006", SetterFetalDeathRecord.AutopsyPerformedIndicator["code"]);
+        Assert.Equal(VR.CodeSystems.SCT, SetterFetalDeathRecord.AutopsyPerformedIndicator["system"]);
+        Assert.Equal("Planned", SetterFetalDeathRecord.AutopsyPerformedIndicator["display"]);
+        Assert.Equal("397943006", SetterFetalDeathRecord.AutopsyPerformedIndicatorHelper);
 
         IJEFetalDeath ije = new IJEFetalDeath();
         ije.AUTOP = "N";
         FetalDeathRecord fetalDeathRecord2 = ije.ToFetalDeathRecord();
-        Assert.Equal("N", fetalDeathRecord2.AutopsyPerformedIndicatorHelper);
+        Assert.Equal("262008008", fetalDeathRecord2.AutopsyPerformedIndicatorHelper);
     }
 
     [Fact]
     public void GetAutopsyPerformedIndicator()
     {
-        Assert.Equal(VR.ValueSets.YesNoUnknown.Yes, BasicFetalDeathRecord.AutopsyPerformedIndicatorHelper);
-        Assert.Equal("Y", BasicFetalDeathRecord.AutopsyPerformedIndicator["code"]);
-        Assert.Equal(VR.CodeSystems.YesNo, BasicFetalDeathRecord.AutopsyPerformedIndicator["system"]);
-        Assert.Equal("Yes", BasicFetalDeathRecord.AutopsyPerformedIndicator["display"]);
+        Assert.Equal(BFDR.ValueSets.PerformedNotPerformedPlanned.Performed, BasicFetalDeathRecord.AutopsyPerformedIndicatorHelper);
+        Assert.Equal("398166005", BasicFetalDeathRecord.AutopsyPerformedIndicator["code"]);
+        Assert.Equal(VR.CodeSystems.SCT, BasicFetalDeathRecord.AutopsyPerformedIndicator["system"]);
+        Assert.Equal("Performed", BasicFetalDeathRecord.AutopsyPerformedIndicator["display"]);
     }
 
     [Fact]
@@ -1462,6 +1462,18 @@ namespace BFDR.Tests
       Assert.Equal("C", ije.FETLNAME.Trim(' '));
       ije.SUFFIX = "D";
       Assert.Equal("D", ije.SUFFIX.Trim(' '));
+
+      // test missing family name
+      Assert.Equal("Quinn", record.FetusFamilyName);
+      Assert.Null(record.GetFamilyNameAbsentDataReason());
+      record.FetusFamilyName = ""; //set family name to empty 
+      Assert.Equal("", record.FetusFamilyName);
+      Assert.Equal("unknown", record.GetFamilyNameAbsentDataReason());
+      record.FetusFamilyName = null; //set family name to null 
+      Assert.Null(record.FetusFamilyName);
+      Assert.Equal("unknown", record.GetFamilyNameAbsentDataReason());
+      IJEFetalDeath ije2 = new(record);
+      Assert.Equal("", ije2.FETLNAME.Trim(' '));
     }
 
     // FHIR manages names in a way that there is a fundamental incompatibility with IJE: the "middle name" is the second element in

--- a/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecord.json
+++ b/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecord.json
@@ -321,9 +321,9 @@
         "valueCodeableConcept": {
           "coding": [
             {
-              "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
-              "code": "Y",
-              "display": "Yes"
+              "system" : "http://snomed.info/sct",
+              "code" : "398166005",
+              "display" : "Performed"
             }
           ]
         }

--- a/projects/BFDR.Tests/fixtures/json/FetalDeathReport.json
+++ b/projects/BFDR.Tests/fixtures/json/FetalDeathReport.json
@@ -1607,9 +1607,9 @@
         "valueCodeableConcept": {
           "coding": [
             {
-              "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
-              "code": "Y",
-              "display": "Yes"
+              "system" : "http://snomed.info/sct",
+              "code" : "398166005",
+              "display" : "Performed"
             }
           ]
         }

--- a/projects/BFDR/BFDR.xml
+++ b/projects/BFDR/BFDR.xml
@@ -33,6 +33,46 @@
         <member name="M:BFDR.BirthRecord.InitializeCompositionAndSubject">
             <inheritdoc/>
         </member>
+        <member name="P:BFDR.BirthRecord.CertificationDate">
+            <summary>Date of Certification.</summary>
+            <value>the date of certification</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.CertifiedDate = "2023-02-19";</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Date of birth certification: {ExampleBirthRecord.CertificationDate}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.CertifiedYear">
+            <summary>Certified Year</summary>
+            <value>year of certification</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.CertifiedYear = 2023;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Certified Year: {ExampleBirthRecord.CertifiedYear}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.CertifiedMonth">
+            <summary>Certified Month</summary>
+            <value>month of certification</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.CertifiedMonth = 10;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Certified Month: {ExampleBirthRecord.CertifiedMonth}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.CertifiedDay">
+            <summary>Certified Day</summary>
+            <value>day of certification</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.CertifiedDay = 23;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Certified Day: {ExampleBirthRecord.CertifiedDay}");</para>
+            </example> 
+        </member>
         <member name="P:BFDR.BirthRecord.BirthPhysicalLocation">
             <summary>Child's Place Of Birth Type.</summary>
             <value>Place Where Birth Occurred, type of place or institution. A Dictionary representing a codeable concept of the physical location type:
@@ -227,6 +267,46 @@
         </member>
         <member name="M:BFDR.FetalDeathRecord.InitializeCompositionAndSubject">
             <inheritdoc/>
+        </member>
+        <member name="P:BFDR.FetalDeathRecord.CertificationDate">
+            <summary>Date of Certification.</summary>
+            <value>the date of certification</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleFetalDeathRecord.CertifiedDate = "2023-02-19";</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Date of certification: {ExampleFetalDeathRecord.CertificationDate}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.FetalDeathRecord.CertifiedYear">
+            <summary>Certified Year</summary>
+            <value>year of certification</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleFetalDeathRecord.CertifiedYear = 2023;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Certified Year: {ExampleFetalDeathRecord.CertifiedYear}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.FetalDeathRecord.CertifiedMonth">
+            <summary>Certified Month</summary>
+            <value>month of certification</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleFetalDeathRecord.CertifiedMonth = 10;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Certified Month: {ExampleFetalDeathRecord.CertifiedMonth}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.FetalDeathRecord.CertifiedDay">
+            <summary>Certified Day</summary>
+            <value>day of certification</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleFetalDeathRecord.CertifiedDay = 23;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Certified Day: {ExampleFetalDeathRecord.CertifiedDay}");</para>
+            </example> 
         </member>
         <member name="P:BFDR.FetalDeathRecord.FetusGivenNames">
             <summary>Fetus Legal Name - Given. Middle name should be the last entry.</summary>
@@ -3290,6 +3370,9 @@
         <member name="M:BFDR.NatalityRecord.CreateBirthEncounter">
             <summary>Create Birth Encounter.</summary>
         </member>
+        <member name="M:BFDR.NatalityRecord.CreateMaternityEncounter">
+            <summary>Create Maternity Encounter.</summary>
+        </member>
         <member name="P:BFDR.NatalityRecord.CertificateNumber">
             <summary>Certificate Number.</summary>
             <value>a record identification string.</value>
@@ -3485,6 +3568,12 @@
             <para>// Getter:</para>
             <para>Console.WriteLine($"Father Family Name(s): {string.Join(", ", ExampleBirthRecord.FatherFamilyName)}");</para>
             </example>
+        </member>
+        <member name="M:BFDR.NatalityRecord.GetFamilyNameAbsentDataReason">
+            <summary>
+             Helper method that gets the child or decedent fetus data absent reason code
+            </summary>
+            <returns>data absent reason code for last name</returns>
         </member>
         <member name="P:BFDR.NatalityRecord.MotherMaidenFamilyName">
             <summary>Mother's Maiden Name - Last.</summary>
@@ -6269,7 +6358,7 @@
         </member>
         <member name="P:BFDR.NatalityRecord.RegistrationDate">
             <summary>Date of Registration.</summary>
-            <value>the date that the birth was registered</value>
+            <value>the date that the birth/fetal death was registered</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleBirthRecord.RegistrationDate = "2023-02-19";</para>
@@ -6279,7 +6368,7 @@
         </member>
         <member name="P:BFDR.NatalityRecord.RegistrationDateYear">
             <summary>Year of Registration.</summary>
-            <value>the year that the birth was registered</value>
+            <value>the year that the birth/fetal death was registered</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleBirthRecord.RegistrationDateYear = 2023;</para>
@@ -6289,7 +6378,7 @@
         </member>
         <member name="P:BFDR.NatalityRecord.RegistrationDateMonth">
             <summary>Month of Registration.</summary>
-            <value>the month that the birth was registered</value>
+            <value>the month that the birth/fetal death was registered</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleBirthRecord.RegistrationDateMonth = 10;</para>
@@ -6299,7 +6388,7 @@
         </member>
         <member name="P:BFDR.NatalityRecord.RegistrationDateDay">
             <summary>Day of Registration.</summary>
-            <value>the day that the birth was registered</value>
+            <value>the day that the birth/fetal death was registered</value>
             <example>
             <para>// Setter:</para>
             <para>ExampleBirthRecord.RegistrationDateDay = 23;</para>
@@ -6516,46 +6605,6 @@
             <para>// Getter:</para>
             <para>Console.WriteLine($"Certifier Other: {ExampleBirthRecord.CertifierOtherHelper}");</para>
             </example>
-        </member>
-        <member name="P:BFDR.NatalityRecord.CertificationDate">
-            <summary>Date of Certification.</summary>
-            <value>the date of certification</value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleBirthRecord.CertifiedDate = "2023-02-19";</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Date of birth certification: {ExampleBirthRecord.CertificationDate}");</para>
-            </example>
-        </member>
-        <member name="P:BFDR.NatalityRecord.CertifiedYear">
-            <summary>Certified Year</summary>
-            <value>year of certification</value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleBirthRecord.CertifiedYear = 2023;</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Certified Year: {ExampleBirthRecord.CertifiedYear}");</para>
-            </example>
-        </member>
-        <member name="P:BFDR.NatalityRecord.CertifiedMonth">
-            <summary>Certified Month</summary>
-            <value>month of certification</value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleBirthRecord.CertifiedMonth = 10;</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Certified Month: {ExampleBirthRecord.CertifiedMonth}");</para>
-            </example>
-        </member>
-        <member name="P:BFDR.NatalityRecord.CertifiedDay">
-            <summary>Certified Day</summary>
-            <value>day of certification</value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleBirthRecord.CertifiedDay = 23;</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Certified Day: {ExampleBirthRecord.CertifiedDay}");</para>
-            </example> 
         </member>
         <member name="M:BFDR.NatalityRecord.SetEmergingIssue(System.String,System.String)">
             <summary>Set an emerging issue value, creating an empty EmergingIssues Observation as needed.</summary>

--- a/projects/BFDR/FetalDeathRecord.cs
+++ b/projects/BFDR/FetalDeathRecord.cs
@@ -72,6 +72,253 @@ namespace BFDR
             Composition.Title = "Fetal Death Report";
         }
 
+        /// <summary>Date of Certification.</summary>
+        /// <value>the date of certification</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleFetalDeathRecord.CertifiedDate = "2023-02-19";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Date of certification: {ExampleFetalDeathRecord.CertificationDate}");</para>
+        /// </example>
+        [Property("CertificationDate", Property.Types.String, "Fetal Death Certification", "Date of Certification.", true, BFDR.IGURL.CompositionProviderFetalDeathReport, true, 243)]
+        [FHIRPath("Bundle.entry.resource.where($this is Encounter).where(extension.value.coding.code='MTH')", "")]
+        public string CertificationDate
+        {
+            get
+            {
+                Encounter.ParticipantComponent certifier = EncounterMaternity?.Participant?.FirstOrDefault(entry => ((Encounter.ParticipantComponent)entry).Type.Any(t => t.Coding.Any(c => c.Code == "87287-9")));
+                if (certifier != null && certifier?.Period?.Start != null)
+                {
+                    return certifier.Period.Start;
+                }
+                return null;
+            }
+            set
+            {
+                Encounter.ParticipantComponent certifier = EncounterMaternity.Participant.FirstOrDefault(entry => ((Encounter.ParticipantComponent)entry).Type.Any(t => t.Coding.Any(c => c.Code == "87287-9")));
+                if (certifier != null)
+                {
+                    Period p = new Period();
+                    p.StartElement = ConvertToDateTime(value);
+                    certifier.Period = p;
+                }
+                else
+                {
+                    Encounter.ParticipantComponent newCertifier = new Encounter.ParticipantComponent();
+                    CodeableConcept t = new CodeableConcept(CodeSystems.LOINC, "87287-9", "Birth certifier", null);
+                    newCertifier.Type.Add(t);
+                    Period p = new Period();
+                    p.StartElement = ConvertToDateTime(value);
+                    newCertifier.Period = p;
+                    EncounterMaternity.Participant.Add(newCertifier);
+                }
+            }
+        }
+
+        /// <summary>Certified Year</summary>
+        /// <value>year of certification</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleFetalDeathRecord.CertifiedYear = 2023;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Certified Year: {ExampleFetalDeathRecord.CertifiedYear}");</para>
+        /// </example>
+        [Property("Certified Year", Property.Types.Int32, "Fetal Death Certification", "Certified Year", true, IGURL.EncounterMaternity, true, 4)]
+        [FHIRPath("Bundle.entry.resource.where($this is Encounter).where(extension.value.coding.code='MTH')", "")] 
+        public int? CertifiedYear
+        {
+            get
+            {
+                if (EncounterMaternity == null)
+                {
+                    return null;
+                }
+                Encounter.ParticipantComponent certifier = EncounterMaternity.Participant.FirstOrDefault(entry => ((Encounter.ParticipantComponent)entry).Type.Any(t => t.Coding.Any(c => c.Code == "87287-9")));
+                // First check the value string
+                if (certifier == null || certifier.Period == null || certifier.Period.StartElement == null)
+                {
+                    return null;
+                }
+                if (certifier != null && certifier.Period.StartElement != null && ParseDateElements(certifier.Period.Start, out int? year, out int? month, out int? day))
+                {
+                    return year;
+                }
+                return GetDateFragmentOrPartialDate(certifier.Period.StartElement, VR.ExtensionURL.PartialDateTimeYearVR);
+            }
+            set
+            {
+                if (value == null)
+                {
+                    return;
+                }
+                if (EncounterMaternity == null)
+                {
+                    CreateMaternityEncounter();
+                }
+                Encounter.ParticipantComponent stateComp = EncounterMaternity.Participant.FirstOrDefault(entry => ((Encounter.ParticipantComponent)entry).Type.Any(t => t.Coding.Any(c => c.Code == "87287-9")));
+                if (stateComp == null) // make certifier participant with date
+                {  
+                    Encounter.ParticipantComponent certifier = new Encounter.ParticipantComponent();
+                    CodeableConcept t = new CodeableConcept(CodeSystems.LOINC, "87287-9", "Birth certifier", null);
+                    certifier.Type.Add(t);
+                    Period p = new Period();
+                    p.StartElement = new FhirDateTime();
+                    p.StartElement.Extension.Add(NewBlankPartialDateTimeExtension(false));
+                    certifier.Period = p;
+                    EncounterMaternity.Participant.Add(certifier);
+                    stateComp = certifier;
+                }  
+                if (stateComp.Period == null || stateComp.Period.StartElement == null) //certifier participant exists but no period or period.start
+                {
+                    Period p = new Period();
+                    p.StartElement = new FhirDateTime();
+                    p.StartElement.Extension.Add(NewBlankPartialDateTimeExtension(false));
+                    stateComp.Period = p;
+                }
+                FhirDateTime newDate = SetYear(value, stateComp.Period.StartElement);
+                if (newDate != null)
+                {
+                    stateComp.Period.StartElement = newDate;
+                }
+            }
+        }
+
+        /// <summary>Certified Month</summary>
+        /// <value>month of certification</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleFetalDeathRecord.CertifiedMonth = 10;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Certified Month: {ExampleFetalDeathRecord.CertifiedMonth}");</para>
+        /// </example>
+        [Property("Certified Month", Property.Types.Int32, "Fetal Death Certification", "Certified Month", true, IGURL.EncounterMaternity, true, 4)]
+        [FHIRPath("Bundle.entry.resource.where($this is Encounter).where(extension.value.coding.code='MTH')", "")] 
+        public int? CertifiedMonth
+        {
+            get
+            {
+                if (EncounterMaternity == null)
+                {
+                    return null;
+                }
+                Encounter.ParticipantComponent certifier = EncounterMaternity.Participant.FirstOrDefault(entry => ((Encounter.ParticipantComponent)entry).Type.Any(t => t.Coding.Any(c => c.Code == "87287-9")));
+                // First check the value string
+                if (certifier == null || certifier.Period == null || certifier.Period.StartElement == null)
+                {
+                    return null;
+                }
+                if (certifier != null && certifier.Period.StartElement != null && ParseDateElements(certifier.Period.Start, out int? year, out int? month, out int? day))
+                {
+                    return month;
+                }
+                return GetDateFragmentOrPartialDate(certifier.Period.StartElement, VR.ExtensionURL.PartialDateTimeMonthVR);
+            }
+            set
+            {
+                if (value == null)
+                {
+                    return;
+                }
+                if (EncounterMaternity == null)
+                {
+                    CreateMaternityEncounter();
+                }
+                Encounter.ParticipantComponent stateComp = EncounterMaternity.Participant.FirstOrDefault(entry => ((Encounter.ParticipantComponent)entry).Type.Any(t => t.Coding.Any(c => c.Code == "87287-9")));
+                if (stateComp == null) // make certifier participant with date
+                {  
+                    Encounter.ParticipantComponent certifier = new Encounter.ParticipantComponent();
+                    CodeableConcept t = new CodeableConcept(CodeSystems.LOINC, "87287-9", "Birth certifier", null);
+                    certifier.Type.Add(t);
+                    Period p = new Period();
+                    p.StartElement = new FhirDateTime();
+                    p.StartElement.Extension.Add(NewBlankPartialDateTimeExtension(false));
+                    certifier.Period = p;
+                    EncounterMaternity.Participant.Add(certifier);
+                    stateComp = certifier;
+                }  
+                if (stateComp.Period == null || stateComp.Period.StartElement == null) //certifier participant exists but no period or period.start
+                {
+                    Period p = new Period();
+                    p.StartElement = new FhirDateTime();
+                    p.StartElement.Extension.Add(NewBlankPartialDateTimeExtension(false));
+                    stateComp.Period = p;
+                }
+                FhirDateTime newDate = SetMonth(value, stateComp.Period.StartElement); 
+                if (newDate != null)
+                {
+                    stateComp.Period.StartElement = newDate; 
+                }
+            }
+        }
+
+        /// <summary>Certified Day</summary>
+        /// <value>day of certification</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleFetalDeathRecord.CertifiedDay = 23;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Certified Day: {ExampleFetalDeathRecord.CertifiedDay}");</para>
+        /// </example> 
+        [Property("Certified Day", Property.Types.Int32, "Fetal Death Certification", "Certified Day", true, IGURL.EncounterMaternity, true, 4)]
+        [FHIRPath("Bundle.entry.resource.where($this is Encounter).where(extension.value.coding.code='MTH')", "")] 
+        public int? CertifiedDay
+        {
+            get
+            {
+                if (EncounterMaternity == null)
+                {
+                    return null;
+                }
+                Encounter.ParticipantComponent certifier = EncounterMaternity.Participant.FirstOrDefault(entry => ((Encounter.ParticipantComponent)entry).Type.Any(t => t.Coding.Any(c => c.Code == "87287-9")));
+                // First check the value string
+                if (certifier == null || certifier.Period == null || certifier.Period.StartElement == null)
+                {
+                    return null;
+                }
+                if (certifier != null && certifier.Period.StartElement != null && ParseDateElements(certifier.Period.Start, out int? year, out int? month, out int? day))
+                {
+                    return day;
+                }
+                return GetDateFragmentOrPartialDate(certifier.Period.StartElement, VR.ExtensionURL.PartialDateTimeDayVR);
+            }
+            set
+            {
+                if (value == null)
+                {
+                    return;
+                }
+                if (EncounterMaternity == null)
+                {
+                    CreateMaternityEncounter();
+                }
+                Encounter.ParticipantComponent stateComp = EncounterMaternity.Participant.FirstOrDefault(entry => ((Encounter.ParticipantComponent)entry).Type.Any(t => t.Coding.Any(c => c.Code == "87287-9")));
+                if (stateComp == null) // make certifier participant with date
+                {  
+                    Encounter.ParticipantComponent certifier = new Encounter.ParticipantComponent();
+                    CodeableConcept t = new CodeableConcept(CodeSystems.LOINC, "87287-9", "Birth certifier", null);
+                    certifier.Type.Add(t);
+                    Period p = new Period();
+                    p.StartElement = new FhirDateTime();
+                    p.StartElement.Extension.Add(NewBlankPartialDateTimeExtension(false));
+                    certifier.Period = p;
+                    EncounterMaternity.Participant.Add(certifier);
+                    stateComp = certifier;
+                }  
+                if (stateComp.Period == null || stateComp.Period.StartElement == null) //certifier participant exists but no period or period.start
+                {
+                    Period p = new Period();
+                    p.StartElement = new FhirDateTime();
+                    p.StartElement.Extension.Add(NewBlankPartialDateTimeExtension(false));
+                    stateComp.Period = p;
+                }
+                FhirDateTime newDate = SetDay(value, stateComp.Period.StartElement); 
+                if (newDate != null)
+                {
+                    stateComp.Period.StartElement = newDate; 
+                }
+            }
+        }
+
         /// <summary>Fetus Legal Name - Given. Middle name should be the last entry.</summary>
         /// <value>the fetus' name (first, etc., middle)</value>
         /// <example>
@@ -467,7 +714,7 @@ namespace BFDR
         public string AutopsyPerformedIndicatorHelper
         {
             get => GetObservationValueHelper();
-            set => SetObservationValueHelper(value, VR.ValueSets.YesNoUnknown.Codes);
+            set => SetObservationValueHelper(value, BFDR.ValueSets.PerformedNotPerformedPlanned.Codes);
         }
 
         /// <summary>Histological Placental Exam Performed.</summary>

--- a/projects/BFDR/IJEFetalDeath.cs
+++ b/projects/BFDR/IJEFetalDeath.cs
@@ -200,13 +200,13 @@ namespace BFDR
         {
             get
             {
-                return Dictionary_Geo_Get("DSTATE", "PlaceOfDelivery", "address", "state", true);
+                return Dictionary_Geo_Get("DSTATE", "PlaceOfBirth", "address", "state", true);
             }
             set
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
-                    Dictionary_Set("DSTATE", "PlaceOfDelivery", "addressState", value);
+                    Dictionary_Set("DSTATE", "PlaceOfBirth", "addressState", value);
                 }
             }
         }
@@ -217,12 +217,23 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
+                if (String.IsNullOrWhiteSpace(record?.CertificateNumber))
+                {
+                    return "".PadLeft(6, '0');
+                }
+                string id_str = record.CertificateNumber;
+                if (id_str.Length > 6)
+                {
+                    id_str = id_str.Substring(id_str.Length - 6);
+                }
+                return id_str.PadLeft(6, '0');
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    RightJustifiedZeroed_Set("FILENO", "CertificateNumber", value.Trim());
+                }
             }
         }
 
@@ -247,12 +258,23 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
-                return "";
+                if (String.IsNullOrWhiteSpace(record?.StateLocalIdentifier1))
+                {
+                    return "".PadLeft(12, '0');
+                }
+                string auxNo = record.StateLocalIdentifier1;
+                if (auxNo.Length > 12)
+                {
+                    auxNo = auxNo.Substring(auxNo.Length - 12);
+                }
+                return auxNo.PadLeft(12, '0');
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    RightJustifiedZeroed_Set("AUXNO", "StateLocalIdentifier1", value.Trim());
+                }
             }
         }
 
@@ -2322,13 +2344,13 @@ namespace BFDR
         {
             get
             {
-                return Get_MappingFHIRToIJE(VR.Mappings.YesNoUnknown.FHIRToIJE, "AutopsyPerformedIndicator", "AUTOP");
+                return Get_MappingFHIRToIJE(BFDR.Mappings.PerformedNotPerformedPlanned.FHIRToIJE, "AutopsyPerformedIndicator", "AUTOP");
             }
             set
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
-                    Set_MappingIJEToFHIR(VR.Mappings.YesNoUnknown.IJEToFHIR, "AUTOP", "AutopsyPerformedIndicator", value);
+                    Set_MappingIJEToFHIR(BFDR.Mappings.PerformedNotPerformedPlanned.IJEToFHIR, "AUTOP", "AutopsyPerformedIndicator", value);
                 }
             }
         }

--- a/projects/BFDR/NatalityRecord_fieldsAndCreateMethods.cs
+++ b/projects/BFDR/NatalityRecord_fieldsAndCreateMethods.cs
@@ -171,6 +171,18 @@ namespace BFDR
             Extension roleExt = new Extension(VRExtensionURLs.Role, new CodeableConcept(CodeSystems.RoleCode_HL7_V3, "CHILD"));
             EncounterBirth.Extension.Add(roleExt);
         }
+
+        /// <summary>Create Maternity Encounter.</summary>
+        protected void CreateMaternityEncounter()
+        {
+            EncounterMaternity = new Encounter();
+            EncounterMaternity .Id = Guid.NewGuid().ToString();
+            EncounterMaternity .Meta = new Meta();
+            string[] encounterBirth_profile = { ProfileURL.EncounterMaternity };
+            EncounterMaternity .Meta.Profile = encounterBirth_profile;
+            Extension roleExt = new Extension(VRExtensionURLs.Role, new CodeableConcept(CodeSystems.RoleCode_HL7_V3, "MTH"));
+            EncounterMaternity.Extension.Add(roleExt);
+        }
     }
 
     /// <summary>Describes the subject of a birth record field</summary>

--- a/projects/BFDR/NatalityRecord_submissionProperties.cs
+++ b/projects/BFDR/NatalityRecord_submissionProperties.cs
@@ -136,7 +136,7 @@ namespace BFDR
                 }
             }
         }
-        
+
         /// <summary>
         ///  Getter method for child or decedent fetus birth/delivery year.
         /// </summary>
@@ -230,8 +230,8 @@ namespace BFDR
                 Subject.BirthDateElement = newDate;
             }
             this.SetBirthTime(time);
-        }        
-        
+        }
+
         /// <summary>
         ///  Getter method for child or decedent fetus birth/delivery day.
         /// </summary>
@@ -399,12 +399,12 @@ namespace BFDR
                 {
                     return (sex.Value as Code).Value;
                 }
-                
+
                 return null;
             }
             return null;
         }
-        
+
         /// <summary>
         ///  Setter method for child or decedent fetus birth/delivery sex.
         /// </summary>
@@ -417,7 +417,7 @@ namespace BFDR
             }
             Subject.Extension.RemoveAll(ext => ext.Url == VR.OtherExtensionURL.BirthSex);
             Subject.SetExtension(VR.OtherExtensionURL.BirthSex, new Code(value));
-            
+
         }
 
         /// <summary>Child's Legal Name - Given. Middle name should be the last entry.</summary>
@@ -592,6 +592,20 @@ namespace BFDR
             {
                 updateFamilyName(value, Father.Name);
             }
+        }
+
+        /// <summary>
+        ///  Helper method that gets the child or decedent fetus data absent reason code
+        /// </summary>
+        /// <returns>data absent reason code for last name</returns>
+        public string GetFamilyNameAbsentDataReason()
+        {
+            Extension dataAbsentOnValue = Subject?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.FamilyElement.Extension?.Find(ext => ext.Url == OtherExtensionURL.DataAbsentReason);
+            if (dataAbsentOnValue != null)
+            {
+                return ((Code)dataAbsentOnValue.Value).Value;
+            }
+            return null;
         }
 
         /// <summary>Mother's Maiden Name - Last.</summary>
@@ -1304,10 +1318,10 @@ namespace BFDR
                 {
                     ids.RemoveAll(id => id.Type.Coding.Any(idCoding => idCoding.System == CodeSystems.HL7_identifier_type && idCoding.Code == "SS"));
                 }
-                else 
+                else
                 {
-                ids.Find(id => id.Type.Coding.Any(idCoding => idCoding.System == CodeSystems.HL7_identifier_type && idCoding.Code == "SS")).Value = ssn;
-                } 
+                    ids.Find(id => id.Type.Coding.Any(idCoding => idCoding.System == CodeSystems.HL7_identifier_type && idCoding.Code == "SS")).Value = ssn;
+                }
             }
             else if (String.IsNullOrWhiteSpace(ssn))
             {
@@ -1387,7 +1401,7 @@ namespace BFDR
             }
             return null;
         }
-        
+
         /// <summary>
         ///  Setter method for child or decedent fetus set order.
         /// </summary>
@@ -1430,7 +1444,7 @@ namespace BFDR
             }
             return EmptyCodeableDict();
         }
-        
+
         /// <summary>
         ///  Setter method for child or decedent fetus plurality edit flag.
         /// </summary>
@@ -1460,7 +1474,7 @@ namespace BFDR
             }
             return null;
         }
-        
+
         /// <summary>
         ///  Helper method for setting child or decedent fetus plurality edit flag.
         /// </summary>
@@ -1495,7 +1509,7 @@ namespace BFDR
             }
             return null;
         }
-        
+
         /// <summary>
         ///  Setter method for child or decedent fetus plurality.
         /// </summary>
@@ -2186,7 +2200,7 @@ namespace BFDR
                 fhirPath.Code = coding.Code;
                 fhirPath.CodeSystem = coding.System;
                 fhirPath.Display = coding.Display;
-               CreateEntry(fhirPath, SubjectId());
+                CreateEntry(fhirPath, SubjectId());
             }
         }
 
@@ -2253,12 +2267,12 @@ namespace BFDR
                 {
                     return CodeableConceptToDict((CodeableConcept)obs.Value);
                 }
-                return EmptyCodeableDict();  
+                return EmptyCodeableDict();
             }
             set
             {
                 Observation obs = GetOrCreateObservation("73761-9", CodeSystems.LOINC, "Fetal Presentation", BFDR.ProfileURL.ObservationFetalPresentation, MEDICAL_INFORMATION_SECTION);
-                obs.Value = DictToCodeableConcept(value);   
+                obs.Value = DictToCodeableConcept(value);
             }
         }
 
@@ -2290,7 +2304,7 @@ namespace BFDR
                 {
                     SetCodeValue("FetalPresentation", value, BFDR.ValueSets.FetalPresentations.Codes);
                 }
-                
+
             }
         }
 
@@ -2347,7 +2361,7 @@ namespace BFDR
                 {
                     return (obs.Value as Hl7.Fhir.Model.Integer).Value;
                 }
-                
+
                 return null;
             }
             set
@@ -2418,7 +2432,7 @@ namespace BFDR
             }
             set
             {
-                if(!String.IsNullOrWhiteSpace(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     SetCodeValue("NumberOfPreviousCesareansEditFlag", value, BFDR.ValueSets.NumberPreviousCesareansEditFlags.Codes);
                 }
@@ -3108,7 +3122,8 @@ namespace BFDR
             }
             set
             {
-                if (value["code"] == "") {
+                if (value["code"] == "")
+                {
                     return;
                 }
                 Observation obs = GetOrCreateObservation("inputraceandethnicityMother", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
@@ -3187,7 +3202,8 @@ namespace BFDR
             }
             set
             {
-                if (value["code"] == "") {
+                if (value["code"] == "")
+                {
                     return;
                 }
                 Observation obs = GetOrCreateObservation("inputraceandethnicityMother", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
@@ -3266,7 +3282,8 @@ namespace BFDR
             }
             set
             {
-                if (value["code"] == "") {
+                if (value["code"] == "")
+                {
                     return;
                 }
                 Observation obs = GetOrCreateObservation("inputraceandethnicityMother", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
@@ -3346,7 +3363,8 @@ namespace BFDR
             }
             set
             {
-                if (value["code"] == "") {
+                if (value["code"] == "")
+                {
                     return;
                 }
                 Observation obs = GetOrCreateObservation("inputraceandethnicityMother", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
@@ -3410,7 +3428,8 @@ namespace BFDR
             set => SetEthnicityLiteral(value, Mother.Id, "inputraceandethnicityMother", RACE_ETHNICITY_PROFILE_MOTHER);
         }
 
-        private string GetEthnicityLiteral(string code, string section, [CallerMemberName] string propertyName = null) {
+        private string GetEthnicityLiteral(string code, string section, [CallerMemberName] string propertyName = null)
+        {
             Observation obs = GetOrCreateObservation(code, CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, section, null, propertyName);
             Observation.ComponentComponent ethnicity = obs.Component.FirstOrDefault(c => c.Code.Coding[0].Code == NvssEthnicity.Literal);
             if (ethnicity != null && ethnicity.Value != null && ethnicity.Value as FhirString != null)
@@ -3420,7 +3439,8 @@ namespace BFDR
             return null;
         }
 
-        private void SetEthnicityLiteral(string value, string subjectId, string code, string section, [CallerMemberName] string propertyName = null) {
+        private void SetEthnicityLiteral(string value, string subjectId, string code, string section, [CallerMemberName] string propertyName = null)
+        {
             if (String.IsNullOrWhiteSpace(value))
             {
                 return;
@@ -3507,7 +3527,8 @@ namespace BFDR
             }
             set
             {
-                if (value.FirstOrDefault() == null) {
+                if (value.FirstOrDefault() == null)
+                {
                     return;
                 }
                 Observation obs = GetOrCreateObservation("inputraceandethnicityMother", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
@@ -3580,7 +3601,8 @@ namespace BFDR
             }
             set
             {
-                if (value["code"] == "") {
+                if (value["code"] == "")
+                {
                     return;
                 }
                 Observation obs = GetOrCreateObservation("inputraceandethnicityFather", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
@@ -3659,7 +3681,8 @@ namespace BFDR
             }
             set
             {
-                if (value["code"] == "") {
+                if (value["code"] == "")
+                {
                     return;
                 }
                 Observation obs = GetOrCreateObservation("inputraceandethnicityFather", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
@@ -3738,7 +3761,8 @@ namespace BFDR
             }
             set
             {
-                if (value["code"] == "") {
+                if (value["code"] == "")
+                {
                     return;
                 }
                 Observation obs = GetOrCreateObservation("inputraceandethnicityFather", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
@@ -3818,7 +3842,8 @@ namespace BFDR
             }
             set
             {
-                if (value["code"] == "") {
+                if (value["code"] == "")
+                {
                     return;
                 }
                 Observation obs = GetOrCreateObservation("inputraceandethnicityFather", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
@@ -3957,7 +3982,8 @@ namespace BFDR
             }
             set
             {
-                if (value.FirstOrDefault() == null) {
+                if (value.FirstOrDefault() == null)
+                {
                     return;
                 }
                 Observation obs = GetOrCreateObservation("inputraceandethnicityFather", CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
@@ -4000,10 +4026,11 @@ namespace BFDR
         /// and returns the corresponding codeable concept or and empty one if none are found.
         /// </para>
         /// </summary>
-        private Dictionary<string, string> GetCodedRaceEthnicity(string observationCode, string componentCode, string section, [CallerMemberName] string propertyName = null) {
+        private Dictionary<string, string> GetCodedRaceEthnicity(string observationCode, string componentCode, string section, [CallerMemberName] string propertyName = null)
+        {
             Observation obs = GetOrCreateObservation(observationCode, CodeSystems.LocalObservationCodes, "Coded Race and Ethnicity Person", VR.ProfileURL.CodedRaceAndEthnicity, section, null, propertyName);
             Observation.ComponentComponent raceEthnicity = obs.Component.FirstOrDefault(c => c.Code.Coding[0].Code == componentCode);
-            if (raceEthnicity!= null && raceEthnicity.Value != null && raceEthnicity.Value as CodeableConcept != null)
+            if (raceEthnicity != null && raceEthnicity.Value != null && raceEthnicity.Value as CodeableConcept != null)
             {
                 return CodeableConceptToDict((CodeableConcept)raceEthnicity.Value);
             }
@@ -4017,8 +4044,10 @@ namespace BFDR
         /// ComponentDisplay gives a more human readable display value for the component code.
         /// </para>
         /// </summary>
-        private void SetCodedRaceEthnicity(Dictionary<string, string>  value, string observationCode, string ComponentCode, string ComponentDisplay, string section, [CallerMemberName] string propertyName = null) {
-            if (value["code"] == "") {
+        private void SetCodedRaceEthnicity(Dictionary<string, string> value, string observationCode, string ComponentCode, string ComponentDisplay, string section, [CallerMemberName] string propertyName = null)
+        {
+            if (value["code"] == "")
+            {
                 return;
             }
             Observation obs = GetOrCreateObservation(observationCode, CodeSystems.LocalObservationCodes, "Coded Race and Ethnicity Person", VR.ProfileURL.CodedRaceAndEthnicity, section, propertyName: propertyName);
@@ -4147,7 +4176,7 @@ namespace BFDR
         }
 
 
-                /// <summary>Mother Race Tabulation 3E.</summary>
+        /// <summary>Mother Race Tabulation 3E.</summary>
         /// <value>Mother Race Tabulation 3E. A Dictionary representing a code, containing the following key/value pairs:
         /// <para>"code" - the code</para>
         /// <para>"system" - the code system this code belongs to</para>
@@ -4726,7 +4755,7 @@ namespace BFDR
                 }
             }
         }
-        
+
         /// <summary>Mother First Other Pacific Islander Code.</summary>
         /// <value>Mother First Other Pacific Islander Code. A Dictionary representing a code, containing the following key/value pairs:
         /// <para>"code" - the code</para>
@@ -5772,7 +5801,7 @@ namespace BFDR
                 }
             }
         }
-        
+
         /// <summary>Father First Other Pacific Islander Code.</summary>
         /// <value>Father First Other Pacific Islander Code. A Dictionary representing a code, containing the following key/value pairs:
         /// <para>"code" - the code</para>
@@ -6149,7 +6178,7 @@ namespace BFDR
             {
                 Observation obs = GetOrCreateObservation("68499-3", CodeSystems.LOINC, "Date of last live birth", BFDR.ProfileURL.ObservationDateOfLastLiveBirth, DATE_OF_LAST_LIVE_BIRTH, Mother.Id);
                 if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
-                {   
+                {
                     obs.Value = new FhirDateTime();
                     obs.Extension.Add(NewBlankPartialDateTimeExtension(false));
                 }
@@ -6188,7 +6217,7 @@ namespace BFDR
             {
                 Observation obs = GetOrCreateObservation("68499-3", CodeSystems.LOINC, "Date of last live birth", BFDR.ProfileURL.ObservationDateOfLastLiveBirth, DATE_OF_LAST_LIVE_BIRTH, Mother.Id);
                 if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
-                {   
+                {
                     obs.Value = new FhirDateTime();
                     obs.Extension.Add(NewBlankPartialDateTimeExtension(false));
                 }
@@ -6227,7 +6256,7 @@ namespace BFDR
             {
                 Observation obs = GetOrCreateObservation("68499-3", CodeSystems.LOINC, "Date of last live birth", BFDR.ProfileURL.ObservationDateOfLastLiveBirth, DATE_OF_LAST_LIVE_BIRTH, Mother.Id);
                 if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
-                {   
+                {
                     obs.Value = new FhirDateTime();
                     obs.Extension.Add(NewBlankPartialDateTimeExtension(false));
                 }
@@ -6267,7 +6296,7 @@ namespace BFDR
                 obs.Value = ConvertToDateTime(value);
             }
         }
-        
+
         /// <summary>Date Of Last Other Pregnancy Outcome Day</summary>
         /// <value>the date of the last other pregnancy outcome day
         /// </value>
@@ -6296,7 +6325,7 @@ namespace BFDR
             {
                 Observation obs = GetOrCreateObservation("68500-8", CodeSystems.LOINC, "Date of last other pregnancy outcome", BFDR.ProfileURL.ObservationDateOfLastOtherPregnancyOutcome, DATE_OF_LAST_OTHER_PREGNANCY_OUTCOME, Mother.Id);
                 if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
-                {   
+                {
                     obs.Value = new FhirDateTime();
                     obs.Extension.Add(NewBlankPartialDateTimeExtension(false));
                 }
@@ -6487,7 +6516,7 @@ namespace BFDR
             }
             set
             {
-                if(!String.IsNullOrWhiteSpace(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     SetCodeValue("NumberOfPrenatalVisitsEditFlag", value, BFDR.ValueSets.PregnancyReportEditFlags.Codes);
                 }
@@ -6632,7 +6661,7 @@ namespace BFDR
             }
             set
             {
-                if(!String.IsNullOrWhiteSpace(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     SetCodeValue("GestationalAgeAtDeliveryEditFlag", value, BFDR.ValueSets.EstimateOfGestationEditFlags.Codes);
                 }
@@ -6652,7 +6681,7 @@ namespace BFDR
         public int? NumberOfBirthsNowDead
         {
             get => GetIntegerObservationValue("68496-9");
-            set => SetIntegerObservationValue("68496-9", CodeSystems.LOINC, value, BFDR.ProfileURL.ObservationNumberBirthsNowDead, NUMBER_OF_BIRTHS_NOW_DEAD, Mother.Id); 
+            set => SetIntegerObservationValue("68496-9", CodeSystems.LOINC, value, BFDR.ProfileURL.ObservationNumberBirthsNowDead, NUMBER_OF_BIRTHS_NOW_DEAD, Mother.Id);
         }
 
         /// <summary>NumberOfBirthsNowLiving.</summary>
@@ -6759,7 +6788,7 @@ namespace BFDR
             }
             set
             {
-                if(!String.IsNullOrWhiteSpace(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     SetCodeValue("MotherReceivedWICFood", value, VR.ValueSets.YesNoUnknown.Codes);
                 }
@@ -6789,7 +6818,7 @@ namespace BFDR
                     }
                 }
                 // blank or absent data 
-                 return null;
+                return null;
             }
             set
             {
@@ -6917,7 +6946,7 @@ namespace BFDR
                 {
                     int? weight = GetWeight(code);
                     currObs = SetWeight(code, weight, "", section, subjectId);
-                } 
+                }
                 currObs.Value.Extension.RemoveAll(ext => ext.Url == VRExtensionURLs.BypassEditFlag);
                 return;
             }
@@ -6958,8 +6987,8 @@ namespace BFDR
             {
                 // mother
                 options = BFDR.ValueSets.PregnancyReportEditFlags.Codes;
-            } 
-            else 
+            }
+            else
             {
                 Console.WriteLine("Warning: provided LOINC code for 'weight' does not correspond to mother or child.");
             }
@@ -7538,8 +7567,8 @@ namespace BFDR
         }
 
         private void SetIndustry(string role, string value)
-        {   
-            if (String.IsNullOrWhiteSpace(value)) 
+        {
+            if (String.IsNullOrWhiteSpace(value))
             {
                 return;
             }
@@ -7638,27 +7667,27 @@ namespace BFDR
         {
             get
             {
-              Observation observation = GetObservation("8302-2");
-              return (int?)(observation?.Value as Hl7.Fhir.Model.Quantity)?.Value;
+                Observation observation = GetObservation("8302-2");
+                return (int?)(observation?.Value as Hl7.Fhir.Model.Quantity)?.Value;
             }
 
             set
             {
-              Observation obs = GetOrCreateObservation("8302-2", CodeSystems.LOINC, "Mother height", BFDR.ProfileURL.ObservationMotherHeight, MOTHER_PRENATAL_SECTION, Mother.Id);
-              obs.Category.Add(new CodeableConcept(CodeSystems.ObservationCategory, "vital-signs"));
-              string unit = "in_i";
-              // Create an empty quantity if needed
-              if (obs.Value == null || obs.Value as Quantity == null)
-              {
-                obs.Value = new Hl7.Fhir.Model.Quantity();
-              }
-              // Set the properties of the value individually to preserve any existing obs.Value.Extension entries
-              if (value != null)
-              {
-                (obs.Value as Quantity).Value = (int)value;
-                (obs.Value as Quantity).Unit = unit;
-                (obs.Value as Quantity).Code = unit;
-              }
+                Observation obs = GetOrCreateObservation("8302-2", CodeSystems.LOINC, "Mother height", BFDR.ProfileURL.ObservationMotherHeight, MOTHER_PRENATAL_SECTION, Mother.Id);
+                obs.Category.Add(new CodeableConcept(CodeSystems.ObservationCategory, "vital-signs"));
+                string unit = "in_i";
+                // Create an empty quantity if needed
+                if (obs.Value == null || obs.Value as Quantity == null)
+                {
+                    obs.Value = new Hl7.Fhir.Model.Quantity();
+                }
+                // Set the properties of the value individually to preserve any existing obs.Value.Extension entries
+                if (value != null)
+                {
+                    (obs.Value as Quantity).Value = (int)value;
+                    (obs.Value as Quantity).Unit = unit;
+                    (obs.Value as Quantity).Code = unit;
+                }
             }
         }
 
@@ -7722,20 +7751,20 @@ namespace BFDR
         [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='8302-2')", "")]
         public string MotherHeightEditFlagHelper
         {
-            get 
+            get
             {
-              Dictionary<string, string> editFlag = this.MotherHeightEditFlag;
-              if (editFlag.ContainsKey("code"))
-              {
-                  string flagCode = editFlag["code"];
-                  if (!String.IsNullOrWhiteSpace(flagCode))
-                  {
-                      return flagCode;
-                  }
-              }
-              return null;
+                Dictionary<string, string> editFlag = this.MotherHeightEditFlag;
+                if (editFlag.ContainsKey("code"))
+                {
+                    string flagCode = editFlag["code"];
+                    if (!String.IsNullOrWhiteSpace(flagCode))
+                    {
+                        return flagCode;
+                    }
+                }
+                return null;
             }
-            set 
+            set
             {
                 Observation obs = GetOrCreateObservation("8302-2", CodeSystems.LOINC, "Mother Height", BFDR.ProfileURL.ObservationMotherHeight, MOTHER_PRENATAL_SECTION, Mother.Id);
                 if (obs.Value == null)
@@ -8058,7 +8087,8 @@ namespace BFDR
         }
 
         /// <summary>Helper method to return birth/delivery or transfer facility location.</summary>
-        public Location GetFacilityLocation(string code) {
+        public Location GetFacilityLocation(string code)
+        {
             return (Location)Bundle.Entry.Where(e => e.Resource is Location loc && loc.Type.Any(type => type.Coding.Any(coding => coding.System == CodeSystems.LocalBFDRCodes && coding.Code == code))).FirstOrDefault()?.Resource;
         }
 
@@ -8209,7 +8239,7 @@ namespace BFDR
                 {
                     return (obs.Value as Hl7.Fhir.Model.FhirDateTime)?.Value;
                 }
-                    return null;
+                return null;
             }
             set
             {
@@ -8365,14 +8395,14 @@ namespace BFDR
         }
 
         /// <summary>Date of Registration.</summary>
-        /// <value>the date that the birth was registered</value>
+        /// <value>the date that the birth/fetal death was registered</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleBirthRecord.RegistrationDate = "2023-02-19";</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Date of birth registration: {ExampleBirthRecord.RegistrationDate}");</para>
         /// </example>
-        [Property("RegistrationDate", Property.Types.String, "Birth Certification", "Date of Registration.", true, BFDR.IGURL.CompositionProviderLiveBirthReport, true, 243)]
+        [Property("RegistrationDate", Property.Types.String, "Registration Date", "Date of Registration.", true, BFDR.IGURL.CompositionProviderLiveBirthReport, true, 243)]
         [FHIRPath("Bundle.entry.resource.where($this is Composition)", "date")]
         public string RegistrationDate
         {
@@ -8387,14 +8417,14 @@ namespace BFDR
         }
 
         /// <summary>Year of Registration.</summary>
-        /// <value>the year that the birth was registered</value>
+        /// <value>the year that the birth/fetal death was registered</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleBirthRecord.RegistrationDateYear = 2023;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Year of birth registration: {ExampleBirthRecord.RegistrationDateYear}");</para>
         /// </example>
-        [Property("RegistrationDateYear", Property.Types.Int32, "Birth Certification", "Year of Registration.", true, BFDR.IGURL.CompositionProviderLiveBirthReport, true, 243)]
+        [Property("RegistrationDateYear", Property.Types.Int32, "Registration Date", "Year of Registration.", true, BFDR.IGURL.CompositionProviderLiveBirthReport, true, 243)]
         [FHIRPath("Bundle.entry.resource.where($this is Composition)", "date")]
         public int? RegistrationDateYear
         {
@@ -8423,14 +8453,14 @@ namespace BFDR
         }
 
         /// <summary>Month of Registration.</summary>
-        /// <value>the month that the birth was registered</value>
+        /// <value>the month that the birth/fetal death was registered</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleBirthRecord.RegistrationDateMonth = 10;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Month of birth registration: {ExampleBirthRecord.RegistrationDateMonth}");</para>
         /// </example>
-        [Property("RegistrationDateMonth", Property.Types.Int32, "Birth Certification", "Month of Registration.", true, BFDR.IGURL.CompositionProviderLiveBirthReport, true, 244)]
+        [Property("RegistrationDateMonth", Property.Types.Int32, "Registration Date", "Month of Registration.", true, BFDR.IGURL.CompositionProviderLiveBirthReport, true, 244)]
         [FHIRPath("Bundle.entry.resource.where($this is Composition)", "date")]
         public int? RegistrationDateMonth
         {
@@ -8459,14 +8489,14 @@ namespace BFDR
         }
 
         /// <summary>Day of Registration.</summary>
-        /// <value>the day that the birth was registered</value>
+        /// <value>the day that the birth/fetal death was registered</value>
         /// <example>
         /// <para>// Setter:</para>
         /// <para>ExampleBirthRecord.RegistrationDateDay = 23;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Day of birth registration: {ExampleBirthRecord.RegistrationDateDay}");</para>
         /// </example>
-        [Property("RegistrationDateDay", Property.Types.Int32, "Birth Certification", "Day of Registration.", true, BFDR.IGURL.CompositionProviderLiveBirthReport, true, 245)]
+        [Property("RegistrationDateDay", Property.Types.Int32, "Registration Date", "Day of Registration.", true, BFDR.IGURL.CompositionProviderLiveBirthReport, true, 245)]
         [FHIRPath("Bundle.entry.resource.where($this is Composition)", "date")]
         public int? RegistrationDateDay
         {
@@ -8734,7 +8764,7 @@ namespace BFDR
                     MotherTransferred = CodeableConceptToDict(new CodeableConcept(CodeSystems.AdmitSource, "hosp-trans", "Transferred from other hospital", "The Patient has been transferred from another hospital for this encounter."));
                     FacilityMotherTransferredFrom = "UNKNOWN";
                 }
-                else 
+                else
                 {
                     // all other codes should be interpretted as N with "other" as the code to express mother did not transfer
                     MotherTransferred = CodeableConceptToDict(new CodeableConcept(CodeSystems.AdmitSource, "other", "Other", "Did not transfer"));
@@ -9219,251 +9249,6 @@ namespace BFDR
             }
         }
 
-        /// <summary>Date of Certification.</summary>
-        /// <value>the date of certification</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.CertifiedDate = "2023-02-19";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Date of birth certification: {ExampleBirthRecord.CertificationDate}");</para>
-        /// </example>
-        [Property("CertificationDate", Property.Types.String, "Birth Certification", "Date of Certification.", true, BFDR.IGURL.CompositionProviderLiveBirthReport, true, 243)]
-        [FHIRPath("Bundle.entry.resource.where($this is Encounter).where(extension.value.coding.code='CHILD')", "")]
-        public string CertificationDate
-        {
-            get
-            {
-                Encounter.ParticipantComponent certifier = EncounterBirth?.Participant?.FirstOrDefault(entry => ((Encounter.ParticipantComponent)entry).Type.Any(t => t.Coding.Any(c => c.Code == "87287-9")));
-                if (certifier != null && certifier.Period.Start != null)
-                {
-                    return certifier.Period.Start;
-                }
-                return null;
-            }
-            set
-            {
-                Encounter.ParticipantComponent certifier = EncounterBirth.Participant.FirstOrDefault(entry => ((Encounter.ParticipantComponent)entry).Type.Any(t => t.Coding.Any(c => c.Code == "87287-9")));
-                if (certifier != null)
-                {
-                    certifier.Period.StartElement = ConvertToDateTime(value);
-                }
-                else
-                {
-                    Encounter.ParticipantComponent newCertifier = new Encounter.ParticipantComponent();
-                    CodeableConcept t = new CodeableConcept(CodeSystems.LOINC, "87287-9", "Birth certifier", null);
-                    newCertifier.Type.Add(t);
-                    Period p = new Period();
-                    p.StartElement = ConvertToDateTime(value);
-                    newCertifier.Period = p;
-                    EncounterBirth.Participant.Add(newCertifier);
-                }
-            }
-        }
-
-        /// <summary>Certified Year</summary>
-        /// <value>year of certification</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.CertifiedYear = 2023;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Certified Year: {ExampleBirthRecord.CertifiedYear}");</para>
-        /// </example>
-        [Property("Certified Year", Property.Types.Int32, "Birth Certification", "Certified Year", true, IGURL.EncounterBirth, true, 4)]
-        [FHIRPath("Bundle.entry.resource.where($this is Encounter).where(extension.value.coding.code='CHILD')", "")] 
-        public int? CertifiedYear
-        {
-            get
-            {
-                if (EncounterBirth == null)
-                {
-                    return null;
-                }
-                Encounter.ParticipantComponent certifier = EncounterBirth.Participant.FirstOrDefault(entry => ((Encounter.ParticipantComponent)entry).Type.Any(t => t.Coding.Any(c => c.Code == "87287-9")));
-                // First check the value string
-                if (certifier == null || certifier.Period == null || certifier.Period.StartElement == null)
-                {
-                    return null;
-                }
-                if (certifier != null && certifier.Period.StartElement != null && ParseDateElements(certifier.Period.Start, out int? year, out int? month, out int? day))
-                {
-                    return year;
-                }
-                return GetDateFragmentOrPartialDate(certifier.Period.StartElement, VR.ExtensionURL.PartialDateTimeYearVR);
-            }
-            set
-            {
-                if (value == null)
-                {
-                    return;
-                }
-                if (EncounterBirth == null)
-                {
-                    CreateBirthEncounter();
-                }
-                Encounter.ParticipantComponent stateComp = EncounterBirth.Participant.FirstOrDefault(entry => ((Encounter.ParticipantComponent)entry).Type.Any(t => t.Coding.Any(c => c.Code == "87287-9")));
-                if (stateComp == null) // make certifier participant with date
-                {  
-                    Encounter.ParticipantComponent certifier = new Encounter.ParticipantComponent();
-                    CodeableConcept t = new CodeableConcept(CodeSystems.LOINC, "87287-9", "Birth certifier", null);
-                    certifier.Type.Add(t);
-                    Period p = new Period();
-                    p.StartElement = new FhirDateTime();
-                    p.StartElement.Extension.Add(NewBlankPartialDateTimeExtension(false));
-                    certifier.Period = p;
-                    EncounterBirth.Participant.Add(certifier);
-                    stateComp = certifier;
-                }  
-                if (stateComp.Period == null || stateComp.Period.StartElement == null) //certifier participant exists but no period or period.start
-                {
-                    Period p = new Period();
-                    p.StartElement = new FhirDateTime();
-                    p.StartElement.Extension.Add(NewBlankPartialDateTimeExtension(false));
-                    stateComp.Period = p;
-                }
-                FhirDateTime newDate = SetYear(value, stateComp.Period.StartElement);
-                if (newDate != null)
-                {
-                    stateComp.Period.StartElement = newDate;
-                }
-            }
-        }
-
-        /// <summary>Certified Month</summary>
-        /// <value>month of certification</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.CertifiedMonth = 10;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Certified Month: {ExampleBirthRecord.CertifiedMonth}");</para>
-        /// </example>
-        [Property("Certified Month", Property.Types.Int32, "Birth Certification", "Certified Month", true, IGURL.EncounterBirth, true, 4)]
-        [FHIRPath("Bundle.entry.resource.where($this is Encounter).where(extension.value.coding.code='CHILD')", "")] 
-        public int? CertifiedMonth
-        {
-            get
-            {
-                if (EncounterBirth == null)
-                {
-                    return null;
-                }
-                Encounter.ParticipantComponent certifier = EncounterBirth.Participant.FirstOrDefault(entry => ((Encounter.ParticipantComponent)entry).Type.Any(t => t.Coding.Any(c => c.Code == "87287-9")));
-                // First check the value string
-                if (certifier == null || certifier.Period == null || certifier.Period.StartElement == null)
-                {
-                    return null;
-                }
-                if (certifier != null && certifier.Period.StartElement != null && ParseDateElements(certifier.Period.Start, out int? year, out int? month, out int? day))
-                {
-                    return month;
-                }
-                return GetDateFragmentOrPartialDate(certifier.Period.StartElement, VR.ExtensionURL.PartialDateTimeMonthVR);
-            }
-            set
-            {
-                if (value == null)
-                {
-                    return;
-                }
-                if (EncounterBirth == null)
-                {
-                    CreateBirthEncounter();
-                }
-                Encounter.ParticipantComponent stateComp = EncounterBirth.Participant.FirstOrDefault(entry => ((Encounter.ParticipantComponent)entry).Type.Any(t => t.Coding.Any(c => c.Code == "87287-9")));
-                if (stateComp == null) // make certifier participant with date
-                {  
-                    Encounter.ParticipantComponent certifier = new Encounter.ParticipantComponent();
-                    CodeableConcept t = new CodeableConcept(CodeSystems.LOINC, "87287-9", "Birth certifier", null);
-                    certifier.Type.Add(t);
-                    Period p = new Period();
-                    p.StartElement = new FhirDateTime();
-                    p.StartElement.Extension.Add(NewBlankPartialDateTimeExtension(false));
-                    certifier.Period = p;
-                    EncounterBirth.Participant.Add(certifier);
-                    stateComp = certifier;
-                }  
-                if (stateComp.Period == null || stateComp.Period.StartElement == null) //certifier participant exists but no period or period.start
-                {
-                    Period p = new Period();
-                    p.StartElement = new FhirDateTime();
-                    p.StartElement.Extension.Add(NewBlankPartialDateTimeExtension(false));
-                    stateComp.Period = p;
-                }
-                FhirDateTime newDate = SetMonth(value, stateComp.Period.StartElement); 
-                if (newDate != null)
-                {
-                    stateComp.Period.StartElement = newDate; 
-                }
-            }
-        }
-
-        /// <summary>Certified Day</summary>
-        /// <value>day of certification</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.CertifiedDay = 23;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Certified Day: {ExampleBirthRecord.CertifiedDay}");</para>
-        /// </example> 
-        [Property("Certified Day", Property.Types.Int32, "Birth Certification", "Certified Day", true, IGURL.EncounterBirth, true, 4)]
-        [FHIRPath("Bundle.entry.resource.where($this is Encounter).where(extension.value.coding.code='CHILD')", "")] 
-        public int? CertifiedDay
-        {
-            get
-            {
-                if (EncounterBirth == null)
-                {
-                    return null;
-                }
-                Encounter.ParticipantComponent certifier = EncounterBirth.Participant.FirstOrDefault(entry => ((Encounter.ParticipantComponent)entry).Type.Any(t => t.Coding.Any(c => c.Code == "87287-9")));
-                // First check the value string
-                if (certifier == null || certifier.Period == null || certifier.Period.StartElement == null)
-                {
-                    return null;
-                }
-                if (certifier != null && certifier.Period.StartElement != null && ParseDateElements(certifier.Period.Start, out int? year, out int? month, out int? day))
-                {
-                    return day;
-                }
-                return GetDateFragmentOrPartialDate(certifier.Period.StartElement, VR.ExtensionURL.PartialDateTimeDayVR);
-            }
-            set
-            {
-                if (value == null)
-                {
-                    return;
-                }
-                if (EncounterBirth == null)
-                {
-                    CreateBirthEncounter();
-                }
-                Encounter.ParticipantComponent stateComp = EncounterBirth.Participant.FirstOrDefault(entry => ((Encounter.ParticipantComponent)entry).Type.Any(t => t.Coding.Any(c => c.Code == "87287-9")));
-                if (stateComp == null) // make certifier participant with date
-                {  
-                    Encounter.ParticipantComponent certifier = new Encounter.ParticipantComponent();
-                    CodeableConcept t = new CodeableConcept(CodeSystems.LOINC, "87287-9", "Birth certifier", null);
-                    certifier.Type.Add(t);
-                    Period p = new Period();
-                    p.StartElement = new FhirDateTime();
-                    p.StartElement.Extension.Add(NewBlankPartialDateTimeExtension(false));
-                    certifier.Period = p;
-                    EncounterBirth.Participant.Add(certifier);
-                    stateComp = certifier;
-                }  
-                if (stateComp.Period == null || stateComp.Period.StartElement == null) //certifier participant exists but no period or period.start
-                {
-                    Period p = new Period();
-                    p.StartElement = new FhirDateTime();
-                    p.StartElement.Extension.Add(NewBlankPartialDateTimeExtension(false));
-                    stateComp.Period = p;
-                }
-                FhirDateTime newDate = SetDay(value, stateComp.Period.StartElement); 
-                if (newDate != null)
-                {
-                    stateComp.Period.StartElement = newDate; 
-                }
-            }
-        }
-
         /// <summary>Set an emerging issue value, creating an empty EmergingIssues Observation as needed.</summary>
         private void SetEmergingIssue(string identifier, string value)
         {
@@ -9482,7 +9267,7 @@ namespace BFDR
         }
 
         /// <summary>Get an emerging issue value.</summary>
-        private string GetEmergingIssue(string identifier)             
+        private string GetEmergingIssue(string identifier)
         {
             Observation EmergingIssues = GetObservation(identifier);
             if (EmergingIssues == null)
@@ -9518,7 +9303,7 @@ namespace BFDR
             }
             set
             {
-                if(!String.IsNullOrWhiteSpace(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     SetEmergingIssue("EmergingIssue1_1", value);
                 }
@@ -9544,7 +9329,7 @@ namespace BFDR
             }
             set
             {
-                if(!String.IsNullOrWhiteSpace(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     SetEmergingIssue("EmergingIssue1_2", value);
                 }
@@ -9570,7 +9355,7 @@ namespace BFDR
             }
             set
             {
-                if(!String.IsNullOrWhiteSpace(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     SetEmergingIssue("EmergingIssue1_3", value);
                 }
@@ -9596,7 +9381,7 @@ namespace BFDR
             }
             set
             {
-                if(!String.IsNullOrWhiteSpace(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     SetEmergingIssue("EmergingIssue1_4", value);
                 }
@@ -9622,7 +9407,7 @@ namespace BFDR
             }
             set
             {
-                if(!String.IsNullOrWhiteSpace(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     SetEmergingIssue("EmergingIssue1_5", value);
                 }
@@ -9648,7 +9433,7 @@ namespace BFDR
             }
             set
             {
-                if(!String.IsNullOrWhiteSpace(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     SetEmergingIssue("EmergingIssue1_6", value);
                 }
@@ -9674,7 +9459,7 @@ namespace BFDR
             }
             set
             {
-                if(!String.IsNullOrWhiteSpace(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     SetEmergingIssue("EmergingIssue8_1", value);
                 }
@@ -9700,7 +9485,7 @@ namespace BFDR
             }
             set
             {
-                if(!String.IsNullOrWhiteSpace(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     SetEmergingIssue("EmergingIssue8_2", value);
                 }
@@ -9726,7 +9511,7 @@ namespace BFDR
             }
             set
             {
-                if(!String.IsNullOrWhiteSpace(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     SetEmergingIssue("EmergingIssue8_3", value);
                 }
@@ -9752,7 +9537,7 @@ namespace BFDR
             }
             set
             {
-                if(!String.IsNullOrWhiteSpace(value))
+                if (!String.IsNullOrWhiteSpace(value))
                 {
                     SetEmergingIssue("EmergingIssue20", value);
                 }

--- a/projects/VitalRecord/VitalRecord.xml
+++ b/projects/VitalRecord/VitalRecord.xml
@@ -6187,11 +6187,12 @@
             <param name="names">The current list of HumanName attributes for the person.</param>
             <param name="use"> The type of name, defaults to official.</param>
         </member>
-        <member name="M:VR.VitalRecord.updateFamilyName(System.String,System.Collections.Generic.List{Hl7.Fhir.Model.HumanName},Hl7.Fhir.Model.HumanName.NameUse)">
+        <member name="M:VR.VitalRecord.updateFamilyName(System.String,System.Collections.Generic.List{Hl7.Fhir.Model.HumanName},Hl7.Fhir.Model.HumanName.NameUse,System.String)">
             <summary>Helper method to update last name.</summary>
             <param name="value">A list of strings to be converted into a name.</param>
             <param name="names">The current list of HumanName attributes for the person.</param>
             <param name="use"> The type of name, defaults to official.</param>
+            <param name="propertyName">The name of the Natality record property</param>
         </member>
         <member name="M:VR.VitalRecord.updateSuffix(System.String,System.Collections.Generic.List{Hl7.Fhir.Model.HumanName},Hl7.Fhir.Model.HumanName.NameUse)">
             <summary>Helper method to update suffix.</summary>


### PR DESCRIPTION
FILENO and AUXNO are blank in IJEFetalDeath -- implemented. 

DOR_YR, DOR_MO, and DOR_DY property field is for birth cert -- updated the xml comment and properties to be more general

CERTIFIED_YR, CERTIFIED_MO, and CERTIFIED_DY relate to encounter birth. -- mirrored these fields in fetal death using encounter maternity instead of encounter birth

AUTOP software is using the wrong VS, should be performedNotPerformedPlanned -- fixed. Examples and test cases updated.

DSTATE investigate -- made implementation of DSTATE the same as BSTATE (using PlaceOfBirth instead of PlaceOfDelivery) 

FSEX software uses birthsexfetusvs but should use sexassignedatbirth -- checked and it was using the right vs and mapping, so no changes needed.

FETLNAME check if absence is properly handled with unknown in software -- added dataAbsentReason extension with code 'temp-unknown' or 'unknown' if child or decedent fetus last name is set to empty/null. Added test cases.



Some of the files look like they have a lot of changes but it's just formatting clean up.. Sorry - that probably makes it harder to review the real changes. I wasn't sure how to undo it... 