### PR TITLE
fix(bfdr): fix birth specific properties

### DIFF
--- a/projects/BFDR.CLI/Program.cs
+++ b/projects/BFDR.CLI/Program.cs
@@ -88,7 +88,7 @@ namespace BFDR.CLI
                 birthRecord.AttendantTitleHelper = "76231001";
                
 
-                birthRecord.BirthLocationJurisdiction = "MA";
+                birthRecord.EventLocationJurisdiction = "MA";
                 Dictionary<string, string> birthAddress = new Dictionary<string, string>();
                 birthAddress.Add("addressLine1", "123 Fake Street");
                 birthAddress.Add("addressCity", "Springfield");
@@ -165,12 +165,12 @@ namespace BFDR.CLI
                 fetaldeathRecord.DateOfDelivery = "2023-01-01";
                 fetaldeathRecord.FetalDeathSex = "M";
 
-                string[] childNames = { "Alexander", "Arlo" };
-                fetaldeathRecord.ChildGivenNames = childNames;
+                string[] fetusNames = { "Alexander", "Arlo" };
+                fetaldeathRecord.FetusGivenNames = fetusNames;
                 string[] motherName = { "Xenia" };
                 fetaldeathRecord.MotherGivenNames = motherName;
                 string lastName = "Adkins";
-                fetaldeathRecord.ChildFamilyName = lastName;
+                fetaldeathRecord.FetusFamilyName = lastName;
                 fetaldeathRecord.MotherFamilyName = lastName;
 
                 fetaldeathRecord.CertifierName = "Janet Seito";
@@ -181,7 +181,7 @@ namespace BFDR.CLI
                 fetaldeathRecord.AttendantTitleHelper = "76231001";
                
 
-                fetaldeathRecord.BirthLocationJurisdiction = "MA";
+                fetaldeathRecord.EventLocationJurisdiction = "MA";
                 Dictionary<string, string> birthAddress = new Dictionary<string, string>();
                 birthAddress.Add("addressLine1", "123 Fake Street");
                 birthAddress.Add("addressCity", "Springfield");

--- a/projects/BFDR.Messaging/BFDRBaseMessage.cs
+++ b/projects/BFDR.Messaging/BFDRBaseMessage.cs
@@ -76,7 +76,7 @@ namespace BFDR
             {
                 this.SetYear((uint)from.GetYear());
             }
-            this.JurisdictionId = from?.BirthLocationJurisdiction;
+            this.JurisdictionId = from?.EventLocationJurisdiction;
         }
 
         /////////////////////////////////////////////////////////////////////////////////

--- a/projects/BFDR.Tests/BirthRecord_Should.cs
+++ b/projects/BFDR.Tests/BirthRecord_Should.cs
@@ -439,7 +439,7 @@ namespace BFDR.Tests
       // State of Birth
       Assert.Equal("UT", firstRecord.PlaceOfBirth["addressState"]);
       Assert.Equal(firstRecord.PlaceOfBirth["addressState"], secondRecord.PlaceOfBirth["addressState"]);
-      Assert.Equal("UT", firstRecord.BirthLocationJurisdiction); // TODO - Birth Location Jurisdiction still needs to be finalized.
+      Assert.Equal("UT", firstRecord.EventLocationJurisdiction); // TODO - Birth Location Jurisdiction still needs to be finalized.
       // Time of Birth
       Assert.Equal("13:00:00", firstRecord.BirthTime);
       Assert.Equal(firstRecord.BirthTime, secondRecord.BirthTime);
@@ -736,7 +736,7 @@ namespace BFDR.Tests
       IJEBirth ije = new(record);
 
       Assert.Equal("UT", record.PlaceOfBirth["addressState"]);
-      Assert.Equal("UT", record.BirthLocationJurisdiction); // TODO - Birth Location Jurisdiction still needs to be finalized.
+      Assert.Equal("UT", record.EventLocationJurisdiction); // TODO - Birth Location Jurisdiction still needs to be finalized.
       // County of Birth (Literal)
       Assert.Equal("Salt Lake", record.PlaceOfBirth["addressCounty"]);
       // City/town/place of birth (Literal)
@@ -976,7 +976,7 @@ namespace BFDR.Tests
       record.BirthYear = 2020;
       record.CertificateNumber = "767676";
       Assert.Equal("2020XX767676", record.RecordIdentifier);
-      record.BirthLocationJurisdiction = "WY";
+      record.EventLocationJurisdiction = "WY";
       record.CertificateNumber = "898989";
       Assert.Equal("2020WY898989", record.RecordIdentifier);
       // Infant Medical Record Number
