### PR TITLE
fix(vr): 722 remove use of meta in the library and 710 fix mother birthplace in canary

### DIFF
--- a/projects/BFDR.Tests/fixtures/json/BasicBirthRecord2.json
+++ b/projects/BFDR.Tests/fixtures/json/BasicBirthRecord2.json
@@ -38,8 +38,8 @@
                "coding":[
                   {
                      "system":"http://loinc.org",
-                     "code":"71230-7",
-                     "display":"Birth certificate"
+                     "code":"92011-6",
+                     "display":"Jurisdiction live birth report Document"
                   }
                ]
             },

--- a/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecord.json
+++ b/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecord.json
@@ -38,8 +38,8 @@
           "coding": [
             {
               "system": "http://loinc.org",
-              "code": "71230-7",
-              "display": "Fetal Death Report"
+              "code": "92010-8",
+              "display": "Jurisdiction fetal death report Document"
             }
           ]
         },

--- a/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecord.json
+++ b/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecord.json
@@ -50,6 +50,21 @@
           "reference": "urn:uuid:d0801c32-d417-41b7-a461-70f9cf163055"
         },
         "title": "Fetal Death Report",
+        "section": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "code": "92014-0"
+                }
+              ]
+            },
+            "focus": {
+              "reference": "urn:uuid:18ef120e-0b0b-49d5-85f7-acb8f3a583b7"
+            }
+          }
+        ],
         "attester": [
           {
             "mode": "legal"

--- a/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecord2.json
+++ b/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecord2.json
@@ -34,8 +34,8 @@
           "coding": [
             {
               "system": "http://loinc.org",
-              "code": "71230-7",
-              "display": "Fetal Death Report"
+              "code": "92010-8",
+              "display": "Jurisdiction fetal death report Document"
             }
           ]
         },

--- a/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecordSubmissionMessage.json
+++ b/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecordSubmissionMessage.json
@@ -84,8 +84,8 @@
                 "coding": [
                   {
                     "system": "http://loinc.org",
-                    "code": "71230-7",
-                    "display": "Fetal Death Report"
+                    "code": "92010-8",
+                    "display": "Jurisdiction fetal death report Document"
                   }
                 ]
               },

