### PR TITLE
feat(bfdr): adding default value 1 block count

### DIFF
--- a/projects/BFDR.Messaging/BFDRVoidMessage.cs
+++ b/projects/BFDR.Messaging/BFDRVoidMessage.cs
@@ -69,6 +69,7 @@ namespace BFDR
         /// <summary>Default constructor that creates a new, empty BFDRVoidMessage.</summary>
         public BFDRVoidMessage() : base(MESSAGE_TYPE)
         {
+            BlockCount = 1;
         }
 
         /// <summary>
@@ -78,12 +79,14 @@ namespace BFDR
         /// <returns></returns>
         internal BFDRVoidMessage(Bundle messageBundle) : base(messageBundle)
         {
+            BlockCount = 1;
         }
 
         /// <summary>Constructor that takes a BFDR.NatalityRecord and creates a message to void that record.</summary>
         /// <param name="record">the BFDR.NatalityRecord to create a BFDRVoidMessage for.</param>
         public BFDRVoidMessage(NatalityRecord record) : this()
         {
+            BlockCount = 1;
             ExtractBusinessIdentifiers(record);
         }
 

--- a/projects/BFDR.Messaging/BFDRVoidMessage.cs
+++ b/projects/BFDR.Messaging/BFDRVoidMessage.cs
@@ -79,7 +79,10 @@ namespace BFDR
         /// <returns></returns>
         internal BFDRVoidMessage(Bundle messageBundle) : base(messageBundle)
         {
-            BlockCount = 1;
+            if (BlockCount == null)
+            {
+                BlockCount = 1;
+            }
         }
 
         /// <summary>Constructor that takes a BFDR.NatalityRecord and creates a message to void that record.</summary>

--- a/projects/BFDR.Tests/Messaging_Should.cs
+++ b/projects/BFDR.Tests/Messaging_Should.cs
@@ -315,12 +315,14 @@ namespace BFDR.Tests
             Assert.Null(message.StateAuxiliaryId);
             message.StateAuxiliaryId = "0000123";
             Assert.Equal("0000123", message.StateAuxiliaryId);
-            Assert.Null(message.BlockCount);
+            Assert.Equal((uint)1, message.BlockCount);
             message.BlockCount = 100;
             Assert.Equal((uint)100, message.BlockCount);
             message.BlockCount = 0;
             Assert.Equal((uint)0, message.BlockCount);
             Assert.Equal("BFDR_STU2_0", message.PayloadVersionId);
+            FetalDeathRecordVoidMessage message2 = new FetalDeathRecordVoidMessage();
+            Assert.Equal((uint)1, message2.BlockCount);
         }
 
         // TODO confirm if Voids exist in BFDR


### PR DESCRIPTION
This PR includes:
- adding a default block count value of 1 for birth and fetal death void messages