@@ -1933,13 +1933,13 @@ namespace BFDR.Tests
     [Fact]
     public void BirthLocationPresent()
     {
-      Assert.Equal("MA", FakeBirthRecord.BirthLocationJurisdiction);
+      Assert.Equal("MA", FakeBirthRecord.EventLocationJurisdiction);
       Assert.Equal("123 Fake Street", FakeBirthRecord.PlaceOfBirth["addressLine1"]);
       Assert.Equal("MA", FakeBirthRecord.PlaceOfBirth["addressState"]);
       Assert.Equal("01101", FakeBirthRecord.PlaceOfBirth["addressZip"]);
       //set after parse
-      FakeBirthRecord.BirthLocationJurisdiction = "MN";
-      Assert.Equal("MN", FakeBirthRecord.BirthLocationJurisdiction);
+      FakeBirthRecord.EventLocationJurisdiction = "MN";
+      Assert.Equal("MN", FakeBirthRecord.EventLocationJurisdiction);
       FakeBirthRecord.PlaceOfBirth = new Dictionary<string, string>
       {
         ["addressState"] = "UT",
@@ -3449,7 +3449,7 @@ namespace BFDR.Tests
       Assert.Null(birthRecord.MotherSuffix);
       Assert.Null(birthRecord.FatherSuffix);
       Assert.Null(birthRecord.MotherMaidenSuffix);
-      Assert.Equal("UT", birthRecord.BirthLocationJurisdiction);
+      Assert.Equal("UT", birthRecord.EventLocationJurisdiction);
       tempDict = new();
       tempDict.Add("addressLine1", "");
       tempDict.Add("addressLine2", "");
@@ -3987,22 +3987,22 @@ namespace BFDR.Tests
       string zalbanaizIje = "2002TT0099990            1025M010101311568794535  1095199505150XXKU73000013AZUSY199506040YYX40NNNN                    NNNNNNNNNNNNNNY                                                                                                                                                                                    MIDDLE EASTERN                ARABIAN                                                                       60NNNN                    NNNNNNNNNNNNNNY                                                                                                                                                                                    MIDDLE EASTERN                ARABIAN                                                                       1N0604201812272018180503016501990N01000001201988888800000000220180418NNNNNN NN000NN NNNNNNNNNNNNNNYNNYYNN14NNNNNNN2277036009880202999999990NNNNNNNNNNNNNNNNNNNNYY        9999NXX                 20190102                                                 XYUGBNX                                           XMX                                               ZALBANAIZ                                                MARICOPA                 MESA                                              MOUNTAIN VISTA MEDICAL CENTER                     REEM                                              NASSER                                            ALHAMADI                                                                                                                                                     ALHAMADI                                                                                                                            999 N COLLEGE AVE5656                             85281    MARICOPA                    TEMPE                       ARIZONA                     UNITED STATES               OMAR                                              AHMED                                             ALBANAI                                                  8888888888888888882626                                                                                                                ZZKU                                                                                                                                                                                                                                                                                                      KUWAIT                                                  KUWAIT                                                                                                 888 N PRIEST AVE9999                              85429                                GLENDALE                    ARIZONA                     UNITED STATES               Y1             MANISHAAPUROHIT                                   1972721538                                                                                     1201183921     1200527124             20190102                                                  0XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        ";
 
       BirthRecord romeroRawBr = new IJEBirth(romeroIje).ToRecord();
-      romeroRawBr.BirthLocationJurisdiction = "AZ";
+      romeroRawBr.EventLocationJurisdiction = "AZ";
       romeroRawBr.CertificateNumber = "8888";
       BirthRecord zalbanaizRawBr = new IJEBirth(zalbanaizIje).ToRecord();
-      zalbanaizRawBr.BirthLocationJurisdiction = "AZ";
+      zalbanaizRawBr.EventLocationJurisdiction = "AZ";
       zalbanaizRawBr.CertificateNumber = "8888";
       BirthRecord romeroConnectathonBr = Connectathon.YytrfCardenasRomero();
-      romeroConnectathonBr.BirthLocationJurisdiction = "AZ";
+      romeroConnectathonBr.EventLocationJurisdiction = "AZ";
       romeroConnectathonBr.CertificateNumber = "8888";
       BirthRecord zalbanaizConnectathonBr = Connectathon.XyugbnxZalbanaiz();
-      zalbanaizConnectathonBr.BirthLocationJurisdiction = "AZ";
+      zalbanaizConnectathonBr.EventLocationJurisdiction = "AZ";
       zalbanaizConnectathonBr.CertificateNumber = "8888";
       BirthRecord romeroImportedBr = new BirthRecord(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/BirthRecordR.json")));
-      romeroImportedBr.BirthLocationJurisdiction = "AZ";
+      romeroImportedBr.EventLocationJurisdiction = "AZ";
       romeroImportedBr.CertificateNumber = "8888";
       BirthRecord zalbanaizImportedBr = new BirthRecord(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/BirthRecordZ.json")));
-      zalbanaizImportedBr.BirthLocationJurisdiction = "AZ";
+      zalbanaizImportedBr.EventLocationJurisdiction = "AZ";
       zalbanaizImportedBr.CertificateNumber = "8888";
       Assert.Equal(JsonConvert.SerializeObject(romeroRawBr), JsonConvert.SerializeObject(romeroConnectathonBr));
       Assert.Equal(JsonConvert.SerializeObject(romeroRawBr), JsonConvert.SerializeObject(romeroImportedBr));

--- a/projects/BFDR.Tests/FetalDeathRecord_Should.cs
+++ b/projects/BFDR.Tests/FetalDeathRecord_Should.cs
@@ -30,8 +30,8 @@ namespace BFDR.Tests
         SetterFetalDeathRecord.DeliveryYear = 2020;
         // SetterFetalDeathRecord.CertificateNumber = "767676";
         // Assert.Equal("2020XX767676", SetterFetalDeathRecord.RecordIdentifier);
-        // Is the field name BirthLocationJurisdiction for Fetal Death?
-        SetterFetalDeathRecord.BirthLocationJurisdiction = "WY";
+        // Is the field name EventLocationJurisdiction for Fetal Death?
+        SetterFetalDeathRecord.EventLocationJurisdiction = "WY";
         SetterFetalDeathRecord.CertificateNumber = "898989";
         Assert.Equal("2020WY898989", SetterFetalDeathRecord.RecordIdentifier);
     }
@@ -1444,7 +1444,7 @@ namespace BFDR.Tests
       parsedRecord.FetusSuffix = "Junior";
       Assert.Equal("Jim", parsedRecord.FetusGivenNames[0]);
       Assert.Equal("Jam", parsedRecord.FetusGivenNames[1]);
-      Assert.Equal("Jones", parsedRecord.ChildFamilyName);
+      Assert.Equal("Jones", parsedRecord.FetusFamilyName);
       Assert.Equal("Junior", parsedRecord.FetusSuffix);
 
       // to IJE

--- a/projects/BFDR.Tests/Messaging_Should.cs
+++ b/projects/BFDR.Tests/Messaging_Should.cs
@@ -110,7 +110,7 @@ namespace BFDR.Tests
             Assert.Equal((uint)48858, submission.CertNo);
             Assert.Equal((uint)2019, submission.EventYear);
             Assert.Equal("000000000042", submission.StateAuxiliaryId);
-            Assert.Equal(submission.JurisdictionId, submission.BirthRecord.BirthLocationJurisdiction);
+            Assert.Equal(submission.JurisdictionId, submission.BirthRecord.EventLocationJurisdiction);
             Assert.Equal(2019, submission.BirthRecord.BirthYear);
             Assert.Null(submission.PayloadVersionId);
         }
@@ -216,7 +216,7 @@ namespace BFDR.Tests
             Assert.Equal((uint)48858, submission.CertNo);
             Assert.Equal((uint)2019, submission.EventYear);
             Assert.Equal("000000000042", submission.StateAuxiliaryId);
-            Assert.Equal(submission.JurisdictionId, submission.BirthRecord.BirthLocationJurisdiction);
+            Assert.Equal(submission.JurisdictionId, submission.BirthRecord.EventLocationJurisdiction);
             Assert.Equal(2019, submission.BirthRecord.BirthYear);
             Assert.Equal("BFDR_STU2_0", submission.PayloadVersionId);
             Assert.Equal("48858", submission.BirthRecord.CertificateNumber);
@@ -232,7 +232,7 @@ namespace BFDR.Tests
         //     Assert.Equal((uint)48858, submission.CertNo);
         //     Assert.Equal((uint)2019, submission.EventYear);
         //     Assert.Equal("000000000042", submission.StateAuxiliaryId);
-        //     Assert.Equal(submission.JurisdictionId, submission.FetalDeathRecord.BirthLocationJurisdiction);
+        //     Assert.Equal(submission.JurisdictionId, submission.FetalDeathRecord.EventLocationJurisdiction);
         //     Assert.Equal(2019, submission.FetalDeathRecord.BirthYear);
         //     Assert.Equal("48858", submission.FetalDeathRecord.CertificateNumber);
         // }

--- a/projects/BFDR.Tests/NatalityData_Should.cs
+++ b/projects/BFDR.Tests/NatalityData_Should.cs
@@ -30,7 +30,7 @@ namespace BFDR.Tests
       Assert.Equal("MA".PadRight(2), ijeImported.BSTATE);
       Assert.Equal(ijeImported.BSTATE, ijeConverted.BSTATE);
       Assert.Equal("MA", br.PlaceOfBirth["addressState"]);
-      Assert.Equal("MA", br.BirthLocationJurisdiction); // TODO - Birth Location Jurisdiction still needs to be finalized.
+      Assert.Equal("MA", br.EventLocationJurisdiction); // TODO - Birth Location Jurisdiction still needs to be finalized.
       // Time of Birth
       Assert.Equal("1230".PadRight(4), ijeImported.TB);
       Assert.Equal(ijeImported.TB, ijeConverted.TB);

--- a/projects/BFDR/BFDR.xml
+++ b/projects/BFDR/BFDR.xml
@@ -214,6 +214,48 @@
             <para>Console.WriteLine($"Infant transferred helper: {ExampleBirthRecord.InfantTransferredHelper}");</para>
             </example>
         </member>
+        <member name="P:BFDR.BirthRecord.ChildGivenNames">
+            <summary>Child's Legal Name - Given. Middle name should be the last entry.</summary>
+            <value>the child's name (first, etc., middle)</value>
+            <example>
+            <para>// Setter:</para>
+            <para>string[] names = { "Example", "Something", "Middle" };</para>
+            <para>ExampleBirthRecord.ChildGivenNames = names;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Child Given Name(s): {string.Join(", ", ExampleBirthRecord.ChildGivenNames)}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.ChildFamilyName">
+            <summary>Child's Legal Name - Last.</summary>
+            <value>the child's last name</value>
+            <example>
+            <para>// Setter:</para>
+            <para>string lastName = "Quinn";</para>
+            <para>ExampleBirthRecord.ChildFamilyName = lastName;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Child Family Name(s): {string.Join(", ", ExampleBirthRecord.ChildFamilyName)}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.ChildSuffix">
+            <summary>Child's Suffix.</summary>
+            <value>the child's suffix</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.ChildSuffix = "Jr.";</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Child Suffix: {ExampleBirthRecord.ChildSuffix}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.DateOfBirth">
+            <summary>Child's Date of Birth.</summary>
+            <value>the child's date of birth</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.DateOfBirth = "1940-02-19";</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Child Date of Birth: {ExampleBirthRecord.DateOfBirth}");</para>
+            </example>
+        </member>
         <member name="F:BFDR.BirthRecord.EncounterBirth">
             <summary>The encounter of the birth.</summary>
         </member>
@@ -3498,16 +3540,6 @@
             <param name="date">The date to check.</param>
             <returns>Whether the given date string is a complete date</returns>
         </member>
-        <member name="P:BFDR.NatalityRecord.DateOfBirth">
-            <summary>Child's Date of Birth.</summary>
-            <value>the child's date of birth</value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleBirthRecord.DateOfBirth = "1940-02-19";</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Child Date of Birth: {ExampleBirthRecord.DateOfBirth}");</para>
-            </example>
-        </member>
         <member name="M:BFDR.NatalityRecord.GetBirthSex">
             <summary>
              Getter method for child or decedent fetus birth/delivery sex.
@@ -3520,16 +3552,17 @@
             </summary>
             <param name="value">The birth/delivery sex.</param>
         </member>
-        <member name="P:BFDR.NatalityRecord.ChildGivenNames">
-            <summary>Child's Legal Name - Given. Middle name should be the last entry.</summary>
-            <value>the child's name (first, etc., middle)</value>
-            <example>
-            <para>// Setter:</para>
-            <para>string[] names = { "Example", "Something", "Middle" };</para>
-            <para>ExampleBirthRecord.ChildGivenNames = names;</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Child Given Name(s): {string.Join(", ", ExampleBirthRecord.ChildGivenNames)}");</para>
-            </example>
+        <member name="M:BFDR.NatalityRecord.GetDateOfDelivery">
+            <summary>
+            Gets the date of delivery of the subject child or fetus.
+            </summary>
+            <returns>The date of delivery</returns>
+        </member>
+        <member name="M:BFDR.NatalityRecord.SetDateOfDelivery(System.String)">
+            <summary>
+            Sets the date of the delivery of the subject child or fetus.
+            </summary>
+            <param name="value"></param>
         </member>
         <member name="P:BFDR.NatalityRecord.MotherGivenNames">
             <summary>Mother's Legal Name - Given. Middle name should be the last entry.</summary>
@@ -3562,17 +3595,6 @@
             <para>ExampleBirthRecord.MotherMaidenGivenNames = names;</para>
             <para>// Getter:</para>
             <para>Console.WriteLine($"Mother Given Name(s): {string.Join(", ", ExampleBirthRecord.MotherMaidenGivenNames)}");</para>
-            </example>
-        </member>
-        <member name="P:BFDR.NatalityRecord.ChildFamilyName">
-            <summary>Child's Legal Name - Last.</summary>
-            <value>the child's last name</value>
-            <example>
-            <para>// Setter:</para>
-            <para>string lastName = "Quinn";</para>
-            <para>ExampleBirthRecord.ChildFamilyName = lastName;</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Child Family Name(s): {string.Join(", ", ExampleBirthRecord.ChildFamilyName)}");</para>
             </example>
         </member>
         <member name="P:BFDR.NatalityRecord.MotherFamilyName">
@@ -3614,16 +3636,6 @@
             <para>Console.WriteLine($"Mother Maiden Family Name(s): {string.Join(", ", ExampleBirthRecord.MotherMaidenFamilyName)}");</para>
             </example>
         </member>
-        <member name="P:BFDR.NatalityRecord.ChildSuffix">
-            <summary>Child's Suffix.</summary>
-            <value>the child's suffix</value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleBirthRecord.ChildSuffix = "Jr.";</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Child Suffix: {ExampleBirthRecord.ChildSuffix}");</para>
-            </example>
-        </member>
         <member name="P:BFDR.NatalityRecord.MotherSuffix">
             <summary>Mother's Suffix.</summary>
             <value>the mother's suffix</value>
@@ -3654,14 +3666,14 @@
             <para>Console.WriteLine($"Mother Maiden Suffix: {ExampleBirthRecord.MotherMaidenSuffix}");</para>
             </example>
         </member>
-        <member name="P:BFDR.NatalityRecord.BirthLocationJurisdiction">
+        <member name="P:BFDR.NatalityRecord.EventLocationJurisdiction">
             <summary>Birth Location Jurisdiction.</summary>
             <value>the vital record jurisdiction identifier.</value>
             <example>
             <para>// Setter:</para>
-            <para>ExampleBirthRecord.BirthLocationJurisdiction = "MA";</para>
+            <para>ExampleBirthRecord.EventLocationJurisdiction = "MA";</para>
             <para>// Getter:</para>
-            <para>Console.WriteLine($"Birth Location Jurisdiction: {ExampleBirthRecord.BirthLocationJurisdiction}");</para>
+            <para>Console.WriteLine($"Birth Location Jurisdiction: {ExampleBirthRecord.EventLocationJurisdiction}");</para>
             </example>
         </member>
         <member name="P:BFDR.NatalityRecord.PlaceOfBirth">
@@ -5813,6 +5825,24 @@
             <para>Console.WriteLine($"InfantBreastfedAtDischarge: {ExampleBirthRecord.InfantBreastfedAtDischarge}");</para>
             </example>
         </member>
+        <member name="M:BFDR.NatalityRecord.GetWeight(System.String)">
+            <summary>
+            Gets the value of the observation matching the given code as a FhirQuanity.
+            </summary>
+            <param name="code"></param>
+            <returns></returns>
+        </member>
+        <member name="M:BFDR.NatalityRecord.SetWeight(System.String,System.Nullable{System.Int32},System.String,System.String,System.String)">
+            <summary>
+            Sets the vital-sign weight of the given subject id in an observation matching the given code.
+            </summary>
+            <param name="code"></param>
+            <param name="value"></param>
+            <param name="unit"></param>
+            <param name="section"></param>
+            <param name="subjectId"></param>
+            <returns></returns>
+        </member>
         <member name="P:BFDR.NatalityRecord.MotherPrepregnancyWeight">
             <summary>Mother's Prepregnancy Weight.</summary>
             <value>the mother's prepregnancy weight in whole pounds, or -1 if explicitly unknown, or null if never specified</value>
@@ -6691,6 +6721,37 @@
             <para>// Getter:</para>
             <para>Console.WriteLine($"Emerging Issue Value: {ExampleBirthRecord.EmergingIssue20}");</para>
             </example>
+        </member>
+        <member name="M:BFDR.NatalityRecord.GetCertifiedDateElement(Hl7.Fhir.Model.Encounter,System.String)">
+            <summary>
+            Gets the certification date element of the given encounter based on whether it's a day, month, or year element.
+            </summary>
+            <param name="encounter"></param>
+            <param name="dateUrl">The type of date element to extract</param>
+            <returns></returns>
+            <exception cref="T:System.Exception"></exception>
+        </member>
+        <member name="M:BFDR.NatalityRecord.SetCertifiedDateElement(Hl7.Fhir.Model.Encounter,System.String,System.Nullable{System.Int32})">
+            <summary>
+            Sets the certification date of the given encounter.
+            </summary>
+            <param name="encounter"></param>
+            <param name="dateUrl">The type of date format such as PartialDate or PartialDateTime</param>
+            <param name="value"></param>
+        </member>
+        <member name="M:BFDR.NatalityRecord.GetCertificationDate(Hl7.Fhir.Model.Encounter)">
+            <summary>
+            Gets the certification date from the given encounter.
+            </summary>
+            <param name="encounter"></param>
+            <returns></returns>
+        </member>
+        <member name="M:BFDR.NatalityRecord.SetCertificationDate(Hl7.Fhir.Model.Encounter,System.String)">
+            <summary>
+            Sets the certification date of the given encounter.
+            </summary>
+            <param name="encounter"></param>
+            <param name="value"></param>
         </member>
         <member name="T:BFDR.FHIRSubject">
             <summary>Describes the subject of a birth record field</summary>

--- a/projects/BFDR/BirthRecord.cs
+++ b/projects/BFDR/BirthRecord.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Hl7.Fhir.Model;
 using VR;
 using static Hl7.Fhir.Model.Encounter;
@@ -396,6 +397,71 @@ namespace BFDR
                     FacilityInfantTransferredTo = "UNKNOWN";
                 }
             }
