### PR TITLE
fix(canary): fix record extraction bug in message inspector

### DIFF
--- a/projects/Canary/Controllers/MessagesController.cs
+++ b/projects/Canary/Controllers/MessagesController.cs
@@ -74,7 +74,7 @@ namespace canary.Controllers
                     string extractedRecordString = ControllerMappers.createEmptyRecord[recordType]().ToJSON();
                     foreach (PropertyInfo property in message.GetType().GetProperties())
                     {
-                        if (property.PropertyType == typeof(VitalRecord))
+                        if (property.PropertyType.IsSubclassOf(typeof(VitalRecord)))
                         {
                             extractedRecordString = ((VitalRecord)property.GetValue(message)).ToJSON();
                         }


### PR DESCRIPTION
This pull request addresses an issue where the message inspector tools in Canary weren't displaying values for any message types. 