--- a/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecordSubmissionMessage_acknowledgement.json
+++ b/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecordSubmissionMessage_acknowledgement.json
@@ -1,14 +1,14 @@
 {
   "resourceType": "Bundle",
-  "id": "9b453f04-6590-4252-a404-761d22703ddf",
+  "id": "b0d3ddd4-b113-4ce4-b2ae-03ad3a4ed46c",
   "type": "message",
-  "timestamp": "2025-02-10T10:52:38.203039-05:00",
+  "timestamp": "2025-02-27T13:26:04.018841-05:00",
   "entry": [
     {
-      "fullUrl": "urn:uuid:c8790167-f586-4471-8dfb-029158a8f12c",
+      "fullUrl": "urn:uuid:aa6c45e1-2a53-42fd-8244-0f7562d68659",
       "resource": {
         "resourceType": "MessageHeader",
-        "id": "c8790167-f586-4471-8dfb-029158a8f12c",
+        "id": "aa6c45e1-2a53-42fd-8244-0f7562d68659",
         "eventUri": "http://nchs.cdc.gov/fd_acknowledgement",
         "destination": [
           {
@@ -25,10 +25,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:00ee54e7-78a0-4bc1-b3b1-09819dee8330",
+      "fullUrl": "urn:uuid:b0c33961-ea29-4bf9-be1f-5d0d06708585",
       "resource": {
         "resourceType": "Parameters",
-        "id": "00ee54e7-78a0-4bc1-b3b1-09819dee8330",
+        "id": "b0c33961-ea29-4bf9-be1f-5d0d06708585",
         "parameter": [
           {
             "name": "cert_no",

--- a/projects/BFDR.Tests/fixtures/json/BirthRecordDemographicsCodingMessage.json
+++ b/projects/BFDR.Tests/fixtures/json/BirthRecordDemographicsCodingMessage.json
@@ -1,79 +1,93 @@
 {
-    "resourceType": "Bundle",
-    "id": "b86878b8-6428-4467-be61-47be71884ce0",
-    "type": "message",
-    "timestamp": "2023-12-21T17:29:07.589702-05:00",
-    "entry": [
-        {
-            "fullUrl": "urn:uuid:acba0c0a-6b83-464c-aa52-ce9cfb4ea7bc",
-            "resource": {
-                "resourceType": "MessageHeader",
-                "id": "acba0c0a-6b83-464c-aa52-ce9cfb4ea7bc",
-                "eventUri": "http://nchs.cdc.gov/birth_demographics_coding",
-                "destination": [
-                    {
-                        "endpoint": "http://nchs.cdc.gov/bfdr_submission"
-                    }
-                ],
-                "focus": [
-                    {
-                        "reference": "urn:uuid:c90e2253-3fb7-46d8-81ec-23329e9ed2fb"
-                    }
-                ]
-            }
+  "resourceType": "Bundle",
+  "id": "b86878b8-6428-4467-be61-47be71884ce0",
+  "type": "message",
+  "timestamp": "2023-12-21T17:29:07.589702-05:00",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:acba0c0a-6b83-464c-aa52-ce9cfb4ea7bc",
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "acba0c0a-6b83-464c-aa52-ce9cfb4ea7bc",
+        "eventUri": "http://nchs.cdc.gov/birth_demographics_coding",
+        "destination": [
+          {
+            "endpoint": "http://nchs.cdc.gov/bfdr_submission"
+          }
+        ],
+        "focus": [
+          {
+            "reference": "urn:uuid:c90e2253-3fb7-46d8-81ec-23329e9ed2fb"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:06c643ee-dd9e-4738-bdc8-5de512c7d94c",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "06c643ee-dd9e-4738-bdc8-5de512c7d94c",
+        "parameter": [
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 100
+          },
+          {
+            "name": "state_auxiliary_id",
+            "valueString": "123"
+          },
+          {
+            "name": "event_year",
+            "valueUnsignedInt": 2023
+          },
+          {
+            "name": "jurisdiction_id",
+            "valueString": "YC"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:c90e2253-3fb7-46d8-81ec-23329e9ed2fb",
+      "resource": {
+        "resourceType": "Bundle",
+        "id": "c90e2253-3fb7-46d8-81ec-23329e9ed2fb",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/bfdr/StructureDefinition/bfdr-demographic-coded-bundle"
+          ]
         },
-        {
-            "fullUrl": "urn:uuid:06c643ee-dd9e-4738-bdc8-5de512c7d94c",
-            "resource": {
-                "resourceType": "Parameters",
-                "id": "06c643ee-dd9e-4738-bdc8-5de512c7d94c",
-                "parameter": [
-                    {
-                        "name": "cert_no",
-                        "valueUnsignedInt": 100
-                    },
-                    {
-                        "name": "state_auxiliary_id",
-                        "valueString": "123"
-                    },
-                    {
-                        "name": "event_year",
-                        "valueUnsignedInt": 2023
-                    },
-                    {
-                        "name": "jurisdiction_id",
-                        "valueString": "YC"
-                    }
-                ]
+        "identifier": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/CertificateNumber",
+              "valueString": "100"
+            },
+            {
+              "url": "http://hl7.org/fhir/us/bfdr/StructureDefinition/AuxiliaryStateIdentifier1",
+              "valueString": "123"
             }
+          ],
+          "system": "http://nchs.cdc.gov/bfdr_id",
+          "value": "2023YC000100"
         },
-        {
-            "fullUrl": "urn:uuid:c90e2253-3fb7-46d8-81ec-23329e9ed2fb",
+        "type": "document",
+        "timestamp": "2023-12-21T17:29:07.592524-05:00",
+        "entry": [
+          {
+            "fullUrl": "urn:uuid:29f4acea-b70a-4170-bc9a-222d98e40919",
             "resource": {
-                "resourceType": "Bundle",
-                "id": "c90e2253-3fb7-46d8-81ec-23329e9ed2fb",
-                "meta": {
-                    "profile": [
-                        "http://hl7.org/fhir/us/bfdr/StructureDefinition/bfdr-demographic-coded-bundle"
-                    ]
-                },
-                "identifier": {
-                    "extension": [
-                        {
-                            "url": "http://hl7.org/fhir/us/vrdr/StructureDefinition/CertificateNumber",
-                            "valueString": "100"
-                        },
-                        {
-                            "url": "http://hl7.org/fhir/us/bfdr/StructureDefinition/AuxiliaryStateIdentifier1",
-                            "valueString": "123"
-                        }
-                    ],
-                    "system": "http://nchs.cdc.gov/bfdr_id",
-                    "value": "2023YC000100"
-                },
-                "type": "collection",
-                "timestamp": "2023-12-21T17:29:07.592524-05:00"
+              "resourceType": "Composition",
+              "id": "29f4acea-b70a-4170-bc9a-222d98e40919",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Composition-jurisdiction-live-birth-report"
+                ]
+              }
             }
-        }
-    ]
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/projects/BFDR.Tests/fixtures/json/BirthRecordDemographicsCodingUpdateMessage.json
+++ b/projects/BFDR.Tests/fixtures/json/BirthRecordDemographicsCodingUpdateMessage.json
@@ -71,8 +71,22 @@
           "system": "http://nchs.cdc.gov/bfdr_id",
           "value": "2023YC000100"
         },
-        "type": "collection",
-        "timestamp": "2023-12-21T17:30:04.866126-05:00"
+        "type": "document",
+        "timestamp": "2023-12-21T17:30:04.866126-05:00",
+        "entry": [
+          {
+            "fullUrl": "urn:uuid:29f4acea-b70a-4170-bc9a-222d98e40919",
+            "resource": {
+              "resourceType": "Composition",
+              "id": "29f4acea-b70a-4170-bc9a-222d98e40919",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Composition-jurisdiction-live-birth-report"
+                ]
+              }
+            }
+          }
+        ]
       }
     }
   ]

--- a/projects/BFDR.Tests/fixtures/json/BirthRecordFakeNoRace.json
+++ b/projects/BFDR.Tests/fixtures/json/BirthRecordFakeNoRace.json
@@ -38,8 +38,8 @@
           "coding": [
             {
               "system": "http://loinc.org",
-              "code": "71230-7",
-              "display": "Birth certificate"
+              "code": "92011-6",
+              "display": "Jurisdiction live birth report Document"
             }
           ]
         },

--- a/projects/BFDR.Tests/fixtures/json/BirthRecordFakeWithRace.json
+++ b/projects/BFDR.Tests/fixtures/json/BirthRecordFakeWithRace.json
@@ -38,8 +38,8 @@
           "coding": [
             {
               "system": "http://loinc.org",
-              "code": "71230-7",
-              "display": "Birth certificate"
+              "code": "92011-6",
+              "display": "Jurisdiction live birth report Document"
             }
           ]
         },

--- a/projects/BFDR.Tests/fixtures/json/BirthRecordR.json
+++ b/projects/BFDR.Tests/fixtures/json/BirthRecordR.json
@@ -34,8 +34,8 @@
           "coding": [
             {
               "system": "http://loinc.org",
-              "code": "71230-7",
-              "display": "Birth certificate"
+              "code": "92011-6",
+              "display": "Jurisdiction live birth report Document"
             }
           ]
         },

--- a/projects/BFDR.Tests/fixtures/json/BirthRecordSubmissionMessage.json
+++ b/projects/BFDR.Tests/fixtures/json/BirthRecordSubmissionMessage.json
@@ -92,8 +92,8 @@
                 "coding": [
                   {
                     "system": "http://loinc.org",
-                    "code": "71230-7",
-                    "display": "Birth certificate"
+                    "code": "92011-6",
+                    "display": "Jurisdiction live birth report Document"
                   }
                 ]
               },

--- a/projects/BFDR.Tests/fixtures/json/BirthRecordUpdateMessage.json
+++ b/projects/BFDR.Tests/fixtures/json/BirthRecordUpdateMessage.json
@@ -96,8 +96,8 @@
                 "coding": [
                   {
                     "system": "http://loinc.org",
-                    "code": "71230-7",
-                    "display": "Birth certificate"
+                    "code": "92011-6",
+                    "display": "Jurisdiction live birth report Document"
                   }
                 ]
               },

--- a/projects/BFDR.Tests/fixtures/json/BirthRecordZ.json
+++ b/projects/BFDR.Tests/fixtures/json/BirthRecordZ.json
@@ -34,8 +34,8 @@
           "coding": [
             {
               "system": "http://loinc.org",
-              "code": "71230-7",
-              "display": "Birth certificate"
+              "code": "92011-6",
+              "display": "Jurisdiction live birth report Document"
             }
           ]
         },

