### PR TITLE
fix(bfdr): fix convert demographic coding msg to json

### DIFF
--- a/projects/BFDR.CLI/Program.cs
+++ b/projects/BFDR.CLI/Program.cs
@@ -50,6 +50,7 @@ namespace BFDR.CLI
   - ijebuilder: Create json birth record using IJE (natality) mapped fields
   - compare: Compare an IJE record with a FHIR record by each IJE field (2 arguments:  IJE record, FHIR Record)
   - extract: Extract a FHIR record from a FHIR message (1 argument: FHIR message)
+  - nre2json: Creates a Demographic Coding Bundle from a NRE Message (1 argument: TRX file)
     ";
 
         static int Main(string[] args)
@@ -657,6 +658,32 @@ namespace BFDR.CLI
                         Console.WriteLine(record.ToJSON());
                         break;
                 }
+                return 0;
+            }
+            else if (args.Length == 1 && args[0] == "nre2json")
+            {
+                IJEBirth ijeb = new IJEBirth();
+                ijeb.MRACE1E = "199";
+                ijeb.MRACE2E = "";
+                ijeb.MRACE3E = "";
+                ijeb.MRACE4E = "";
+                ijeb.MRACE5E = "";
+                ijeb.MRACE6E = "";
+                ijeb.MRACE7E = "";
+                ijeb.MRACE8E = "";
+
+                ijeb.METHNIC1 = "N";
+                ijeb.METHNIC2 = "N";                
+                ijeb.METHNIC3 = "N";
+                ijeb.METHNIC4 = "N";
+                ijeb.METHNIC5 = "";
+                ijeb.METHNICE = "100";
+                ijeb.METHNIC5C = "";
+
+                BirthRecord br = ijeb.ToRecord();
+                BirthRecordDemographicsCodingMessage msg = new BirthRecordDemographicsCodingMessage(br);
+                Console.WriteLine(msg.ToJson());
+                // there's something wrong with the ToJson call when converting the message to json to insert in the db
                 return 0;
             }
             else

--- a/projects/BFDR.Messaging/BirthRecordDemographicsCodingMessage.cs
+++ b/projects/BFDR.Messaging/BirthRecordDemographicsCodingMessage.cs
@@ -93,7 +93,7 @@ namespace BFDR
         {
             get
             {
-                return birthRecord?.GetDemographicCodedContentBundle();
+                return birthRecord?.GetBundle();
             }
         }
         /// <summary>The id of the birth record submission/update message that was coded to produce the content of this message</summary>

--- a/projects/BFDR.Tests/Messaging_Should.cs
+++ b/projects/BFDR.Tests/Messaging_Should.cs
@@ -422,7 +422,8 @@ namespace BFDR.Tests
             ije.BSTATE = "YC";
             ije.FILENO = "123";
             // TODO: Set the IJE fields that support demographic data
-            BirthRecordDemographicsCodingUpdateMessage message = new BirthRecordDemographicsCodingUpdateMessage(ije.ToRecord());
+            BirthRecord br = ije.ToRecord();
+            BirthRecordDemographicsCodingUpdateMessage message = new BirthRecordDemographicsCodingUpdateMessage(br);
             message.MessageSource = "http://nchs.cdc.gov/bfdr_submission";
             message.MessageDestination = "https://example.org/jurisdiction/endpoint";
             Assert.Equal(BirthRecordDemographicsCodingUpdateMessage.MESSAGE_TYPE, message.MessageType);

--- a/projects/BFDR.Tests/Messaging_Should.cs
+++ b/projects/BFDR.Tests/Messaging_Should.cs
@@ -382,6 +382,38 @@ namespace BFDR.Tests
         }
 
         [Fact]
+        public void CreateDemographicCodingResponseJson()
+        {
+                // create an IJE birth message, convert it to FHIR, round trip the FHIR to json and back to make sure the bundles are all added to the json correctly
+                IJEBirth ijeb = new IJEBirth();
+                ijeb.MRACE1E = "199";
+                ijeb.MRACE2E = "";
+                ijeb.MRACE3E = "";
+                ijeb.MRACE4E = "";
+                ijeb.MRACE5E = "";
+                ijeb.MRACE6E = "";
+                ijeb.MRACE7E = "";
+                ijeb.MRACE8E = "";
+
+                ijeb.METHNIC1 = "N";
+                ijeb.METHNIC2 = "N";                
+                ijeb.METHNIC3 = "N";
+                ijeb.METHNIC4 = "N";
+                ijeb.METHNIC5 = "";
+                ijeb.METHNICE = "100";
+                ijeb.METHNIC5C = "";
+
+                BirthRecord br = ijeb.ToRecord();
+                BirthRecordDemographicsCodingMessage msg = new BirthRecordDemographicsCodingMessage(br);
+                String msgJson = msg.ToJson();
+                // parse the json and make sure the bundles are present
+                BirthRecordDemographicsCodingMessage message = BirthRecordBaseMessage.Parse<BirthRecordDemographicsCodingMessage>(msgJson);
+                BirthRecord br2 = message.BirthRecord;
+                Assert.Equal("100", br2.MotherEthnicityEditedCodeHelper);
+                Assert.Equal("199", br2.MotherRaceTabulation1EHelper);
+        }
+
+        [Fact]
         public void CreateDemographicCodingUpdate()
         {
             // This test creates a response using the approach NCHS will use via IJE setters

--- a/projects/BFDR/NatalityRecord_constructors.cs
+++ b/projects/BFDR/NatalityRecord_constructors.cs
@@ -222,6 +222,11 @@ namespace BFDR
                   //TODO: add mother, input, coded race/ethnicity reference slices
                 };
                 Composition.Section.Add(motherSection);
