### PR TITLE
refactor: link to Canary compatible with VRDR STU2

### DIFF
--- a/projects/Canary/ClientApp/src/components/HomeScreen.js
+++ b/projects/Canary/ClientApp/src/components/HomeScreen.js
@@ -28,12 +28,12 @@ export class HomeScreen extends Component {
             </Header>
           </Divider>
           <div className="p-t-30" />
-          <CanaryCard 
+          <CanaryCard
             title='Vital Records Death Reporting'
-            subtitle={`VRDR ${window.VRDR_VERSION}`}
-            link='/vrdr'
+            subtitle='VRDR STU2'
+            link='https://canary-v4.fhir.nvss.cdc.gov'
           />
-          <CanaryCard 
+          <CanaryCard
             title='Birth and Fetal Death Reporting'
             subtitle={`BFDR ${window.BFDR_VERSION}`}
             link='/bfdr'

--- a/projects/Canary/ClientApp/src/components/Navigation.js
+++ b/projects/Canary/ClientApp/src/components/Navigation.js
@@ -86,9 +86,6 @@ export function Navigation(props) {
           </span>
           <span className="p-l-5">
             <small>
-              {window.VERSION};
-            </small>
-            <small>
               VRDR {window.VRDR_VERSION};
             </small>
             <small>


### PR DESCRIPTION
- Publish the edge version of Canary to https://canary.fhir.nvss.cdc.gov.
- Link to Canary v4 (https://canary-v4.fhir.nvss.cdc.gov) from the home screen.
- Remove Canary version reference.
- Use IG series instead of library version when referencing to the reporting category.