+        }
+
+        /// <summary>Child's Legal Name - Given. Middle name should be the last entry.</summary>
+        /// <value>the child's name (first, etc., middle)</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>string[] names = { "Example", "Something", "Middle" };</para>
+        /// <para>ExampleBirthRecord.ChildGivenNames = names;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Child Given Name(s): {string.Join(", ", ExampleBirthRecord.ChildGivenNames)}");</para>
+        /// </example>
+        [Property("Child Given Names", Property.Types.StringArr, "Child Demographics", "Child’s First Name.", true, VR.IGURL.Child, true, 0)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "name")]
+        public string[] ChildGivenNames
+        {
+            get => Subject?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Given?.ToArray() ?? new string[0];
+            set => updateGivenHumanName(value, Subject.Name);
+        }
+        /// <summary>Child's Legal Name - Last.</summary>
+        /// <value>the child's last name</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>string lastName = "Quinn";</para>
+        /// <para>ExampleBirthRecord.ChildFamilyName = lastName;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Child Family Name(s): {string.Join(", ", ExampleBirthRecord.ChildFamilyName)}");</para>
+        /// </example>
+        [Property("Child Family Name", Property.Types.String, "Child Demographics", "Child's Last Name.", true, VR.IGURL.Child, true, 0)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "name")]
+        public string ChildFamilyName
+        {
+            get => Subject?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Family;
+            set => updateFamilyName(value, Subject.Name);
+        }
+
+        /// <summary>Child's Suffix.</summary>
+        /// <value>the child's suffix</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.ChildSuffix = "Jr.";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Child Suffix: {ExampleBirthRecord.ChildSuffix}");</para>
+        /// </example>
+        [Property("ChildSuffix", Property.Types.String, "Child Demographics", "Child's Suffix.", true, VR.IGURL.Child, true, 6)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "name")]
+        public string ChildSuffix
+        {
+            get => Subject?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Suffix.FirstOrDefault();
+            set => updateSuffix(value, Subject.Name);
+        }
+
+        /// <summary>Child's Date of Birth.</summary>
+        /// <value>the child's date of birth</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.DateOfBirth = "1940-02-19";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Child Date of Birth: {ExampleBirthRecord.DateOfBirth}");</para>
+        /// </example>
+        [Property("Date Of Birth", Property.Types.String, "Child Demographics", "Child's Date of Birth.", true, VR.IGURL.Child, true, 14)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient).birthDate", "")]
+        public string DateOfBirth
+        {
+            get => GetDateOfDelivery();
+            set => SetDateOfDelivery(value);
         }
     }
 }