+                // get the input and coded observation
+                Observation motherInputRaceAdEthnicityObs = GetOrCreateObservation(RACE_ETHNICITY_PROFILE_MOTHER, CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
+                AddResourceToBundleIfPresent(motherInputRaceAdEthnicityObs, dccBundle);
+                Observation motherCodedRaceAdEthnicityObs = GetOrCreateObservation(CODED_RACE_ETHNICITY_PROFILE_MOTHER, CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.CodedRaceAndEthnicity, CODED_RACE_ETHNICITY_PROFILE_MOTHER);
+                AddResourceToBundleIfPresent(motherCodedRaceAdEthnicityObs, dccBundle);
             } else if (Father != null)
             {
                 Composition.SectionComponent fatherSection = new Composition.SectionComponent
@@ -230,6 +235,12 @@ namespace BFDR
                   //TODO: add father, input, coded race/ethnicity reference slices
                 };
                 Composition.Section.Add(fatherSection);
+
+                // get the input and coded observation
+                Observation fatherInputRaceAdEthnicityObs = GetOrCreateObservation(RACE_ETHNICITY_PROFILE_FATHER, CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
+                AddResourceToBundleIfPresent(fatherInputRaceAdEthnicityObs, dccBundle);
+                Observation fatherCodedRaceAdEthnicityObs = GetOrCreateObservation(CODED_RACE_ETHNICITY_PROFILE_FATHER, CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.CodedRaceAndEthnicity, CODED_RACE_ETHNICITY_PROFILE_FATHER);
+                AddResourceToBundleIfPresent(fatherCodedRaceAdEthnicityObs, dccBundle);
             } else 
             {
                 //TODO: demographic content composition should have a relevant mother and/or father - this should be an exception

--- a/projects/BFDR/NatalityRecord_constructors.cs
+++ b/projects/BFDR/NatalityRecord_constructors.cs
@@ -222,11 +222,6 @@ namespace BFDR
                   //TODO: add mother, input, coded race/ethnicity reference slices
                 };
                 Composition.Section.Add(motherSection);
-                // get the input and coded observation
-                Observation motherInputRaceAdEthnicityObs = GetOrCreateObservation(RACE_ETHNICITY_PROFILE_MOTHER, CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_MOTHER);
-                AddResourceToBundleIfPresent(motherInputRaceAdEthnicityObs, dccBundle);
-                Observation motherCodedRaceAdEthnicityObs = GetOrCreateObservation(CODED_RACE_ETHNICITY_PROFILE_MOTHER, CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.CodedRaceAndEthnicity, CODED_RACE_ETHNICITY_PROFILE_MOTHER);
-                AddResourceToBundleIfPresent(motherCodedRaceAdEthnicityObs, dccBundle);
             } else if (Father != null)
             {
                 Composition.SectionComponent fatherSection = new Composition.SectionComponent
@@ -236,11 +231,6 @@ namespace BFDR
                 };
                 Composition.Section.Add(fatherSection);
 
-                // get the input and coded observation
-                Observation fatherInputRaceAdEthnicityObs = GetOrCreateObservation(RACE_ETHNICITY_PROFILE_FATHER, CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.InputRaceAndEthnicity, RACE_ETHNICITY_PROFILE_FATHER);
-                AddResourceToBundleIfPresent(fatherInputRaceAdEthnicityObs, dccBundle);
-                Observation fatherCodedRaceAdEthnicityObs = GetOrCreateObservation(CODED_RACE_ETHNICITY_PROFILE_FATHER, CodeSystems.InputRaceAndEthnicityPerson, "Input Race and Ethnicity Person", VR.ProfileURL.CodedRaceAndEthnicity, CODED_RACE_ETHNICITY_PROFILE_FATHER);
-                AddResourceToBundleIfPresent(fatherCodedRaceAdEthnicityObs, dccBundle);
             } else 
             {
                 //TODO: demographic content composition should have a relevant mother and/or father - this should be an exception


### PR DESCRIPTION
Fixes Demographic coding message to retrieve the full birth record bundle. Added a test to confirm the observations in a demographics coding message are all parsed when converting from fhir to json and parsing back to fhir.