### PR TITLE
feat(canary): adds clear error message when message submitted for record

### DIFF
--- a/projects/BFDR/NatalityRecord_constructors.cs
+++ b/projects/BFDR/NatalityRecord_constructors.cs
@@ -17,7 +17,7 @@ namespace BFDR
     public abstract partial class NatalityRecord : VitalRecord
     {
         /// <summary>Default constructor that creates a new, empty NatalityRecord.</summary>
-        public NatalityRecord(string bundleProfile) : base()
+        protected NatalityRecord(string bundleProfile) : base()
         {
             InitializeCompositionAndSubject();
 
@@ -122,12 +122,12 @@ namespace BFDR
         /// <param name="record">represents a FHIR Natality Record in either XML or JSON format.</param>
         /// <param name="permissive">if the parser should be permissive when parsing the given string</param>
         /// <exception cref="ArgumentException">Record is neither valid XML nor JSON.</exception>
-        public NatalityRecord(string record, bool permissive = false) : base(record, permissive){}
+        protected NatalityRecord(string record, bool permissive = false) : base(record, permissive){}
 
         /// <summary>Constructor that takes a FHIR Bundle that represents a FHIR Natality Record.</summary>
         /// <param name="bundle">represents a FHIR Bundle.</param>
         /// <exception cref="ArgumentException">Record is invalid.</exception>
-        public NatalityRecord(Bundle bundle)
+        protected NatalityRecord(Bundle bundle)
         {
             Bundle = bundle;
             Navigator = Bundle.ToTypedElement();

--- a/projects/VitalRecord/VitalRecord_constructors.cs
+++ b/projects/VitalRecord/VitalRecord_constructors.cs
@@ -13,7 +13,7 @@ namespace VR
     public abstract partial class VitalRecord
     {
         /// <summary>Default constructor that creates a new, empty Record.</summary>
-        public VitalRecord()
+        protected VitalRecord()
         {
             Composition = new Composition();
         }
@@ -22,7 +22,7 @@ namespace VR
         /// <param name="record">represents a FHIR Vital Record in either XML or JSON format.</param>
         /// <param name="permissive">if the parser should be permissive when parsing the given string</param>
         /// <exception cref="ArgumentException">Record is neither valid XML nor JSON.</exception>
-        public VitalRecord(string record, bool permissive = false)
+        protected VitalRecord(string record, bool permissive = false)
         {
             ParserSettings parserSettings = new ParserSettings
             {

--- a/projects/VitalRecord/VitalRecord_constructors.cs
+++ b/projects/VitalRecord/VitalRecord_constructors.cs
@@ -97,6 +97,11 @@ namespace VR
             {
                 throw new System.ArgumentException("The given input does not appear to be a valid XML or JSON FHIR record.");
             }
+            // Validate that the given Bundle is not a message.
+            if (this.Bundle.Type == Bundle.BundleType.Message)
+            {
+                throw new Exception("Expected a Vital Record Bundle, given a Message.");
+            }
         }
         
         /// <summary>Restores class references from a newly parsed record.</summary>


### PR DESCRIPTION
This PR adds a clear error message when a Message is submitted when a Record is expected. This issue was made apparent at the Canary level, but this fix addresses the same issue at the CLI level.