--- a/projects/BFDR/Connectathon.cs
+++ b/projects/BFDR/Connectathon.cs
@@ -41,7 +41,7 @@ namespace BFDR
 
             if (record != null && state != null)
             {
-                record.BirthLocationJurisdiction = state;
+                record.EventLocationJurisdiction = state;
             }
 
             if (record != null && year != null)

--- a/projects/BFDR/FetalDeathRecord.cs
+++ b/projects/BFDR/FetalDeathRecord.cs
@@ -89,14 +89,8 @@ namespace BFDR
         [FHIRPath("Bundle.entry.resource.where($this is Patient)", "name")]
         public string[] FetusGivenNames
         {
-            get
-            {
-                return Subject?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Given?.ToArray() ?? new string[0];
-            }
-            set
-            {
-                updateGivenHumanName(value, Subject.Name);
-            }
+            get => Subject?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Given?.ToArray() ?? new string[0];
+            set => updateGivenHumanName(value, Subject.Name);
         }
 
         /// <summary>Fetus' Legal Name - Last.</summary>
@@ -112,14 +106,8 @@ namespace BFDR
         [FHIRPath("Bundle.entry.resource.where($this is Patient)", "name")]
         public string FetusFamilyName
         {
-            get
-            {
-                return Subject?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Family;
-            }
-            set
-            {
-                updateFamilyName(value, Subject.Name);
-            }
+            get => Subject?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Family;
+            set => updateFamilyName(value, Subject.Name);
         }
 
         /// <summary>Fetus' Suffix.</summary>