--- a/projects/BFDR.Tests/fixtures/json/MessageHeaderValidation.json
+++ b/projects/BFDR.Tests/fixtures/json/MessageHeaderValidation.json
@@ -92,8 +92,8 @@
                 "coding": [
                   {
                     "system": "http://loinc.org",
-                    "code": "71230-7",
-                    "display": "Birth certificate"
+                    "code": "92011-6",
+                    "display": "Jurisdiction live birth report Document"
                   }
                 ]
               },

--- a/projects/BFDR.Tests/fixtures/json/MessageHeaderValidationMissingYear.json
+++ b/projects/BFDR.Tests/fixtures/json/MessageHeaderValidationMissingYear.json
@@ -88,8 +88,8 @@
                 "coding": [
                   {
                     "system": "http://loinc.org",
-                    "code": "71230-7",
-                    "display": "Birth certificate"
+                    "code": "92011-6",
+                    "display": "Jurisdiction live birth report Document"
                   }
                 ]
               },

--- a/projects/BFDR.Tests/fixtures/json/RaceEthnicityCaseRecord.json
+++ b/projects/BFDR.Tests/fixtures/json/RaceEthnicityCaseRecord.json
@@ -34,8 +34,8 @@
           "coding": [
             {
               "system": "http://loinc.org",
-              "code": "71230-7",
-              "display": "Birth certificate"
+              "code": "92011-6",
+              "display": "Jurisdiction live birth report Document"
             }
           ]
         },

