### PR TITLE
fix(canary): add descriptions for payload version id and event year

### DIFF
--- a/projects/Canary/Models/CanaryBirthMessage.cs
+++ b/projects/Canary/Models/CanaryBirthMessage.cs
@@ -21,7 +21,9 @@ namespace canary.Models
             { "CertNo", "Birth Certificate Number (BirthRecord Identifier)" },
             { "StateAuxiliaryId", "Auxiliary State File Number (BirthRecord BundleIdentifier)" },
             { "NCHSIdentifier", "The NCHS compound identifier for the supplied BirthRecord" },
-            { "JurisdictionId", "Two character identifier of the jurisdiction in which the birth occurred" }
+            { "JurisdictionId", "Two character identifier of the jurisdiction in which the birth occurred" },
+            { "PayloadVersionId", "Identifier of the payload FHIR IG version" },
+            { "EventYear", "The year in which the birth occurred" }
         };
 
         public CanaryBirthMessage() { }

--- a/projects/Canary/Models/CanaryFetalDeathMessage.cs
+++ b/projects/Canary/Models/CanaryFetalDeathMessage.cs
@@ -21,7 +21,9 @@ namespace canary.Models
             { "CertNo", "Birth Certificate Number (BirthRecord Identifier)" },
             { "StateAuxiliaryId", "Auxiliary State File Number (BirthRecord BundleIdentifier)" },
             { "NCHSIdentifier", "The NCHS compound identifier for the supplied BirthRecord" },
-            { "JurisdictionId", "Two character identifier of the jurisdiction in which the birth occurred" }
+            { "JurisdictionId", "Two character identifier of the jurisdiction in which the birth occurred" },
+            { "PayloadVersionId", "Identifier of the payload FHIR IG version" },
+            { "EventYear", "The year in which the birth occurred" }
         };
 
         public CanaryFetalDeathMessage() { }

--- a/projects/VitalRecord.Messaging/CommonMessage.cs
+++ b/projects/VitalRecord.Messaging/CommonMessage.cs
@@ -357,7 +357,7 @@ namespace VR
             }
         }
 
-        /// <summary>Identifier of the payload version</summary>
+        /// <summary>Identifier of the payload FHIR IG version</summary>
         [FHIRPath("Bundle.entry.resource.where($this is Parameters)", "")]
         public string PayloadVersionId
         {
@@ -371,8 +371,9 @@ namespace VR
             }
         }
         /// TODO move this to an override for GetYear and SetYear in fetal death messaging
-        /// <summary>The year in which the fetal death occurred</summary>
+        /// <summary>The year in which the event occurred</summary>
         [FHIRPath("Bundle.entry.resource.where($this is Parameters)", "")]
+
         public uint? EventYear
         {
             get


### PR DESCRIPTION
Address ticket 714 Fix Unknown Properties in Canary. A couple properties were missing discriptions in the Canary Connectathon Message tool. Added the descriptions so now Canary displays the name correctly.