@@ -134,14 +122,8 @@ namespace BFDR
         [FHIRPath("Bundle.entry.resource.where($this is Patient)", "name")]
         public string FetusSuffix
         {
-            get
-            {
-                return Subject?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Suffix.FirstOrDefault();
-            }
-            set
-            {
-                updateSuffix(value, Subject.Name);
-            }
+            get => Subject?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Suffix.FirstOrDefault();
+            set => updateSuffix(value, Subject.Name);
         }
 
         /// <summary>The place of delivery Type.</summary>
@@ -1164,20 +1146,8 @@ namespace BFDR
         [FHIRPath("Bundle.entry.resource.where($this is Patient).birthDate", "")]
         public string DateOfDelivery
         {
-            get
-            {
-                if (this.Subject == null || this.Subject.BirthDateElement == null)
-                {
-                    return null;
-                }
-                return this.Subject.BirthDate;
-            }
-            set
-            {
-                string time = this.GetBirthTime();
-                this.Subject.BirthDateElement = ConvertToDate(value);
-                this.SetBirthTime(time);
-            }
+            get => GetDateOfDelivery();
+            set => SetDateOfDelivery(value);
         }
 
         /// <summary>Decedent Fetus's Year of Delivery.</summary>
@@ -1236,7 +1206,7 @@ namespace BFDR
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Decedent Fetus Time of Birth: {ExampleFetalDeathRecord.DeliveryTime}");</para>
         /// </example>