--- a/projects/BFDR.Tests/fixtures/json/RaceEthnicityCaseRecord2.json
+++ b/projects/BFDR.Tests/fixtures/json/RaceEthnicityCaseRecord2.json
@@ -34,8 +34,8 @@
           "coding": [
             {
               "system": "http://loinc.org",
-              "code": "71230-7",
-              "display": "Birth certificate"
+              "code": "92011-6",
+              "display": "Jurisdiction live birth report Document"
             }
           ]
         },

--- a/projects/BFDR.Tests/fixtures/xml/BasicFetalDeathRecord.xml
+++ b/projects/BFDR.Tests/fixtures/xml/BasicFetalDeathRecord.xml
@@ -27,8 +27,8 @@
         <type>
           <coding>
             <system value="http://loinc.org" />
-            <code value="71230-7" />
-            <display value="Fetal Death Report" />
+            <code value="92010-8" />
+            <display value="Jurisdiction fetal death report Document" />
           </coding>
         </type>
         <subject>

--- a/projects/BFDR/BFDR.xml
+++ b/projects/BFDR/BFDR.xml
@@ -3413,7 +3413,7 @@
             <summary>Helper method to return the subset of this record that makes up a DemographicCodedContent bundle.</summary>
             <returns>a new FHIR Bundle</returns>
         </member>
