### PR TITLE
feat(vr): 724 adds error message clarity to canary

### DIFF
--- a/projects/BFDR/BFDR.xml
+++ b/projects/BFDR/BFDR.xml
@@ -3392,7 +3392,7 @@
         <member name="M:BFDR.NatalityRecord.InitializeCompositionAndSubject">
             <summary>Initialize Composition and Subject.</summary>
         </member>
-        <member name="M:BFDR.NatalityRecord.#ctor(System.String,System.Boolean)">
+        <member name="M:BFDR.NatalityRecord.#ctor(System.String,System.String[],System.Boolean)">
             <summary>Constructor that takes a string that represents a FHIR Natality Record in either XML or JSON format.</summary>
             <param name="record">represents a FHIR Natality Record in either XML or JSON format.</param>
             <param name="permissive">if the parser should be permissive when parsing the given string</param>

--- a/projects/BFDR/BirthRecord_constructors.cs
+++ b/projects/BFDR/BirthRecord_constructors.cs
@@ -28,7 +28,7 @@ namespace BFDR
         /// <param name="record">represents a FHIR Birth Record in either XML or JSON format.</param>
         /// <param name="permissive">if the parser should be permissive when parsing the given string</param>
         /// <exception cref="ArgumentException">Record is neither valid XML nor JSON.</exception>
-        public BirthRecord(string record, bool permissive = false) : base(record, permissive) {}
+        public BirthRecord(string record, bool permissive = false) : base(record, new[] { ProfileURL.BundleDocumentBirthReport }, permissive) {}
 
         /// <summary>Constructor that takes a FHIR Bundle that represents a FHIR Birth Record.</summary>
         /// <param name="bundle">represents a FHIR Bundle.</param>

--- a/projects/BFDR/FetalDeathRecord_constructors.cs
+++ b/projects/BFDR/FetalDeathRecord_constructors.cs
@@ -26,7 +26,7 @@ namespace BFDR
     /// <param name="record">represents a FHIR FetalDeath Record in either XML or JSON format.</param>
     /// <param name="permissive">if the parser should be permissive when parsing the given string</param>
     /// <exception cref="ArgumentException">Record is neither valid XML nor JSON.</exception>
-    public FetalDeathRecord(string record, bool permissive = false) : base(record, permissive) { }
+    public FetalDeathRecord(string record, bool permissive = false) : base(record, new[] { ProfileURL.BundleDocumentFetalDeathReport  }, permissive) { }
 
     /// <summary>Constructor that takes a FHIR Bundle that represents a FHIR FetalDeath Record.</summary>
     /// <param name="bundle">represents a FHIR Bundle.</param>

--- a/projects/BFDR/NatalityRecord_constructors.cs
+++ b/projects/BFDR/NatalityRecord_constructors.cs
@@ -122,7 +122,7 @@ namespace BFDR
         /// <param name="record">represents a FHIR Natality Record in either XML or JSON format.</param>
         /// <param name="permissive">if the parser should be permissive when parsing the given string</param>
         /// <exception cref="ArgumentException">Record is neither valid XML nor JSON.</exception>
-        public NatalityRecord(string record, bool permissive = false) : base(record, permissive){}
+        public NatalityRecord(string record, string[] validProfiles, bool permissive = false) : base(record, validProfiles, permissive) {}
 
         /// <summary>Constructor that takes a FHIR Bundle that represents a FHIR Natality Record.</summary>
         /// <param name="bundle">represents a FHIR Bundle.</param>

--- a/projects/VRDR/DeathRecord_constructors.cs
+++ b/projects/VRDR/DeathRecord_constructors.cs
@@ -97,7 +97,7 @@ namespace VRDR
         /// <param name="record">represents a FHIR Death Record in either XML or JSON format.</param>
         /// <param name="permissive">if the parser should be permissive when parsing the given string</param>
         /// <exception cref="ArgumentException">Record is neither valid XML nor JSON.</exception>
-        public DeathRecord(string record, bool permissive = false) : base(record, permissive){}
+        public DeathRecord(string record, bool permissive = false) : base(record, new[] { ProfileURL.DeathCertificateDocument }, permissive){}
 
         /// <summary>Constructor that takes a FHIR Bundle that represents a FHIR Death Record.</summary>
         /// <param name="bundle">represents a FHIR Bundle.</param>

--- a/projects/VitalRecord/VitalRecord.xml
+++ b/projects/VitalRecord/VitalRecord.xml
@@ -6823,7 +6823,7 @@
         <member name="M:VR.VitalRecord.#ctor">
             <summary>Default constructor that creates a new, empty Record.</summary>
         </member>
-        <member name="M:VR.VitalRecord.#ctor(System.String,System.Boolean)">
+        <member name="M:VR.VitalRecord.#ctor(System.String,System.String[],System.Boolean)">
             <summary>Constructor that takes a string that represents a FHIR Vital Record in either XML or JSON format.</summary>
             <param name="record">represents a FHIR Vital Record in either XML or JSON format.</param>
             <param name="permissive">if the parser should be permissive when parsing the given string</param>

--- a/projects/VitalRecord/VitalRecord_constructors.cs
+++ b/projects/VitalRecord/VitalRecord_constructors.cs
@@ -13,7 +13,7 @@ namespace VR
     public abstract partial class VitalRecord
     {
         /// <summary>Default constructor that creates a new, empty Record.</summary>
-        public VitalRecord()
+        protected VitalRecord()
         {
             Composition = new Composition();
         }
@@ -22,7 +22,7 @@ namespace VR
         /// <param name="record">represents a FHIR Vital Record in either XML or JSON format.</param>
         /// <param name="permissive">if the parser should be permissive when parsing the given string</param>
         /// <exception cref="ArgumentException">Record is neither valid XML nor JSON.</exception>
-        public VitalRecord(string record, bool permissive = false)
+        protected VitalRecord(string record, string[] validProfiles, bool permissive = false)
         {
             ParserSettings parserSettings = new ParserSettings
             {
@@ -77,6 +77,11 @@ namespace VR
                         }
                         FhirJsonParser parser = new FhirJsonParser(parserSettings);
                         Bundle = parser.Parse<Bundle>(record);
+                    }
+
+                    if(Bundle?.Meta?.Profile == null || !Bundle.Meta.Profile.Any(p => validProfiles.Contains(p)))
+                    {
+                        throw new Exception("Did not receive a valid vital record with a meta.profile of one of [" + String.Join(", ", validProfiles) + "]. Check if the given string is a valid record-only bundle.");
                     }
 
                     ValidatePartialDates(Bundle);


### PR DESCRIPTION
This PR aims to improve error message clarity in Canary, specifically for the case where a Message is submitted where a Record is expected.
It was a little ambiguous as to where this check should go since I felt it was iffy to make a record vs. message check at the Canary level since this isn't technically a Canary-specific issue and could impact the CLI as well. So the check is made at the Vital Record constructor level. However, it again felt iffy to have a hardcoded message vs. record check, so I took the approach of checking for a valid record, rather than explicitly checking if it's a message. Let me know any thoughts.