-        [Property("BirthTime", Property.Types.String, "Fetus Demographics", "Decedent Fetus's Time of Birth.", true, BFDR.IGURL.PatientDecedentFetus, true, 14)]
+        [Property("DeliveryTime", Property.Types.String, "Fetus Demographics", "Decedent Fetus's Time of Delivery.", true, BFDR.IGURL.PatientDecedentFetus, true, 14)]
         // How should FHIRPath work when the time could be in 1 of 2 different places (value in PatientBirthTime | PartialDateTime extension)
         [FHIRPath("Bundle.entry.resource.where($this is Patient).birthDate.extension.where(url='" + VR.ExtensionURL.PatientBirthTime + "')", "")]
         public string DeliveryTime

--- a/projects/BFDR/IJEFetalDeath.cs
+++ b/projects/BFDR/IJEFetalDeath.cs
@@ -198,17 +198,8 @@ namespace BFDR
         [IJEField(2, 5, 2, "State, U.S. Territory or Canadian Province of Place of Delivery - code", "DSTATE", 1)]
         public string DSTATE
         {
-            get
-            {
-                return Dictionary_Geo_Get("DSTATE", "PlaceOfBirth", "address", "state", true);
-            }
-            set
-            {
-                if (!String.IsNullOrWhiteSpace(value))
-                {
-                    Dictionary_Set("DSTATE", "PlaceOfBirth", "addressState", value);
-                }
-            }
+            get => LeftJustified_Get("DSTATE", "EventLocationJurisdiction");
+            set => LeftJustified_Set("DSTATE", "EventLocationJurisdiction", value);
         }
 
         /// <summary>Certificate Number</summary>

--- a/projects/BFDR/NatalityRecord_constructors.cs
+++ b/projects/BFDR/NatalityRecord_constructors.cs
@@ -150,7 +150,7 @@ namespace BFDR
                 year = (uint)this.GetYear();
             }
             
-            String jurisdictionId = this.BirthLocationJurisdiction;
+            String jurisdictionId = this.EventLocationJurisdiction;
             if (jurisdictionId == null || jurisdictionId.Trim().Length < 2)
             {
                 jurisdictionId = "XX";

--- a/projects/BFDR/NatalityRecord_submissionProperties.cs
+++ b/projects/BFDR/NatalityRecord_submissionProperties.cs
@@ -283,34 +283,6 @@ namespace BFDR
             return year != null && month != null && day != null;
         }
 
-        /// <summary>Child's Date of Birth.</summary>
-        /// <value>the child's date of birth</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.DateOfBirth = "1940-02-19";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Child Date of Birth: {ExampleBirthRecord.DateOfBirth}");</para>
-        /// </example>
-        [Property("Date Of Birth", Property.Types.String, "Child Demographics", "Child's Date of Birth.", true, VR.IGURL.Child, true, 14)]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient).birthDate", "")]
-        public string DateOfBirth
-        {
-            get
-            {
-                if (this.Subject == null || this.Subject.BirthDateElement == null)
-                {
-                    return null;
-                }
-                return this.Subject.BirthDate;
-            }
-            set
-            {
-                string time = this.GetBirthTime();
-                this.Subject.BirthDateElement = ConvertToDate(value);
-                this.SetBirthTime(time);
-            }
-        }
-
         // TODO: waiting to figure out how to differentiate between Encounters in the record
         // /// <summary>Certified Year</summary>
         // /// <value>year of certification</value>
@@ -383,31 +355,31 @@ namespace BFDR
             {
                 Console.WriteLine($"Failed to set BirthSex: {ex}");
             }
-
-
         }
 