-        <member name="M:BFDR.NatalityRecord.RestoreReferences(System.String,System.String[],System.String)">
+        <member name="M:BFDR.NatalityRecord.RestoreReferences">
             <summary>Restores class references from a newly parsed record.</summary>
         </member>
         <member name="F:BFDR.NatalityRecord.Subject">
@@ -3436,6 +3436,9 @@
         </member>
         <member name="F:BFDR.NatalityRecord.EncounterMaternity">
             <summary>The maternity encounter.</summary>
+        </member>
+        <member name="F:BFDR.NatalityRecord.COMPOSITION_PROVIDER_FETAL_DEATH_REPORT">
+            <summary>Composition Type Constants</summary>
         </member>
         <member name="F:BFDR.NatalityRecord.MOTHER_PRENATAL_SECTION">
             <summary>Composition Section Constants</summary>

--- a/projects/BFDR/BirthRecord.cs
+++ b/projects/BFDR/BirthRecord.cs
@@ -34,7 +34,7 @@ namespace BFDR
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Encounter)", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Encounter).where(extension.value.coding.code='CHILD')", "")]
         public Dictionary<string, string> BirthPhysicalLocation
         {
             get => GetPhysicalLocation(EncounterBirth);
@@ -50,7 +50,7 @@ namespace BFDR
         /// <para>Console.WriteLine($"Child's Place Of Birth Type: {ExampleBirthRecord.BirthPhysicalLocationHelper}");</para>
         /// </example>
         [Property("BirthPhysicalLocationHelper", Property.Types.String, "Birth Physical Location", "Birth Physical Location Helper.", false, IGURL.EncounterBirth, true, 4)]
-        [FHIRPath("Bundle.entry.resource.where($this is Encounter).where(meta.profile == " + IGURL.EncounterBirth + ")", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Encounter).where(extension.value.coding.code='CHILD')", "")]
         public string BirthPhysicalLocationHelper
         {
             get => GetPhysicalLocationHelper(EncounterBirth);

--- a/projects/BFDR/BirthRecord_constructors.cs
+++ b/projects/BFDR/BirthRecord_constructors.cs
@@ -48,9 +48,9 @@ namespace BFDR
             base.RestoreReferences(ProfileURL.BundleDocumentBirthReport, new[] {ProfileURL.CompositionProviderLiveBirthReport, ProfileURL.CompositionJurisdictionLiveBirthReport}, VR.ProfileURL.Child);
             // Restore BirthRecord specific references.
             string birthEncounterId = Composition?.Encounter?.Reference;
-            EncounterBirth = Bundle.Entry.FindAll(entry => entry.Resource is Encounter).ConvertAll(entry => (Encounter) entry.Resource).Find(resource => resource.Meta.Profile.Any(p => p == ProfileURL.EncounterBirth) && birthEncounterId.Contains(resource.Id));
-            string encounterMaternityId = ((ResourceReference) Composition?.Encounter?.Extension.FirstOrDefault(e => e.Url == ExtensionURL.ExtensionEncounterMaternityReference)?.Value)?.Reference;
-            EncounterMaternity = Bundle.Entry.FindAll(entry => entry.Resource is Encounter).ConvertAll(entry => (Encounter) entry.Resource).Find(resource => resource.Meta.Profile.Any(p => p == ProfileURL.EncounterMaternity) && encounterMaternityId.Contains(resource.Id));
+            EncounterBirth = (Encounter)Bundle.Entry.Find(entry => entry.Resource is Encounter && birthEncounterId.Contains(entry.Resource.Id))?.Resource;
+            string maternityEncounterId = ((ResourceReference) Composition?.Encounter?.Extension.FirstOrDefault(e => e.Url == ExtensionURL.ExtensionEncounterMaternityReference)?.Value)?.Reference;
+            EncounterMaternity = (Encounter)Bundle.Entry.Find(entry => entry.Resource is Encounter && maternityEncounterId.Contains(entry.Resource.Id))?.Resource;
         }
 
         /// <inheritdoc/>

--- a/projects/BFDR/BirthRecord_constructors.cs
+++ b/projects/BFDR/BirthRecord_constructors.cs
@@ -68,7 +68,7 @@ namespace BFDR
             {
                 Profile = new[] { ProfileURL.CompositionJurisdictionLiveBirthReport }
             };
-            Composition.Type = new CodeableConcept(CodeSystems.LOINC, "71230-7", "Birth certificate", null);
+            Composition.Type = new CodeableConcept(CodeSystems.LOINC, "92011-6", "Jurisdiction live birth report Document", null);
             Composition.Title = "Birth Certificate";
         }
 

--- a/projects/BFDR/BirthRecord_constructors.cs
+++ b/projects/BFDR/BirthRecord_constructors.cs
@@ -45,7 +45,7 @@ namespace BFDR
         protected override void RestoreReferences()
         {
             // Restore the common references between Birth Records and Fetal Death Records.
-            base.RestoreReferences(ProfileURL.BundleDocumentBirthReport, new[] {ProfileURL.CompositionProviderLiveBirthReport, ProfileURL.CompositionJurisdictionLiveBirthReport}, VR.ProfileURL.Child);
+            base.RestoreReferences();
             // Restore BirthRecord specific references.
             string birthEncounterId = Composition?.Encounter?.Reference;
             EncounterBirth = (Encounter)Bundle.Entry.Find(entry => entry.Resource is Encounter && birthEncounterId.Contains(entry.Resource.Id))?.Resource;

--- a/projects/BFDR/FetalDeathRecord.cs
+++ b/projects/BFDR/FetalDeathRecord.cs
@@ -146,7 +146,7 @@ namespace BFDR
         [PropertyParam("code", "The code used to describe this concept.")]
         [PropertyParam("system", "The relevant code system.")]
         [PropertyParam("display", "The human readable version of this code.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Encounter)", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Encounter).where(extension.value.coding.code='MTH')", "")]
         public Dictionary<string, string> DeliveryPhysicalLocation
         {
             get => GetPhysicalLocation(EncounterMaternity);
@@ -162,7 +162,7 @@ namespace BFDR
         /// <para>Console.WriteLine($"Child's Place Of Birth Type: {ExampleFetalDeathRecord.DeliveryPhysicalLocationHelper}");</para>
         /// </example>
         [Property("DeliveryPhysicalLocationHelper", Property.Types.String, "Delivery Physical Location", "Delivery Physical Location Helper.", false, IGURL.EncounterMaternity, true, 4)]
-        [FHIRPath("Bundle.entry.resource.where($this is Encounter).where(meta.profile == " + IGURL.EncounterMaternity + ")", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Encounter).where(extension.value.coding.code='MTH')", "")]
         public string DeliveryPhysicalLocationHelper
         {
             get => GetPhysicalLocationHelper(EncounterMaternity);

--- a/projects/BFDR/FetalDeathRecord_constructors.cs
+++ b/projects/BFDR/FetalDeathRecord_constructors.cs
@@ -48,7 +48,7 @@ namespace BFDR
       this.RestoreReferences(ProfileURL.BundleDocumentFetalDeathReport, new[] { ProfileURL.CompositionJurisdictionFetalDeathReport }, ProfileURL.PatientDecedentFetus);
       // Restore FetalDeath specific references.
       string maternityEncounterId = Composition?.Encounter.Reference;
-      EncounterMaternity = Bundle.Entry.FindAll(entry => entry.Resource is Encounter).ConvertAll(entry => (Encounter)entry.Resource).Find(resource => resource.Meta.Profile.Any(p => p == ProfileURL.EncounterMaternity) && maternityEncounterId.Contains(resource.Id));
+      EncounterMaternity = (Encounter)Bundle.Entry.Find(entry => entry.Resource is Encounter && maternityEncounterId.Contains(entry.Resource.Id))?.Resource;
     }
 
     /// <inheritdoc/>

--- a/projects/BFDR/FetalDeathRecord_constructors.cs
+++ b/projects/BFDR/FetalDeathRecord_constructors.cs
@@ -68,7 +68,7 @@ namespace BFDR
       {
         Profile = new[] { ProfileURL.CompositionJurisdictionFetalDeathReport }
       };
-      Composition.Type = new CodeableConcept(CodeSystems.LOINC, "71230-7", "Fetal Death Report", null);
+      Composition.Type = new CodeableConcept(CodeSystems.LOINC, "92010-8", "Jurisdiction fetal death report Document", null);
       Composition.Title = "Fetal Death Report";
     }
   }

--- a/projects/BFDR/FetalDeathRecord_constructors.cs
+++ b/projects/BFDR/FetalDeathRecord_constructors.cs
@@ -45,9 +45,9 @@ namespace BFDR
     {
       // Do we need differentiate anything for [http://hl7.org/fhir/us/bfdr/StructureDefinition/Bundle-document-demographic-coded-content]? It's not technically a Fetal Death Report bundle... https://build.fhir.org/ig/HL7/fhir-bfdr/StructureDefinition-Bundle-document-demographic-coded-content.html
       // Restore the common references between Birth Records and Fetal Death Records.
-      this.RestoreReferences(ProfileURL.BundleDocumentFetalDeathReport, new[] { ProfileURL.CompositionJurisdictionFetalDeathReport }, ProfileURL.PatientDecedentFetus);
+      base.RestoreReferences();
       // Restore FetalDeath specific references.
-      string maternityEncounterId = Composition?.Encounter.Reference;
+      string maternityEncounterId = Composition?.Encounter?.Reference;
       EncounterMaternity = (Encounter)Bundle.Entry.Find(entry => entry.Resource is Encounter && maternityEncounterId.Contains(entry.Resource.Id))?.Resource;
     }
 

--- a/projects/BFDR/NatalityRecord_fieldsAndCreateMethods.cs
+++ b/projects/BFDR/NatalityRecord_fieldsAndCreateMethods.cs
@@ -43,6 +43,15 @@ namespace BFDR
         private const string CODED_RACE_ETHNICITY_PROFILE_FATHER = "codedraceandethnicityFather";
         private const string CODED_RACE_ETHNICITY_PROFILE_MOTHER = "codedraceandethnicityMother";
 
+        /// <summary>Composition Type Constants</summary>
+        private const string COMPOSITION_PROVIDER_FETAL_DEATH_REPORT = "69045-3";
+        private const string COMPOSITION_PROVIDER_LIVE_BIRTH_REPORT = "68998-4";
+        private const string COMPOSITION_JURISDICTION_FETAL_DEATH_REPORT = "92010-8";
+        private const string COMPOSITION_JURISDICTION_LIVE_BIRTH_REPORT  ="92011-6";
+        private const string COMPOSITION_CODED_CAUSE_OF_FETAL_DEATH = "86804-2";
+        private const string COMPOSITION_CODED_RACE_AND_ETHNICITY = "86805-9";
+        private const string COMPOSITION_CODED_INDUSTRY_AND_OCCUPATION = "industry_occupation_document";
+
         /// <summary>Composition Section Constants</summary>
         protected const string MOTHER_PRENATAL_SECTION = "57073-9";
         private const string MEDICAL_INFORMATION_SECTION = "55752-0";

--- a/projects/BFDR/NatalityRecord_submissionProperties.cs
+++ b/projects/BFDR/NatalityRecord_submissionProperties.cs
@@ -740,7 +740,12 @@ namespace BFDR
         [Property("Mother's Place Of Birth", Property.Types.Dictionary, "Mother Demographics", "Mother's Place Of Birth.", true, VR.IGURL.Mother, true, 305)]
         [PropertyParam("addressState", "address, state")]
         [PropertyParam("addressCountry", "address, country")]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient).extension.where(url='" + OtherExtensionURL.PatientBirthPlace + "')", "")]
+        // NOTE TODO: In order to distinguish between multiple patient records we would need to follow the subject
+        // reference; since following references is not available as part of the FHIR Path implementation in version
+        // 4.3.0 of the Hl7.Fhir.R4 library we fall back to using the Meta Profile URL, which is not guaranteed to
+        // be present but will either provide a correct result or blank; we can revisit this when the version of the
+        // FHIR library is updated to a version that supports following references
+        [FHIRPath("Bundle.entry.resource.where($this is Patient).where(meta.profile='" + VR.ProfileURL.Mother + "').extension.where(url='" + OtherExtensionURL.PatientBirthPlace + "')", "")]
         public Dictionary<string, string> MotherPlaceOfBirth
         {
             get => GetPlaceOfBirth(Mother);
@@ -8412,7 +8417,7 @@ namespace BFDR
         /// <para>Console.WriteLine($"Child's Place Of Birth Type: {ExampleBirthRecord.PayorTypeFinancialClassHelper}");</para>
         /// </example>
         [Property("PayorTypeFinancialClassHelper", Property.Types.String, "PayorTypeFinancialClassHelper", "Principal source of Payment for this delivery Helper.", false, IGURL.CoveragePrincipalPayerDelivery, true, 4)]
-        [FHIRPath("Bundle.entry.resource.where($this is Coverage).where(meta.profile == " + ProfileURL.CoveragePrincipalPayerDelivery + ")", "")]
+        [FHIRPath("Bundle.entry.resource.where($this is Coverage)", "")]
         public string PayorTypeFinancialClassHelper
         {
             get

--- a/projects/Canary.Tests/fixtures/json/BirthRecordR.json
+++ b/projects/Canary.Tests/fixtures/json/BirthRecordR.json
@@ -34,8 +34,8 @@
           "coding": [
             {
               "system": "http://loinc.org",
-              "code": "71230-7",
-              "display": "Birth certificate"
+              "code": "92011-6",
+              "display": "Jurisdiction live birth report Document"
             }
           ]
         },

--- a/projects/VRDR/DeathRecord_constructors.cs
+++ b/projects/VRDR/DeathRecord_constructors.cs
@@ -236,8 +236,8 @@ namespace VRDR
         protected override void RestoreReferences()
         {
             // Depending on the type of bundle, some of this information may not be present, so check it in a null-safe way
-            string profile = Bundle.Meta?.Profile?.FirstOrDefault();
-            bool fullRecord = VRDR.ProfileURL.DeathCertificateDocument.Equals(profile);
+            // Note: for VRDR, full record bundles are of type "document" and response bundles are of type collection
+            bool fullRecord = Bundle.Type == Bundle.BundleType.Document;
             // Grab Composition
             var compositionEntry = Bundle.Entry.FirstOrDefault(entry => entry.Resource is Composition);
             if (compositionEntry != null)


### PR DESCRIPTION
This pull request addresses NVSS-722: meta profile tags are not required to be present in FHIR documents, so should not be relied on when reading content from a VR record of any type; these changes update the code to use alternate approaches for finding content such as following references.

This pull request also provides a work around for NVSS-710. Canary uses FHIR paths to identify and display relevant sections of a FHIR document. The 4.3.0 version of the Hl7.Fhir.R4 library does not support following references in FHIR paths; until a newer version is available we make an exception to our avoidance of relying on meta profile tags since there is no other way to distinguish between the patient entries for the mother and the child.

Specific changes include

1. Updating fixtures to use correct type codes and include required content like compositions
2. Updating BFDR constructors to use correct type codes for compositions
3. Updating FHIR paths to avoid the use of meta.profile where possible (besides the one exception mentioned above)
4. Updating BFDR RestoreReferences() to reflect that BFDR records always have a composition, determine whether a subject is expected based on the composition type, and use references to find content rather than meta profiles
5. Updating VRDR RestoreReferences() to use the bundle type to determine whether a full record is present