-        /// <summary>Child's Legal Name - Given. Middle name should be the last entry.</summary>
-        /// <value>the child's name (first, etc., middle)</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>string[] names = { "Example", "Something", "Middle" };</para>
-        /// <para>ExampleBirthRecord.ChildGivenNames = names;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Child Given Name(s): {string.Join(", ", ExampleBirthRecord.ChildGivenNames)}");</para>
-        /// </example>
-        [Property("Child Given Names", Property.Types.StringArr, "Child Demographics", "Child’s First Name.", true, VR.IGURL.Child, true, 0)]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "name")]
-        public string[] ChildGivenNames
+
+        /// <summary>
+        /// Gets the date of delivery of the subject child or fetus.
+        /// </summary>
+        /// <returns>The date of delivery</returns>
+        protected string GetDateOfDelivery()
         {
-            get
+            if (this.Subject == null || this.Subject.BirthDateElement == null)
             {
-                return Subject?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Given?.ToArray() ?? new string[0];
+                return null;
             }
-            set
-            {
-                updateGivenHumanName(value, Subject.Name);
-            }
+            return this.Subject.BirthDate;
+        }
+
+        /// <summary>
+        /// Sets the date of the delivery of the subject child or fetus.
+        /// </summary>
+        /// <param name="value"></param>
+        protected void SetDateOfDelivery(string value)
+        {
+            string time = this.GetBirthTime();
+            this.Subject.BirthDateElement = ConvertToDate(value);
+            this.SetBirthTime(time);
         }
 
         /// <summary>Mother's Legal Name - Given. Middle name should be the last entry.</summary>
@@ -476,29 +448,6 @@ namespace BFDR
             set
             {
                 updateGivenHumanName(value, Mother.Name, HumanName.NameUse.Maiden);
-            }
-        }
-
-        /// <summary>Child's Legal Name - Last.</summary>
-        /// <value>the child's last name</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>string lastName = "Quinn";</para>
-        /// <para>ExampleBirthRecord.ChildFamilyName = lastName;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Child Family Name(s): {string.Join(", ", ExampleBirthRecord.ChildFamilyName)}");</para>
-        /// </example>
-        [Property("Child Family Name", Property.Types.String, "Child Demographics", "Child's Last Name.", true, VR.IGURL.Child, true, 0)]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "name")]
-        public string ChildFamilyName
-        {
-            get
-            {
-                return Subject?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Family;
-            }
-            set
-            {
-                updateFamilyName(value, Subject.Name);
             }
         }
 
@@ -611,28 +560,6 @@ namespace BFDR
             }
         }
 
-        /// <summary>Child's Suffix.</summary>
-        /// <value>the child's suffix</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.ChildSuffix = "Jr.";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Child Suffix: {ExampleBirthRecord.ChildSuffix}");</para>
-        /// </example>
-        [Property("ChildSuffix", Property.Types.String, "Child Demographics", "Child's Suffix.", true, VR.IGURL.Child, true, 6)]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "name")]
-        public string ChildSuffix
-        {
-            get
-            {
-                return Subject?.Name?.Find(name => name.Use == HumanName.NameUse.Official)?.Suffix.FirstOrDefault();
-            }
-            set
-            {
-                updateSuffix(value, Subject.Name);
-            }
-        }
-
         /// <summary>Mother's Suffix.</summary>
         /// <value>the mother's suffix</value>
         /// <example>
@@ -720,14 +647,14 @@ namespace BFDR
         /// <value>the vital record jurisdiction identifier.</value>
         /// <example>
         /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.BirthLocationJurisdiction = "MA";</para>
+        /// <para>ExampleBirthRecord.EventLocationJurisdiction = "MA";</para>
         /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Birth Location Jurisdiction: {ExampleBirthRecord.BirthLocationJurisdiction}");</para>
+        /// <para>Console.WriteLine($"Birth Location Jurisdiction: {ExampleBirthRecord.EventLocationJurisdiction}");</para>
         /// </example>
         [Property("Birth Location Jurisdiction", Property.Types.String, "Birth Location", "Vital Records Jurisdiction of Birth Location (two character jurisdiction code, e.g. CA).", true, VR.IGURL.Child, false, 16)]
         // TODO - Currently not sure where the birth location would be in the record via FHIRPath, it seems different in BFDR vs VRDR. Some of the property fields above also need updating. Is this not in PatientChildVitalRecords at all and I just can't find it? There seems to be no reference to a jurisdiction location in the IG table of contents.
         [FHIRPath("Bundle.entry.resource.where($this is Location).where(type.coding.code='birth')", "")]
-        public string BirthLocationJurisdiction
+        public string EventLocationJurisdiction
         {
             get
             {
@@ -6722,6 +6649,11 @@ namespace BFDR
             }
         }
 
+        /// <summary>
+        /// Gets the value of the observation matching the given code as a FhirQuanity.
+        /// </summary>
+        /// <param name="code"></param>
+        /// <returns></returns>
         protected int? GetWeight(string code)
         {
             var entry = Bundle.Entry.Where(e => e.Resource is Observation obs && CodeableConceptToDict(obs.Code)["code"] == code).FirstOrDefault();
@@ -6733,6 +6665,15 @@ namespace BFDR
             return null;
         }
 
+        /// <summary>
+        /// Sets the vital-sign weight of the given subject id in an observation matching the given code.
+        /// </summary>
+        /// <param name="code"></param>
+        /// <param name="value"></param>
+        /// <param name="unit"></param>
+        /// <param name="section"></param>
+        /// <param name="subjectId"></param>
+        /// <returns></returns>
         protected Observation SetWeight(string code, int? value, string unit, string section, string subjectId)
         {
             var entry = Bundle.Entry.Where(e => e.Resource is Observation o && CodeableConceptToDict(o.Code)["code"] == code).FirstOrDefault();
@@ -9343,6 +9284,13 @@ namespace BFDR
             }
         }
 
+        /// <summary>
+        /// Gets the certification date element of the given encounter based on whether it's a day, month, or year element.
+        /// </summary>
+        /// <param name="encounter"></param>
+        /// <param name="dateUrl">The type of date element to extract</param>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
         protected int? GetCertifiedDateElement(Encounter encounter, string dateUrl)
         {
             if (encounter == null)
@@ -9371,6 +9319,12 @@ namespace BFDR
             return GetDateFragmentOrPartialDate(certifier.Period.StartElement, dateUrl);
         }
 
+        /// <summary>
+        /// Sets the certification date of the given encounter.
+        /// </summary>
+        /// <param name="encounter"></param>
+        /// <param name="dateUrl">The type of date format such as PartialDate or PartialDateTime</param>
+        /// <param name="value"></param>
         protected void SetCertifiedDateElement(Encounter encounter, string dateUrl, int? value)
         {
             if (value == null)
@@ -9424,11 +9378,22 @@ namespace BFDR
             // }
         }
 
+        /// <summary>
+        /// Gets the certification date from the given encounter.
+        /// </summary>
+        /// <param name="encounter"></param>
+        /// <returns></returns>
         protected string GetCertificationDate(Encounter encounter)
         {
             Encounter.ParticipantComponent certifier = encounter?.Participant?.FirstOrDefault(entry => ((Encounter.ParticipantComponent)entry).Type.Any(t => t.Coding.Any(c => c.Code == "87287-9")));
             return certifier?.Period?.Start;
         }
+
+        /// <summary>
+        /// Sets the certification date of the given encounter.
+        /// </summary>
+        /// <param name="encounter"></param>
+        /// <param name="value"></param>
         protected void SetCertificationDate(Encounter encounter, string value)
         {
             Encounter.ParticipantComponent certifier = encounter.Participant.FirstOrDefault(entry => ((Encounter.ParticipantComponent)entry).Type.Any(t => t.Coding.Any(c => c.Code == "87287-9")));

--- a/projects/Canary.Tests/RecordTests.cs
+++ b/projects/Canary.Tests/RecordTests.cs
@@ -40,10 +40,10 @@ namespace canary.tests
             };
             _recController.ControllerContext.HttpContext = httpContext;
             var response = await _recController.NewPostAsync("bfdr-birth");
-            ((BirthRecord) response.Item1.GetRecord()).BirthLocationJurisdiction = "AZ";
+            ((BirthRecord) response.Item1.GetRecord()).EventLocationJurisdiction = "AZ";
             ((BirthRecord) response.Item1.GetRecord()).CertificateNumber = "99991";
             BirthRecord br = new BirthRecord(romeroJson);
-            br.BirthLocationJurisdiction = "AZ";
+            br.EventLocationJurisdiction = "AZ";
             br.CertificateNumber = "99991";
 
             Assert.Equal(JsonConvert.SerializeObject(br), JsonConvert.SerializeObject(new BirthRecord(response.Item1.Json)));

--- a/projects/Canary/Models/BirthRecordFaker.cs
+++ b/projects/Canary/Models/BirthRecordFaker.cs
@@ -192,7 +192,7 @@ namespace canary.Models
                 record.FatherRace = new Tuple<string, string>[] { race1 };
                 record.MotherRace = new Tuple<string, string>[] { race2 };
             }
-            record.BirthLocationJurisdiction = state;
+            record.EventLocationJurisdiction = state;
             Dictionary<string, string> birthAddress = new Dictionary<string, string>();
             birthAddress.Add("addressLine1", $"{faker.Random.Number(999) + 1} Main Street");
             birthAddress.Add("addressCity", "Springfield");

--- a/projects/Canary/Models/FetalDeathFaker.cs
+++ b/projects/Canary/Models/FetalDeathFaker.cs
@@ -19,9 +19,9 @@ namespace canary.Models
             // Grab Gender enum value
             Bogus.DataSets.Name.Gender gender = sex == "Male" ? Bogus.DataSets.Name.Gender.Male : Bogus.DataSets.Name.Gender.Female;
             record.CertificateNumber = Convert.ToString(faker.Random.Number(999999));
-            record.ChildGivenNames = new string[] { faker.Name.FirstName(gender), faker.Name.FirstName(gender) };
-            record.ChildFamilyName = faker.Name.LastName(gender);
-            record.ChildSuffix = faker.Name.Suffix();
+            record.FetusGivenNames = new string[] { faker.Name.FirstName(gender), faker.Name.FirstName(gender) };
+            record.FetusFamilyName = faker.Name.LastName(gender);
+            record.FetusSuffix = faker.Name.Suffix();
             record.InfantMedicalRecordNumber = "912912";
             record.MotherMedicalRecordNumber = "876876";
             record.MotherSocialSecurityNumber = faker.Person.Ssn();
@@ -35,7 +35,7 @@ namespace canary.Models
             record.FatherOccupation = "COO";
             DateTime birth = faker.Date.Recent();
             DateTimeOffset birthUtc = new DateTimeOffset(birth.Year, birth.Month, birth.Day, 0, 0, 0, TimeSpan.Zero);
-            record.DateOfBirth = birthUtc.ToString("yyyy-MM-dd");
+            record.DateOfDelivery = birthUtc.ToString("yyyy-MM-dd");
             birth = faker.Date.Past(123, DateTime.Today.AddYears(-18));
             birthUtc = new DateTimeOffset(birth.Year, birth.Month, birth.Day, 0, 0, 0, TimeSpan.Zero);
             record.FatherDateOfBirth = birthUtc.ToString("yyyy-MM-dd");


### PR DESCRIPTION
For Fetal Death, there are some birth-specific properties that should not be present on the fetal death side but are because those properties are in the common NatalityRecord class. This became apparent when viewing a Fetal Death Record in Canary.
This resulted in several duplicates such as:

ChildGivenName and FetusGivenName
- `DateOfBirth` vs `DateOfDelivery`