### PR TITLE
fix(bfdr): update fakerecord fetaldeath to include more data

### DIFF
--- a/projects/BFDR.CLI/Program.cs
+++ b/projects/BFDR.CLI/Program.cs
@@ -119,6 +119,17 @@ namespace BFDR.CLI
 
                 birthRecord.NoObstetricProcedures = true;
 
+                // Mother Residence
+                Dictionary<string, string> motherResidence = new Dictionary<string, string>();
+                motherResidence.Add("addressLine1", "7 Blue Street");
+                motherResidence.Add("addressCity", "Milford");
+                motherResidence.Add("addressCounty", "New Haven");
+                motherResidence.Add("addressState", "CT");
+                motherResidence.Add("addressZip", "06460");
+                motherResidence.Add("addressCountry", "US");
+                birthRecord.MotherResidence = motherResidence;
+
+                // Mother and Father birthdate
                 birthRecord.MotherBirthDay = 12;
                 birthRecord.MotherBirthMonth = 1;
                 birthRecord.MotherBirthYear = 1992;
@@ -128,23 +139,21 @@ namespace BFDR.CLI
                 birthRecord.FatherBirthYear = 1990;
                 birthRecord.FatherDateOfBirth = "1990-09-21";
 
+                // Mother and Father education
                 birthRecord.MotherEducationLevelHelper = VR.ValueSets.EducationLevel.Doctoral_Or_Post_Graduate_Education;
                 birthRecord.MotherEducationLevelEditFlagHelper = VR.ValueSets.EditBypass01234.Edit_Passed;
                 birthRecord.FatherEducationLevelHelper = VR.ValueSets.EducationLevel.Bachelors_Degree;
                 birthRecord.FatherEducationLevelEditFlagHelper = VR.ValueSets.EditBypass01234.Edit_Failed_Data_Queried_But_Not_Verified;
 
-                //Ethnicity
-                birthRecord.MotherEthnicityLiteral = VR.ValueSets.HispanicOrigin.Colombian;
+                // Mother and Father Ethnicity
+                birthRecord.MotherEthnicityLiteral = "Colombian";
                 birthRecord.MotherEthnicity3Helper = VR.ValueSets.YesNoUnknown.Yes;
-                // Race
+                // Mother and Father Race
                 Tuple<string, string>[] motherRace = { Tuple.Create(NvssRace.BlackOrAfricanAmerican, "Y")};
                 birthRecord.MotherRace = motherRace;
                 Tuple<string, string>[] fatherRace = { Tuple.Create(NvssRace.White, "Y")};
                 birthRecord.FatherRace = fatherRace;
-                birthRecord.MotherRaceTabulation1EHelper = VR.ValueSets.RaceCode.Colombian;
-                birthRecord.FatherRaceTabulation1EHelper = VR.ValueSets.RaceCode.Arab;
-                birthRecord.MotherEthnicityEditedCodeHelper = VR.ValueSets.HispanicOrigin.Colombian;
-                birthRecord.FatherEthnicityEditedCodeHelper = VR.ValueSets.HispanicOrigin.Non_Hispanic;
+
 
                 // Write out the Record
                 Console.WriteLine(birthRecord.ToJSON());
@@ -180,14 +189,14 @@ namespace BFDR.CLI
                
 
                 fetaldeathRecord.EventLocationJurisdiction = "MA";
-                Dictionary<string, string> birthAddress = new Dictionary<string, string>();
-                birthAddress.Add("addressLine1", "123 Fake Street");
-                birthAddress.Add("addressCity", "Springfield");
-                birthAddress.Add("addressCounty", "Hampden");
-                birthAddress.Add("addressState", "MA");
-                birthAddress.Add("addressZip", "01101");
-                birthAddress.Add("addressCountry", "US");
-                fetaldeathRecord.PlaceOfBirth = birthAddress;
+                Dictionary<string, string> deliveryAddress = new Dictionary<string, string>();
+                deliveryAddress.Add("addressLine1", "123 Fake Street");
+                deliveryAddress.Add("addressCity", "Springfield");
+                deliveryAddress.Add("addressCounty", "Hampden");
+                deliveryAddress.Add("addressState", "MA");
+                deliveryAddress.Add("addressZip", "01101");
+                deliveryAddress.Add("addressCountry", "US");
+                fetaldeathRecord.PlaceOfDelivery = deliveryAddress;
 
                 fetaldeathRecord.InfantMedicalRecordNumber = "7134703";
                 fetaldeathRecord.MotherMedicalRecordNumber = "2286144";
@@ -203,15 +212,27 @@ namespace BFDR.CLI
                 fetaldeathRecord.NoInfectionsPresentDuringPregnancy = true;
                 fetaldeathRecord.GestationalHypertension = true;
 
+                // Initiating Cause or Condition
+                fetaldeathRecord.PrematureRuptureOfMembranes = true;
 
                 Dictionary<string, string> route = new Dictionary<string, string>();
                 route.Add("code", "700000006");
                 route.Add("system", "http://snomed.info/sct");
                 route.Add("display", "Vaginal delivery of fetus (procedure)");
                 fetaldeathRecord.FinalRouteAndMethodOfDelivery = route;
-
                 fetaldeathRecord.NoObstetricProcedures = true;
 
+                // Mother Residence
+                Dictionary<string, string> motherResidence = new Dictionary<string, string>();
+                motherResidence.Add("addressLine1", "7 Blue Street");
+                motherResidence.Add("addressCity", "Milford");
+                motherResidence.Add("addressCounty", "New Haven");
+                motherResidence.Add("addressState", "CT");
+                motherResidence.Add("addressZip", "06460");
+                motherResidence.Add("addressCountry", "US");
+                fetaldeathRecord.MotherResidence = motherResidence;
+
+                // Mother and Father birthdates
                 fetaldeathRecord.MotherBirthDay = 12;
                 fetaldeathRecord.MotherBirthMonth = 1;
                 fetaldeathRecord.MotherBirthYear = 1992;
@@ -221,23 +242,21 @@ namespace BFDR.CLI
                 fetaldeathRecord.FatherBirthYear = 1990;
                 fetaldeathRecord.FatherDateOfBirth = "1990-09-21";
 
+                // Mother and Father Education
                 fetaldeathRecord.MotherEducationLevelHelper = VR.ValueSets.EducationLevel.Doctoral_Or_Post_Graduate_Education;
                 fetaldeathRecord.MotherEducationLevelEditFlagHelper = VR.ValueSets.EditBypass01234.Edit_Passed;
                 fetaldeathRecord.FatherEducationLevelHelper = VR.ValueSets.EducationLevel.Bachelors_Degree;
                 fetaldeathRecord.FatherEducationLevelEditFlagHelper = VR.ValueSets.EditBypass01234.Edit_Failed_Data_Queried_But_Not_Verified;
 
-                //Ethnicity
-                fetaldeathRecord.MotherEthnicityLiteral = VR.ValueSets.HispanicOrigin.Colombian;
+                // Mother and Father Ethnicity
+                fetaldeathRecord.MotherEthnicityLiteral = "Colombian";
                 fetaldeathRecord.MotherEthnicity3Helper = VR.ValueSets.YesNoUnknown.Yes;
-                // Race
+                // Mother and Father Race
                 Tuple<string, string>[] motherRace = { Tuple.Create(NvssRace.BlackOrAfricanAmerican, "Y")};
                 fetaldeathRecord.MotherRace = motherRace;
                 Tuple<string, string>[] fatherRace = { Tuple.Create(NvssRace.White, "Y")};
                 fetaldeathRecord.FatherRace = fatherRace;
-                fetaldeathRecord.MotherRaceTabulation1EHelper = VR.ValueSets.RaceCode.Colombian;
-                fetaldeathRecord.FatherRaceTabulation1EHelper = VR.ValueSets.RaceCode.Arab;
-                fetaldeathRecord.MotherEthnicityEditedCodeHelper = VR.ValueSets.HispanicOrigin.Colombian;
-                fetaldeathRecord.FatherEthnicityEditedCodeHelper = VR.ValueSets.HispanicOrigin.Non_Hispanic;
+
 
                 // Write out the Record
                 Console.WriteLine(fetaldeathRecord.ToJSON());

--- a/projects/BFDR.Tests/BirthRecord_Should.cs
+++ b/projects/BFDR.Tests/BirthRecord_Should.cs
@@ -46,25 +46,21 @@ namespace BFDR.Tests
       String json = SetterBirthRecord.ToJSON();
       Assert.DoesNotContain("89369001", json); // code
       Assert.DoesNotContain("73780-9", json); // category code
-      Assert.DoesNotContain("57075-4", json); // composition section code
       // Check nothing changes if we set a missing entry to false
       SetterBirthRecord.Anencephaly = false;
       json = SetterBirthRecord.ToJSON();
       Assert.DoesNotContain("89369001", json); // code
       Assert.DoesNotContain("73780-9", json); // category code
-      Assert.DoesNotContain("57075-4", json); // composition section code
       SetterBirthRecord.Anencephaly = true;
       Assert.True(SetterBirthRecord.Anencephaly);
       json = SetterBirthRecord.ToJSON();
       Assert.Contains("89369001", json); // code
       Assert.Contains("73780-9", json); // category code
-      Assert.Contains("57075-4", json); // composition section code
       // Check nothing changes if we set an existing entry to true
       SetterBirthRecord.Anencephaly = true;
       json = SetterBirthRecord.ToJSON();
       Assert.Contains("89369001", json); // code
       Assert.Contains("73780-9", json); // category code
-      Assert.Contains("57075-4", json); // composition section code
       SetterBirthRecord.Anencephaly = false;
       Assert.False(SetterBirthRecord.Anencephaly);
       json = SetterBirthRecord.ToJSON();
@@ -79,25 +75,21 @@ namespace BFDR.Tests
       String json = SetterBirthRecord.ToJSON();
       Assert.DoesNotContain("434691000124101", json); // code
       Assert.DoesNotContain("73813-8", json); // category code
-      Assert.DoesNotContain("55752-0", json); // composition section code
       // Check nothing changes if we set a missing entry to false
       SetterBirthRecord.AntibioticsAdministeredDuringLabor = false;
       json = SetterBirthRecord.ToJSON();
       Assert.DoesNotContain("434691000124101", json); // code
       Assert.DoesNotContain("73813-8", json); // category code
-      Assert.DoesNotContain("55752-0", json); // composition section code
       SetterBirthRecord.AntibioticsAdministeredDuringLabor = true;
       Assert.True(SetterBirthRecord.AntibioticsAdministeredDuringLabor);
       json = SetterBirthRecord.ToJSON();
       Assert.Contains("434691000124101", json); // code
       Assert.Contains("73813-8", json); // category code
-      Assert.Contains("55752-0", json); // composition section code
       // Check nothing changes if we set an existing entry to true
       SetterBirthRecord.AntibioticsAdministeredDuringLabor = true;
       json = SetterBirthRecord.ToJSON();
       Assert.Contains("434691000124101", json); // code
       Assert.Contains("73813-8", json); // category code
-      Assert.Contains("55752-0", json); // composition section code
       SetterBirthRecord.AntibioticsAdministeredDuringLabor = false;
       Assert.False(SetterBirthRecord.AntibioticsAdministeredDuringLabor);
       json = SetterBirthRecord.ToJSON();
@@ -111,12 +103,10 @@ namespace BFDR.Tests
       Assert.False(SetterBirthRecord.InductionOfLabor);
       String json = SetterBirthRecord.ToJSON();
       Assert.DoesNotContain("236958009", json); // code
-      Assert.DoesNotContain("55752-0", json); // composition section code
       SetterBirthRecord.InductionOfLabor = true;
       Assert.True(SetterBirthRecord.InductionOfLabor);
       json = SetterBirthRecord.ToJSON();
       Assert.Contains("236958009", json); // code
-      Assert.Contains("55752-0", json); // composition section code
       SetterBirthRecord.InductionOfLabor = false;
       Assert.False(SetterBirthRecord.InductionOfLabor);
       json = SetterBirthRecord.ToJSON();

--- a/projects/BFDR.Tests/FetalDeathRecord_Should.cs
+++ b/projects/BFDR.Tests/FetalDeathRecord_Should.cs
@@ -5,6 +5,7 @@ using VR;
 using Xunit;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
+using System.Linq;
 
 namespace BFDR.Tests
 {
@@ -2220,5 +2221,6 @@ namespace BFDR.Tests
         }
       }
     }
+
   }
 }

--- a/projects/BFDR.Tests/IJEFetalDeath_Should.cs
+++ b/projects/BFDR.Tests/IJEFetalDeath_Should.cs
@@ -500,6 +500,34 @@ namespace BFDR.Tests
       Assert.Equal("", ije.BLANK2.Trim());
     }
 
+    [Fact]
+    public void TestMotherDateOfBirthRoundtrip()
+    {
+      IJEFetalDeath ije = new IJEFetalDeath();
+      ije.MDOB_YR = "1992";
+      ije.MDOB_MO = "01";
+      ije.MDOB_DY = "12";
+      // convert IJE to FHIR
+      FetalDeathRecord fd = ije.ToRecord();
+      Assert.Equal(1992, fd.MotherBirthYear);
+      Assert.Equal(1, fd.MotherBirthMonth);
+      Assert.Equal(12, fd.MotherBirthDay);
+
+      // then to a json string
+      string asJson = fd.ToJSON();
+      // Create a fhir record from the json
+      FetalDeathRecord fdRecord = new FetalDeathRecord(asJson);
+      Assert.Equal(1992, fdRecord.MotherBirthYear);
+      Assert.Equal(1, fdRecord.MotherBirthMonth);
+      Assert.Equal(12, fdRecord.MotherBirthDay);
+
+      // convert back to IJE and confirm the values are the same
+      IJEFetalDeath ije2 = new IJEFetalDeath(fdRecord);
+      Assert.Equal("1992", ije2.MDOB_YR);
+      Assert.Equal("01", ije2.MDOB_MO);
+      Assert.Equal("12", ije2.MDOB_DY);
+    }
+
 
   [Fact]
     public void TestDeathState()

--- a/projects/BFDR.Tests/NatalityData_Should.cs
+++ b/projects/BFDR.Tests/NatalityData_Should.cs
@@ -310,6 +310,34 @@ namespace BFDR.Tests
     }
 
     [Fact]
+    public void TestBirthRecordMotherDateOfBirthRoundtrip()
+    {
+      IJEBirth ije = new IJEBirth();
+      ije.MDOB_YR = "1992";
+      ije.MDOB_MO = "01";
+      ije.MDOB_DY = "12";
+      // convert IJE to FHIR
+      BirthRecord br = ije.ToRecord();
+      Assert.Equal(1992, br.MotherBirthYear);
+      Assert.Equal(1, br.MotherBirthMonth);
+      Assert.Equal(12, br.MotherBirthDay);
+
+      // then to a json string
+      string asJson = br.ToJSON();
+      // Create a fhir record from the json
+      BirthRecord birthRecord = new BirthRecord(asJson);
+      Assert.Equal(1992, birthRecord.MotherBirthYear);
+      Assert.Equal(1, birthRecord.MotherBirthMonth);
+      Assert.Equal(12, birthRecord.MotherBirthDay);
+
+      // convert back to IJE and confirm the values are the same
+      IJEBirth ije2 = new IJEBirth(birthRecord);
+      Assert.Equal("1992", ije2.MDOB_YR);
+      Assert.Equal("01", ije2.MDOB_MO);
+      Assert.Equal("12", ije2.MDOB_DY);
+    }
+
+    [Fact]
     public void TestPlurality()
     {
       BirthRecord fhir = new BirthRecord();

--- a/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecord.json
+++ b/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecord.json
@@ -63,6 +63,19 @@
             "focus": {
               "reference": "urn:uuid:18ef120e-0b0b-49d5-85f7-acb8f3a583b7"
             }
+          },
+          {
+            "code": {
+                "coding": [
+                    {
+                        "system": "http://loinc.org",
+                        "code": "55752-0"
+                    }
+                ]
+            },
+            "focus": {
+                "reference": "urn:uuid:18ef120e-0b0b-49d5-85f7-acb8f3a583b7"
+            }
           }
         ],
         "attester": [

--- a/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecord.json
+++ b/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecord.json
@@ -101,6 +101,10 @@
           {
             "extension": [
               {
+                "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+                "valueCode": "M"
+              },
+              {
                 "url": "motherOrFather",
                 "valueCodeableConcept": {
                   "coding": [
@@ -189,7 +193,26 @@
           "profile": [
             "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Patient-mother-vr"
           ]
-        }
+        },
+        "birthDate": "1992-01-12",
+        "address": [
+            {
+                "extension": [
+                    {
+                        "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-within-city-limits-indicator-vr"
+                    }
+                ],
+                "use": "home",
+                "line": [
+                    "7 Blue Street"
+                ],
+                "city": "Milford",
+                "district": "New Haven",
+                "state": "CT",
+                "postalCode": "06460",
+                "country": "US"
+            }
+        ]
       }
     },
     {
@@ -432,6 +455,144 @@
           ]
         }
       }
-    }
+    },
+    {
+      "fullUrl": "urn:uuid:3fe557f1-4928-466e-bc4e-7e6dc71c74ed",
+      "resource": {
+          "resourceType": "Condition",
+          "id": "3fe557f1-4928-466e-bc4e-7e6dc71c74ed",
+          "category": [
+              {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "76060-3"
+                      }
+                  ]
+              }
+          ],
+          "code": {
+              "coding": [
+                  {
+                      "system": "http://snomed.info/sct",
+                      "code": "44223004"
+                  }
+              ]
+          },
+          "subject": {
+              "reference": "urn:uuid:5f76fab9-6fb0-4901-9c4a-dcedab7e1ef4"
+          }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:3819b92a-8906-4370-8326-7f8088fcb722",
+      "resource": {
+          "resourceType": "Observation",
+          "id": "3819b92a-8906-4370-8326-7f8088fcb722",
+          "meta": {
+              "profile": [
+                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/input-race-and-ethnicity-vr"
+              ]
+          },
+          "status": "final",
+          "code": {
+              "coding": [
+                  {
+                      "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-local-observation-codes-vr",
+                      "code": "inputraceandethnicityMother",
+                      "display": "Input Race and Ethnicity Person"
+                  }
+              ]
+          },
+          "subject": {
+              "reference": "urn:uuid:9c4ca888-c4dc-4aa6-9673-828923445ce8"
+          },
+          "component": [
+              {
+                  "code": {
+                      "coding": [
+                          {
+                              "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                              "code": "HispanicLiteral",
+                              "display": "Hispanic Literal"
+                          }
+                      ]
+                  },
+                  "valueString": "Colombian"
+              },
+              {
+                  "code": {
+                      "coding": [
+                          {
+                              "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                              "code": "HispanicCuban",
+                              "display": "Hispanic Cuban"
+                          }
+                      ]
+                  },
+                  "valueCodeableConcept": {
+                      "coding": [
+                          {
+                              "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                              "code": "Y",
+                              "display": "Yes"
+                          }
+                      ]
+                  }
+              },
+              {
+                  "code": {
+                      "coding": [
+                          {
+                              "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                              "code": "BlackOrAfricanAmerican",
+                              "display": "Black Or African American"
+                          }
+                      ]
+                  },
+                  "valueBoolean": true
+              }
+          ]
+      }
+  },
+  {
+      "fullUrl": "urn:uuid:c2a5861e-9b5f-4837-826d-38d9a24d71c3",
+      "resource": {
+          "resourceType": "Observation",
+          "id": "c2a5861e-9b5f-4837-826d-38d9a24d71c3",
+          "meta": {
+              "profile": [
+                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/input-race-and-ethnicity-vr"
+              ]
+          },
+          "status": "final",
+          "code": {
+              "coding": [
+                  {
+                      "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-local-observation-codes-vr",
+                      "code": "inputraceandethnicityFather",
+                      "display": "Input Race and Ethnicity Person"
+                  }
+              ]
+          },
+          "subject": {
+              "reference": "urn:uuid:9c4ca888-c4dc-4aa6-9673-828923445ce8"
+          },
+          "component": [
+              {
+                  "code": {
+                      "coding": [
+                          {
+                              "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                              "code": "White",
+                              "display": "White"
+                          }
+                      ]
+                  },
+                  "valueBoolean": true
+              }
+          ]
+      }
+  }
   ]
 }

--- a/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecord2.json
+++ b/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecord2.json
@@ -309,6 +309,34 @@
       }
     },
     {
+      "fullUrl": "urn:uuid:3fe557f1-4928-466e-bc4e-7e6dc71c74ed",
+      "resource": {
+          "resourceType": "Condition",
+          "id": "3fe557f1-4928-466e-bc4e-7e6dc71c74ed",
+          "category": [
+              {
+                  "coding": [
+                      {
+                          "system": "http://loinc.org",
+                          "code": "76060-3"
+                      }
+                  ]
+              }
+          ],
+          "code": {
+              "coding": [
+                  {
+                      "system": "http://snomed.info/sct",
+                      "code": "44223004"
+                  }
+              ]
+          },
+          "subject": {
+              "reference": "urn:uuid:5f76fab9-6fb0-4901-9c4a-dcedab7e1ef4"
+          }
+      }
+    },
+    {
       "fullUrl": "urn:uuid:64aa77c0-0361-4882-90b7-476c2a070fe3",
       "resource": {
         "resourceType": "Patient",

--- a/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecordSubmissionMessage.json
+++ b/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecordSubmissionMessage.json
@@ -309,6 +309,24 @@
               },
               "extension": [
                 {
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+                  "valueCode": "M"
+                },
+                {
+                    "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+                    "valueAddress": {
+                        "state": "MA",
+                        "_state": {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-jurisdiction-id-vr",
+                                    "valueString": "MA"
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
                   "extension": [
                     {
                       "url": "motherOrFather",
@@ -374,6 +392,34 @@
                   }
                 ]
               }
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:3fe557f1-4928-466e-bc4e-7e6dc71c74ed",
+            "resource": {
+                "resourceType": "Condition",
+                "id": "3fe557f1-4928-466e-bc4e-7e6dc71c74ed",
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://loinc.org",
+                                "code": "76060-3"
+                            }
+                        ]
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "44223004"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "urn:uuid:5f76fab9-6fb0-4901-9c4a-dcedab7e1ef4"
+                }
             }
           },
           {
@@ -1420,364 +1466,6 @@
                   }
                 }
               ]
-            }
-          },
-          {
-            "fullUrl": "urn:uuid:37326aab-44db-480f-830c-29414c92a46a",
-            "resource": {
-              "resourceType": "Observation",
-              "id": "37326aab-44db-480f-830c-29414c92a46a",
-              "meta": {
-                "profile": [
-                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/coded-race-and-ethnicity-vr"
-                ]
-              },
-              "status": "final",
-              "code": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-local-observation-codes-vr",
-                    "code": "codedraceandethnicityMother",
-                    "display": "Coded Race and Ethnicity Person"
-                  }
-                ]
-              },
-              "subject": {
-                "reference": "urn:uuid:1c271768-fbe0-43c6-9676-5e0de6b9cbd0"
-              }
-            }
-          },
-          {
-            "fullUrl": "urn:uuid:5bd7dc49-9284-4724-b476-569f4dd34982",
-            "resource": {
-              "resourceType": "Observation",
-              "id": "5bd7dc49-9284-4724-b476-569f4dd34982",
-              "meta": {
-                "profile": [
-                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-coded-initiating-fetal-death-cause-or-condition"
-                ]
-              },
-              "status": "final",
-              "code": {
-                "coding": [
-                  {
-                    "system": "http://loinc.org",
-                    "code": "92023-1",
-                    "display": "Coded other significant causes or conditions of fetal death"
-                  }
-                ]
-              },
-              "subject": {
-                "reference": "urn:uuid:1c271768-fbe0-43c6-9676-5e0de6b9cbd0"
-              },
-              "performer": [
-                {
-                  "reference": "urn:uuid:194e1d14-a1f6-4f8a-8be4-74336fd1cab5"
-                }
-              ],
-              "component": [
-                {
-                  "code": {
-                    "coding": [
-                      {
-                        "system": "http://snomed.info/sct",
-                        "code": "246268007",
-                        "display": "Position (attribute)"
-                      }
-                    ]
-                  },
-                  "valueInteger": 1
-                }
-              ]
-            }
-          },
-          {
-            "fullUrl": "urn:uuid:3a9e52de-e599-4a39-86f1-afecf0c753bd",
-            "resource": {
-              "resourceType": "Observation",
-              "id": "3a9e52de-e599-4a39-86f1-afecf0c753bd",
-              "meta": {
-                "profile": [
-                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-coded-initiating-fetal-death-cause-or-condition"
-                ]
-              },
-              "status": "final",
-              "code": {
-                "coding": [
-                  {
-                    "system": "http://loinc.org",
-                    "code": "92023-1",
-                    "display": "Coded other significant causes or conditions of fetal death"
-                  }
-                ]
-              },
-              "subject": {
-                "reference": "urn:uuid:1c271768-fbe0-43c6-9676-5e0de6b9cbd0"
-              },
-              "performer": [
-                {
-                  "reference": "urn:uuid:194e1d14-a1f6-4f8a-8be4-74336fd1cab5"
-                }
-              ],
-              "component": [
-                {
-                  "code": {
-                    "coding": [
-                      {
-                        "system": "http://snomed.info/sct",
-                        "code": "246268007",
-                        "display": "Position (attribute)"
-                      }
-                    ]
-                  },
-                  "valueInteger": 2
-                }
-              ]
-            }
-          },
-          {
-            "fullUrl": "urn:uuid:8a4c5a29-9db5-43c2-a824-9fa4de64e0bc",
-            "resource": {
-              "resourceType": "Observation",
-              "id": "8a4c5a29-9db5-43c2-a824-9fa4de64e0bc",
-              "meta": {
-                "profile": [
-                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-coded-initiating-fetal-death-cause-or-condition"
-                ]
-              },
-              "status": "final",
-              "code": {
-                "coding": [
-                  {
-                    "system": "http://loinc.org",
-                    "code": "92023-1",
-                    "display": "Coded other significant causes or conditions of fetal death"
-                  }
-                ]
-              },
-              "subject": {
-                "reference": "urn:uuid:1c271768-fbe0-43c6-9676-5e0de6b9cbd0"
-              },
-              "performer": [
-                {
-                  "reference": "urn:uuid:194e1d14-a1f6-4f8a-8be4-74336fd1cab5"
-                }
-              ],
-              "component": [
-                {
-                  "code": {
-                    "coding": [
-                      {
-                        "system": "http://snomed.info/sct",
-                        "code": "246268007",
-                        "display": "Position (attribute)"
-                      }
-                    ]
-                  },
-                  "valueInteger": 3
-                }
-              ]
-            }
-          },
-          {
-            "fullUrl": "urn:uuid:7bd467dd-2d43-4ff1-a9de-0fb841d9ace5",
-            "resource": {
-              "resourceType": "Observation",
-              "id": "7bd467dd-2d43-4ff1-a9de-0fb841d9ace5",
-              "meta": {
-                "profile": [
-                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-coded-initiating-fetal-death-cause-or-condition"
-                ]
-              },
-              "status": "final",
-              "code": {
-                "coding": [
-                  {
-                    "system": "http://loinc.org",
-                    "code": "92023-1",
-                    "display": "Coded other significant causes or conditions of fetal death"
-                  }
-                ]
-              },
-              "subject": {
-                "reference": "urn:uuid:1c271768-fbe0-43c6-9676-5e0de6b9cbd0"
-              },
-              "performer": [
-                {
-                  "reference": "urn:uuid:194e1d14-a1f6-4f8a-8be4-74336fd1cab5"
-                }
-              ],
-              "component": [
-                {
-                  "code": {
-                    "coding": [
-                      {
-                        "system": "http://snomed.info/sct",
-                        "code": "246268007",
-                        "display": "Position (attribute)"
-                      }
-                    ]
-                  },
-                  "valueInteger": 4
-                }
-              ]
-            }
-          },
-          {
-            "fullUrl": "urn:uuid:f66e744a-f2df-4905-9a93-b884f89da3cc",
-            "resource": {
-              "resourceType": "Observation",
-              "id": "f66e744a-f2df-4905-9a93-b884f89da3cc",
-              "meta": {
-                "profile": [
-                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-coded-initiating-fetal-death-cause-or-condition"
-                ]
-              },
-              "status": "final",
-              "code": {
-                "coding": [
-                  {
-                    "system": "http://loinc.org",
-                    "code": "92023-1",
-                    "display": "Coded other significant causes or conditions of fetal death"
-                  }
-                ]
-              },
-              "subject": {
-                "reference": "urn:uuid:1c271768-fbe0-43c6-9676-5e0de6b9cbd0"
-              },
-              "performer": [
-                {
-                  "reference": "urn:uuid:194e1d14-a1f6-4f8a-8be4-74336fd1cab5"
-                }
-              ],
-              "component": [
-                {
-                  "code": {
-                    "coding": [
-                      {
-                        "system": "http://snomed.info/sct",
-                        "code": "246268007",
-                        "display": "Position (attribute)"
-                      }
-                    ]
-                  },
-                  "valueInteger": 5
-                }
-              ]
-            }
-          },
-          {
-            "fullUrl": "urn:uuid:96b40c04-1196-48b8-b750-83b3d86a86a3",
-            "resource": {
-              "resourceType": "Observation",
-              "id": "96b40c04-1196-48b8-b750-83b3d86a86a3",
-              "meta": {
-                "profile": [
-                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-coded-initiating-fetal-death-cause-or-condition"
-                ]
-              },
-              "status": "final",
-              "code": {
-                "coding": [
-                  {
-                    "system": "http://loinc.org",
-                    "code": "92023-1",
-                    "display": "Coded other significant causes or conditions of fetal death"
-                  }
-                ]
-              },
-              "subject": {
-                "reference": "urn:uuid:1c271768-fbe0-43c6-9676-5e0de6b9cbd0"
-              },
-              "performer": [
-                {
-                  "reference": "urn:uuid:194e1d14-a1f6-4f8a-8be4-74336fd1cab5"
-                }
-              ],
-              "component": [
-                {
-                  "code": {
-                    "coding": [
-                      {
-                        "system": "http://snomed.info/sct",
-                        "code": "246268007",
-                        "display": "Position (attribute)"
-                      }
-                    ]
-                  },
-                  "valueInteger": 6
-                }
-              ]
-            }
-          },
-          {
-            "fullUrl": "urn:uuid:129edd28-1d00-45ff-a21a-74cbc83a4a48",
-            "resource": {
-              "resourceType": "Observation",
-              "id": "129edd28-1d00-45ff-a21a-74cbc83a4a48",
-              "meta": {
-                "profile": [
-                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-coded-initiating-fetal-death-cause-or-condition"
-                ]
-              },
-              "status": "final",
-              "code": {
-                "coding": [
-                  {
-                    "system": "http://loinc.org",
-                    "code": "92023-1",
-                    "display": "Coded other significant causes or conditions of fetal death"
-                  }
-                ]
-              },
-              "subject": {
-                "reference": "urn:uuid:1c271768-fbe0-43c6-9676-5e0de6b9cbd0"
-              },
-              "performer": [
-                {
-                  "reference": "urn:uuid:194e1d14-a1f6-4f8a-8be4-74336fd1cab5"
-                }
-              ],
-              "component": [
-                {
-                  "code": {
-                    "coding": [
-                      {
-                        "system": "http://snomed.info/sct",
-                        "code": "246268007",
-                        "display": "Position (attribute)"
-                      }
-                    ]
-                  },
-                  "valueInteger": 7
-                }
-              ]
-            }
-          },
-          {
-            "fullUrl": "urn:uuid:451b52bf-264b-463f-b4fb-e56bc5136557",
-            "resource": {
-              "resourceType": "Observation",
-              "id": "451b52bf-264b-463f-b4fb-e56bc5136557",
-              "meta": {
-                "profile": [
-                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/coded-race-and-ethnicity-vr"
-                ]
-              },
-              "status": "final",
-              "code": {
-                "coding": [
-                  {
-                    "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-local-observation-codes-vr",
-                    "code": "codedraceandethnicityFather",
-                    "display": "Coded Race and Ethnicity Person"
-                  }
-                ]
-              },
-              "subject": {
-                "reference": "urn:uuid:1c271768-fbe0-43c6-9676-5e0de6b9cbd0"
-              }
             }
           }
         ]

--- a/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecordSubmissionMessage_acknowledgement.json
+++ b/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecordSubmissionMessage_acknowledgement.json
@@ -1,14 +1,14 @@
 {
   "resourceType": "Bundle",
-  "id": "b0d3ddd4-b113-4ce4-b2ae-03ad3a4ed46c",
+  "id": "c0795a6a-e616-4c41-9b9b-4cf2bfaeb2ba",
   "type": "message",
-  "timestamp": "2025-02-27T13:26:04.018841-05:00",
+  "timestamp": "2025-04-01T16:38:53.330347-04:00",
   "entry": [
     {
-      "fullUrl": "urn:uuid:aa6c45e1-2a53-42fd-8244-0f7562d68659",
+      "fullUrl": "urn:uuid:ff98538e-544e-4e3b-8e6e-2700dbc65dd4",
       "resource": {
         "resourceType": "MessageHeader",
-        "id": "aa6c45e1-2a53-42fd-8244-0f7562d68659",
+        "id": "ff98538e-544e-4e3b-8e6e-2700dbc65dd4",
         "eventUri": "http://nchs.cdc.gov/fd_acknowledgement",
         "destination": [
           {
@@ -25,10 +25,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:b0c33961-ea29-4bf9-be1f-5d0d06708585",
+      "fullUrl": "urn:uuid:971912f3-380f-4f0b-b08b-44531eb813ab",
       "resource": {
         "resourceType": "Parameters",
-        "id": "b0c33961-ea29-4bf9-be1f-5d0d06708585",
+        "id": "971912f3-380f-4f0b-b08b-44531eb813ab",
         "parameter": [
           {
             "name": "cert_no",

--- a/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecordSubmissionMessage_acknowledgement.json
+++ b/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecordSubmissionMessage_acknowledgement.json
@@ -1,14 +1,14 @@
 {
   "resourceType": "Bundle",
-  "id": "c0795a6a-e616-4c41-9b9b-4cf2bfaeb2ba",
+  "id": "210c5b29-5ad9-401c-be8b-4daefcd9f295",
   "type": "message",
-  "timestamp": "2025-04-01T16:38:53.330347-04:00",
+  "timestamp": "2025-04-10T09:24:54.028427-04:00",
   "entry": [
     {
-      "fullUrl": "urn:uuid:ff98538e-544e-4e3b-8e6e-2700dbc65dd4",
+      "fullUrl": "urn:uuid:f48f72ee-84e9-4647-9e4d-525de186fb20",
       "resource": {
         "resourceType": "MessageHeader",
-        "id": "ff98538e-544e-4e3b-8e6e-2700dbc65dd4",
+        "id": "f48f72ee-84e9-4647-9e4d-525de186fb20",
         "eventUri": "http://nchs.cdc.gov/fd_acknowledgement",
         "destination": [
           {
@@ -25,10 +25,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:971912f3-380f-4f0b-b08b-44531eb813ab",
+      "fullUrl": "urn:uuid:589e4889-0ebb-4afe-a8bd-b1ae3d2dd33d",
       "resource": {
         "resourceType": "Parameters",
-        "id": "971912f3-380f-4f0b-b08b-44531eb813ab",
+        "id": "589e4889-0ebb-4afe-a8bd-b1ae3d2dd33d",
         "parameter": [
           {
             "name": "cert_no",

--- a/projects/BFDR/BFDR.xml
+++ b/projects/BFDR/BFDR.xml
@@ -3396,6 +3396,18 @@
         <member name="M:BFDR.NatalityRecord.InitializeCompositionAndSubject">
             <summary>Initialize Composition and Subject.</summary>
         </member>
+        <member name="M:BFDR.NatalityRecord.InitializeSections">
+            <summary>
+            Initialize sections creates empty sections based on the composition type
+            These are necessary so resources like Mother and Father can be referenced from somewhere in the composition
+            </summary>
+        </member>
+        <member name="M:BFDR.NatalityRecord.CreateNewSection(System.String)">
+            <summary>
+            Creates a section based on the section code provided. Sets the focus defined for that section and provides an empty reason by default.
+            </summary>
+            <param name="code"></param>
+        </member>
         <member name="M:BFDR.NatalityRecord.#ctor(System.String,System.Boolean)">
             <summary>Constructor that takes a string that represents a FHIR Natality Record in either XML or JSON format.</summary>
             <param name="record">represents a FHIR Natality Record in either XML or JSON format.</param>
@@ -3443,6 +3455,10 @@
         <member name="M:BFDR.NatalityRecord.RestoreReferences">
             <summary>Restores class references from a newly parsed record.</summary>
         </member>
+        <member name="M:BFDR.NatalityRecord.GetSectionFocusId(System.String)">
+            <summary>Returns the focus id of a section in the composition.</summary>
+            <returns>the string uuid of the section focus</returns> 
+        </member>
         <member name="F:BFDR.NatalityRecord.Subject">
             <summary>The Natality Subject - eithr a Child or a DecedentFetus.</summary>
         </member>
@@ -3469,6 +3485,12 @@
         </member>
         <member name="F:BFDR.NatalityRecord.MOTHER_PRENATAL_SECTION">
             <summary>Composition Section Constants</summary>
+        </member>
+        <member name="F:BFDR.NatalityRecord.FETUS_SECTION">
+            <summary> Fetus Section Constant </summary>
+        </member>
+        <member name="F:BFDR.NatalityRecord.CODEDCAUSEOFFETALDEATH_SECTION">
+            <summary> Coded Cause of Fetal Death Section Constant </summary>
         </member>
         <member name="F:BFDR.NatalityRecord.RACE_ETHNICITY_MOTHER">
             <summary>DemographicComposition Section Constants</summary>

--- a/projects/BFDR/BFDR.xml
+++ b/projects/BFDR/BFDR.xml
@@ -3712,7 +3712,26 @@
             <para>Console.WriteLine($"Event Location Jurisdiction: {ExampleBirthRecord.EventLocationJurisdiction}");</para>
             </example>
         </member>
-        <!-- Badly formed XML comment ignored for member "P:BFDR.NatalityRecord.PlaceOfBirth" -->
+        <member name="P:BFDR.NatalityRecord.PlaceOfBirth">
+            <summary>Child's Place Of Birth.</summary>
+            <value>Child's Place Of Birth. A Dictionary representing residence address, containing the following key/value pairs:
+            <para>"addressCity" - address, city</para>
+            <para>"addressCounty" - address, county</para>
+            <para>"addressCountyC" - address, countyC</para>
+            <para>"addressState" - address, state</para>
+            </value>
+            <example>
+            <para>// Setter:</para>
+            <para>Dictionary&lt;string, string&gt; address = new Dictionary&lt;string, string&gt;();</para>
+            <para>address.Add("addressCity", "Boston");</para>
+            <para>address.Add("addressCounty", "Suffolk");</para>
+            <para>address.Add("addressCountyC", "8153");</para>
+            <para>address.Add("addressState", "MA");</para>
+            <para>ExampleBirthRecord.PlaceOfBirth = address;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"State where child was born: {ExampleBirthRecord.PlaceOfBirth["placeOfBirthState"]}");</para>
+            </example>
+        </member>
         <member name="P:BFDR.NatalityRecord.MotherPlaceOfBirth">
             <summary>Mother's Place Of Birth.</summary>
             <value>Mother's Place Of Birth. A Dictionary representing birthplace location, containing the following key/value pairs:

--- a/projects/BFDR/BFDR.xml
+++ b/projects/BFDR/BFDR.xml
@@ -282,6 +282,12 @@
         <member name="M:BFDR.BirthRecord.InitializeCompositionAndSubject">
             <inheritdoc/>
         </member>
+        <member name="M:BFDR.BirthRecord.InitializeSections">
+            <summary>
+            Initialize sections creates empty sections based on the composition type
+            These are necessary so resources like Mother and Father can be referenced from somewhere in the composition
+            </summary>
+        </member>
         <member name="M:BFDR.BirthRecord.CreateBirthEncounter">
             <summary>Create Birth Encounter.</summary>
         </member>
@@ -866,6 +872,12 @@
         </member>
         <member name="M:BFDR.FetalDeathRecord.InitializeCompositionAndSubject">
             <inheritdoc/>
+        </member>
+        <member name="M:BFDR.FetalDeathRecord.InitializeSections">
+            <summary>
+            Initialize sections creates empty sections based on the composition type
+            These are necessary so resources like Mother and Father can be referenced from somewhere in the composition
+            </summary>
         </member>
         <member name="P:BFDR.FetalDeathRecord.CodedInitiatingFetalCOD">
             <summary>Decedent Fetus's Coded Initiating Fetal Death Cause or Condition</summary>
@@ -3397,10 +3409,7 @@
             <summary>Initialize Composition and Subject.</summary>
         </member>
         <member name="M:BFDR.NatalityRecord.InitializeSections">
-            <summary>
-            Initialize sections creates empty sections based on the composition type
-            These are necessary so resources like Mother and Father can be referenced from somewhere in the composition
-            </summary>
+            <summary>Initialize sections for the composition.</summary>
         </member>
         <member name="M:BFDR.NatalityRecord.CreateNewSection(System.String)">
             <summary>
@@ -3483,8 +3492,26 @@
         <member name="F:BFDR.NatalityRecord.COMPOSITION_PROVIDER_FETAL_DEATH_REPORT">
             <summary>Composition Type Constants</summary>
         </member>
+        <member name="F:BFDR.NatalityRecord.COMPOSITION_CODED_CAUSE_OF_FETAL_DEATH">
+            <summary>Composition code coded cause of fetal death</summary>
+        </member>
         <member name="F:BFDR.NatalityRecord.MOTHER_PRENATAL_SECTION">
-            <summary>Composition Section Constants</summary>
+            <summary>Mother Prenatal Section Constant</summary>
+        </member>
+        <member name="F:BFDR.NatalityRecord.MEDICAL_INFORMATION_SECTION">
+            <summary>Medical Information Section Constant</summary>
+        </member>
+        <member name="F:BFDR.NatalityRecord.NEWBORN_INFORMATION_SECTION">
+            <summary>Newbord Information Section Constant</summary>
+        </member>
+        <member name="F:BFDR.NatalityRecord.MOTHER_INFORMATION_SECTION">
+            <summary>Mother Information Section Constant</summary>
+        </member>
+        <member name="F:BFDR.NatalityRecord.FATHER_INFORMATION_SECTION">
+            <summary>Father Information Section Constant</summary>
+        </member>
+        <member name="F:BFDR.NatalityRecord.EMERGING_ISSUES_SECTION">
+            <summary>Emerging Issues Section Constant</summary>
         </member>
         <member name="F:BFDR.NatalityRecord.FETUS_SECTION">
             <summary> Fetus Section Constant </summary>

--- a/projects/BFDR/BirthRecord_constructors.cs
+++ b/projects/BFDR/BirthRecord_constructors.cs
@@ -72,6 +72,20 @@ namespace BFDR
             Composition.Title = "Birth Certificate";
         }
 
+        /// <summary>
+        /// Initialize sections creates empty sections based on the composition type
+        /// These are necessary so resources like Mother and Father can be referenced from somewhere in the composition
+        /// </summary>
+        protected override void InitializeSections()
+        {
+            CreateNewSection(MOTHER_PRENATAL_SECTION);
+            CreateNewSection(MEDICAL_INFORMATION_SECTION);
+            CreateNewSection(NEWBORN_INFORMATION_SECTION);
+            CreateNewSection(MOTHER_INFORMATION_SECTION);
+            CreateNewSection(FATHER_INFORMATION_SECTION);
+            CreateNewSection(EMERGING_ISSUES_SECTION);   
+        }
+
         /// <summary>Create Birth Encounter.</summary>
         protected Encounter CreateBirthEncounter()
         {

--- a/projects/BFDR/FetalDeathRecord_constructors.cs
+++ b/projects/BFDR/FetalDeathRecord_constructors.cs
@@ -84,5 +84,19 @@ namespace BFDR
       Composition.Type = new CodeableConcept(CodeSystems.LOINC, "92010-8", "Jurisdiction fetal death report Document", null);
       Composition.Title = "Fetal Death Report";
     }
+
+    /// <summary>
+    /// Initialize sections creates empty sections based on the composition type
+    /// These are necessary so resources like Mother and Father can be referenced from somewhere in the composition
+    /// </summary>
+    protected override void InitializeSections()
+    {
+      CreateNewSection(MOTHER_PRENATAL_SECTION);
+      CreateNewSection(MEDICAL_INFORMATION_SECTION);
+      CreateNewSection(FETUS_SECTION);
+      CreateNewSection(MOTHER_INFORMATION_SECTION);
+      CreateNewSection(FATHER_INFORMATION_SECTION);
+      CreateNewSection(EMERGING_ISSUES_SECTION);
+    }
   }
 }

--- a/projects/BFDR/FetalDeathRecord_constructors.cs
+++ b/projects/BFDR/FetalDeathRecord_constructors.cs
@@ -11,9 +11,6 @@ namespace BFDR
   /// </summary>
   public partial class FetalDeathRecord : NatalityRecord
   {
-    // private const string FETUS_SECTION = "76400-1";
-
-    // private const string CODEDCAUSEOFFETALDEATH_SECTION = "86804-2";
 
     /// <summary>Default constructor that creates a new, empty FetalDeathRecord.</summary>
     public FetalDeathRecord() : base(ProfileURL.BundleDocumentFetalDeathReport)

--- a/projects/BFDR/FetalDeathRecord_constructors.cs
+++ b/projects/BFDR/FetalDeathRecord_constructors.cs
@@ -11,9 +11,9 @@ namespace BFDR
   /// </summary>
   public partial class FetalDeathRecord : NatalityRecord
   {
-    private const string FETUS_SECTION = "76400-1";
+    // private const string FETUS_SECTION = "76400-1";
 
-    private const string CODEDCAUSEOFFETALDEATH_SECTION = "86804-2";
+    // private const string CODEDCAUSEOFFETALDEATH_SECTION = "86804-2";
 
     /// <summary>Default constructor that creates a new, empty FetalDeathRecord.</summary>
     public FetalDeathRecord() : base(ProfileURL.BundleDocumentFetalDeathReport)

--- a/projects/BFDR/NatalityRecord_constructors.cs
+++ b/projects/BFDR/NatalityRecord_constructors.cs
@@ -138,47 +138,10 @@ namespace BFDR
         /// <summary>Initialize Composition and Subject.</summary>
         protected abstract void InitializeCompositionAndSubject();
 
+        /// <summary>Initialize sections for the composition.</summary>
+        protected abstract void InitializeSections();
 
-        /// <summary>
-        /// Initialize sections creates empty sections based on the composition type
-        /// These are necessary so resources like Mother and Father can be referenced from somewhere in the composition
-        /// </summary>
-        protected void InitializeSections()
-        {
-            // if fetal death, add fetal death sections
-            if (Composition.Type.Coding.First().Code == COMPOSITION_JURISDICTION_FETAL_DEATH_REPORT)
-            {
-                CreateNewSection(MOTHER_PRENATAL_SECTION);
-                CreateNewSection(MEDICAL_INFORMATION_SECTION);
-                CreateNewSection(FETUS_SECTION);
-                CreateNewSection(MOTHER_INFORMATION_SECTION);
-                CreateNewSection(FATHER_INFORMATION_SECTION);
-                CreateNewSection(EMERGING_ISSUES_SECTION);
-            }
-            if (Composition.Type.Coding.First().Code == COMPOSITION_JURISDICTION_LIVE_BIRTH_REPORT)
-            {
-                CreateNewSection(MOTHER_PRENATAL_SECTION);
-                CreateNewSection(MEDICAL_INFORMATION_SECTION);
-                CreateNewSection(NEWBORN_INFORMATION_SECTION);
-                CreateNewSection(MOTHER_INFORMATION_SECTION);
-                CreateNewSection(FATHER_INFORMATION_SECTION);
-                CreateNewSection(EMERGING_ISSUES_SECTION);
-            }
-            if (Composition.Type.Coding.First().Code == COMPOSITION_CODED_CAUSE_OF_FETAL_DEATH)
-            {
-                CreateNewSection(CODEDCAUSEOFFETALDEATH_SECTION);
-            }
-            if (Composition.Type.Coding.First().Code == COMPOSITION_CODED_INDUSTRY_AND_OCCUPATION)
-            {
-                CreateNewSection(RACE_ETHNICITY_MOTHER);
-                CreateNewSection(RACE_ETHNICITY_FATHER);
-            }
-            if (Composition.Type.Coding.First().Code == COMPOSITION_CODED_RACE_AND_ETHNICITY)
-            {
-                CreateNewSection(RACE_ETHNICITY_MOTHER);
-                CreateNewSection(RACE_ETHNICITY_FATHER);
-            }
-        }
+
 
         /// <summary>
         /// Creates a section based on the section code provided. Sets the focus defined for that section and provides an empty reason by default.
@@ -319,17 +282,11 @@ namespace BFDR
                 }
                 // Add the resource to the bundle and a reference to the correct place in the composition section
                 bundle.AddResourceEntry(resource, $"urn:uuid:{resource.Id}");
-                if (resource is Patient || resource is RelatedPerson)
-                {
-                    // TODO: is this accurate? that if the resource is a patient or related person its also the focus?
-                    section.Focus = new ResourceReference($"urn:uuid:{resource.Id}");
-                }
-                else
-                {
-                    section.Entry.Add(new ResourceReference($"urn:uuid:{resource.Id}"));
-                    // all sections start with an "Empty Reason" by default, since we added an entry, clear the empty reason
-                    section.EmptyReason = null;
-                }
+                // this method is used for coded bundles where all resources, including patients, are entries in the composition sections
+                section.Entry.Add(new ResourceReference($"urn:uuid:{resource.Id}"));
+                // some composition sections start with an "Empty Reason" by default, since we added an entry, clear the empty reason
+                section.EmptyReason = null;
+                
             }
         }
 

--- a/projects/BFDR/NatalityRecord_constructors.cs
+++ b/projects/BFDR/NatalityRecord_constructors.cs
@@ -28,6 +28,11 @@ namespace BFDR
             MOTHER_PRENATAL_SECTION, MEDICAL_INFORMATION_SECTION, MOTHER_INFORMATION_SECTION
         };
 
+        // Within a composition some sections have a focus that references the father
+        private static readonly string[] COMPOSITION_FATHER_FOCUS_SECTIONS = {
+            FATHER_INFORMATION_SECTION
+        };
+
         /// <summary>Default constructor that creates a new, empty NatalityRecord.</summary>
         protected NatalityRecord(string bundleProfile) : base()
         {
@@ -121,6 +126,9 @@ namespace BFDR
             // AddReferenceToComposition(BirthCertification.Id, "BirthCertification");
             // Bundle.AddResourceEntry(BirthCertification, "urn:uuid:" + BirthCertification.Id);
 
+            // Create the sections for this composition
+            InitializeSections();
+
             // Create a Navigator for this new birth record.
             Navigator = Bundle.ToTypedElement();
 
@@ -129,6 +137,72 @@ namespace BFDR
 
         /// <summary>Initialize Composition and Subject.</summary>
         protected abstract void InitializeCompositionAndSubject();
+
+
+        /// <summary>
+        /// Initialize sections creates empty sections based on the composition type
+        /// These are necessary so resources like Mother and Father can be referenced from somewhere in the composition
+        /// </summary>
+        protected void InitializeSections()
+        {
+            // if fetal death, add fetal death sections
+            if (Composition.Type.Coding.First().Code == COMPOSITION_JURISDICTION_FETAL_DEATH_REPORT)
+            {
+                CreateNewSection(MOTHER_PRENATAL_SECTION);
+                CreateNewSection(MEDICAL_INFORMATION_SECTION);
+                CreateNewSection(FETUS_SECTION);
+                CreateNewSection(MOTHER_INFORMATION_SECTION);
+                CreateNewSection(FATHER_INFORMATION_SECTION);
+                CreateNewSection(EMERGING_ISSUES_SECTION);
+            }
+            if (Composition.Type.Coding.First().Code == COMPOSITION_JURISDICTION_LIVE_BIRTH_REPORT)
+            {
+                CreateNewSection(MOTHER_PRENATAL_SECTION);
+                CreateNewSection(MEDICAL_INFORMATION_SECTION);
+                CreateNewSection(NEWBORN_INFORMATION_SECTION);
+                CreateNewSection(MOTHER_INFORMATION_SECTION);
+                CreateNewSection(FATHER_INFORMATION_SECTION);
+                CreateNewSection(EMERGING_ISSUES_SECTION);
+            }
+            if (Composition.Type.Coding.First().Code == COMPOSITION_CODED_CAUSE_OF_FETAL_DEATH)
+            {
+                CreateNewSection(CODEDCAUSEOFFETALDEATH_SECTION);
+            }
+            if (Composition.Type.Coding.First().Code == COMPOSITION_CODED_INDUSTRY_AND_OCCUPATION)
+            {
+                CreateNewSection(RACE_ETHNICITY_MOTHER);
+                CreateNewSection(RACE_ETHNICITY_FATHER);
+            }
+            if (Composition.Type.Coding.First().Code == COMPOSITION_CODED_RACE_AND_ETHNICITY)
+            {
+                CreateNewSection(RACE_ETHNICITY_MOTHER);
+                CreateNewSection(RACE_ETHNICITY_FATHER);
+            }
+        }
+
+        /// <summary>
+        /// Creates a section based on the section code provided. Sets the focus defined for that section and provides an empty reason by default.
+        /// </summary>
+        /// <param name="code"></param>
+        protected void CreateNewSection(string code)
+        {
+            Composition.SectionComponent section = new Composition.SectionComponent();
+            Dictionary<string, string> coding = new Dictionary<string, string>();
+            coding["system"] = CompositionSectionCodeSystem;
+            coding["code"] = code;
+            section.Code = DictToCodeableConcept(coding);
+
+            string focusId = GetSectionFocusId(code);
+            if (!String.IsNullOrEmpty(focusId))
+            {   
+                section.Focus = new ResourceReference($"urn:uuid:{focusId}");
+            }
+            Dictionary<string, string> emptyReason = new Dictionary<string, string>();
+            emptyReason["system"] = "http://terminology.hl7.org/CodeSystem/list-empty-reason";
+            emptyReason["code"] = "notasked"; // TODO is this an okay default empty reason for the sections?
+            section.EmptyReason = DictToCodeableConcept(emptyReason);
+            Composition.Section.Add(section);
+        }
 
         /// <summary>Constructor that takes a string that represents a FHIR Natality Record in either XML or JSON format.</summary>
         /// <param name="record">represents a FHIR Natality Record in either XML or JSON format.</param>
@@ -247,11 +321,14 @@ namespace BFDR
                 bundle.AddResourceEntry(resource, $"urn:uuid:{resource.Id}");
                 if (resource is Patient || resource is RelatedPerson)
                 {
+                    // TODO: is this accurate? that if the resource is a patient or related person its also the focus?
                     section.Focus = new ResourceReference($"urn:uuid:{resource.Id}");
                 }
                 else
                 {
                     section.Entry.Add(new ResourceReference($"urn:uuid:{resource.Id}"));
+                    // all sections start with an "Empty Reason" by default, since we added an entry, clear the empty reason
+                    section.EmptyReason = null;
                 }
             }
         }
@@ -376,7 +453,23 @@ namespace BFDR
                     throw new System.ArgumentException("Found an Observation resource that did not contain a code. All Observations must include a code to specify what the Observation is referring to.");
                 }
             }
+        }
 
+        /// <summary>Returns the focus id of a section in the composition.</summary>
+        /// <returns>the string uuid of the section focus</returns> 
+        protected override string GetSectionFocusId(string section)
+        {
+            // TODO check the defined sections for Natality Records
+            // return the correct uuid, ex Mother.Id if the section is part of the mother section group
+            if (COMPOSITION_MOTHER_FOCUS_SECTIONS.Contains(section))
+            {   
+                return Mother.Id;
+            }
+            if (COMPOSITION_FATHER_FOCUS_SECTIONS.Contains(section))
+            {   
+                return Father.Id;
+            }
+            return "";
         }
     }
 }

--- a/projects/BFDR/NatalityRecord_fieldsAndCreateMethods.cs
+++ b/projects/BFDR/NatalityRecord_fieldsAndCreateMethods.cs
@@ -48,18 +48,24 @@ namespace BFDR
         private const string COMPOSITION_PROVIDER_LIVE_BIRTH_REPORT = "68998-4";
         private const string COMPOSITION_JURISDICTION_FETAL_DEATH_REPORT = "92010-8";
         private const string COMPOSITION_JURISDICTION_LIVE_BIRTH_REPORT  ="92011-6";
-        private const string COMPOSITION_CODED_CAUSE_OF_FETAL_DEATH = "86804-2";
+        /// <summary>Composition code coded cause of fetal death</summary>
+        protected const string COMPOSITION_CODED_CAUSE_OF_FETAL_DEATH = "86804-2";
         private const string COMPOSITION_CODED_RACE_AND_ETHNICITY = "86805-9";
         private const string COMPOSITION_CODED_INDUSTRY_AND_OCCUPATION = "industry_occupation_document";
 
-        /// <summary>Composition Section Constants</summary>
+        /// <summary>Mother Prenatal Section Constant</summary>
         protected const string MOTHER_PRENATAL_SECTION = "57073-9";
-        private const string MEDICAL_INFORMATION_SECTION = "55752-0";
-        private const string NEWBORN_INFORMATION_SECTION = "57075-4";
-        private const string MOTHER_INFORMATION_SECTION = "92014-0";
-        private const string FATHER_INFORMATION_SECTION = "92013-2";
+        /// <summary>Medical Information Section Constant</summary>
+        protected const string MEDICAL_INFORMATION_SECTION = "55752-0";
+        /// <summary>Newbord Information Section Constant</summary>
+        protected const string NEWBORN_INFORMATION_SECTION = "57075-4";
+        /// <summary>Mother Information Section Constant</summary>
+        protected const string MOTHER_INFORMATION_SECTION = "92014-0";
+        /// <summary>Father Information Section Constant</summary>
+        protected const string FATHER_INFORMATION_SECTION = "92013-2";
         private const string PATIENT_QUESTIONAIRRE_RESPONSE_SECTION = "74465-6";
-        private const string EMERGING_ISSUES_SECTION = "emergingIssues";
+        /// <summary>Emerging Issues Section Constant</summary>
+        protected const string EMERGING_ISSUES_SECTION = "emergingIssues";
         private const string SUCCESSFUL_OUTCOME = "385669000";
         private const string UNSUCCESSFUL_OUTCOME = "385671000";
         private const string DATE_OF_LAST_LIVE_BIRTH = "68499-3";

--- a/projects/BFDR/NatalityRecord_fieldsAndCreateMethods.cs
+++ b/projects/BFDR/NatalityRecord_fieldsAndCreateMethods.cs
@@ -72,6 +72,12 @@ namespace BFDR
         private const string MOTHER_RECEIVED_WIC_FOOD = "87303-4";
         private const string INFANT_BREASTFED_AT_DISCHARGE = "73756-9";
 
+        /// <summary> Fetus Section Constant </summary>
+        protected const string FETUS_SECTION = "76400-1";
+
+        /// <summary> Coded Cause of Fetal Death Section Constant </summary>
+        protected const string CODEDCAUSEOFFETALDEATH_SECTION = "86804-2";
+
         /// <summary>DemographicComposition Section Constants</summary>
         private const string RACE_ETHNICITY_MOTHER = "MTH";
         private const string RACE_ETHNICITY_FATHER = "NFTH";

--- a/projects/BFDR/NatalityRecord_submissionProperties.cs
+++ b/projects/BFDR/NatalityRecord_submissionProperties.cs
@@ -6683,6 +6683,7 @@ namespace BFDR
                     Subject = new ResourceReference($"urn:uuid:{subjectId}")
                 };
                 obs.Category.Add(new CodeableConcept(CodeSystems.ObservationCategory, "vital-signs"));
+                
                 AddReferenceToComposition(obs.Id, section);
                 Bundle.AddResourceEntry(obs, "urn:uuid:" + obs.Id);
             }

--- a/projects/BFDR/NatalityRecord_submissionProperties.cs
+++ b/projects/BFDR/NatalityRecord_submissionProperties.cs
@@ -6682,8 +6682,7 @@ namespace BFDR
                     Code = new CodeableConcept(VR.CodeSystems.LOINC, code),
                     Subject = new ResourceReference($"urn:uuid:{subjectId}")
                 };
-                obs.Category.Add(new CodeableConcept(CodeSystems.ObservationCategory, "vital-signs"));
-                
+                obs.Category.Add(new CodeableConcept(CodeSystems.ObservationCategory, "vital-signs"));  
                 AddReferenceToComposition(obs.Id, section);
                 Bundle.AddResourceEntry(obs, "urn:uuid:" + obs.Id);
             }

--- a/projects/VRDR/DeathRecord.xml
+++ b/projects/VRDR/DeathRecord.xml
@@ -96,6 +96,10 @@
         <member name="M:VRDR.DeathRecord.RestoreReferences">
             <summary>Restores class references from a newly parsed record.</summary>
         </member>
+        <member name="M:VRDR.DeathRecord.GetSectionFocusId(System.String)">
+            <summary>Returns the focus id of a section in the composition.</summary>
+            <returns>the string uuid of the section focus</returns> 
+        </member>
         <member name="F:VRDR.DeathRecord.BlankPlaceholder">
             <summary>Overide the extension URL prefix used by the VR library</summary>
             <summary>String to represent a blank value when an empty string is not allowed</summary>

--- a/projects/VRDR/DeathRecord_constructors.cs
+++ b/projects/VRDR/DeathRecord_constructors.cs
@@ -522,5 +522,12 @@ namespace VRDR
                 }
             }
         }
+        /// <summary>Returns the focus id of a section in the composition.</summary>
+        /// <returns>the string uuid of the section focus</returns> 
+        protected override string GetSectionFocusId(string section)
+        {
+            // The VRDR has no required focus defined for any sections in the composition
+            return "";
+        }
     }
 }

--- a/projects/VitalRecord/VitalRecord.xml
+++ b/projects/VitalRecord/VitalRecord.xml
@@ -6850,6 +6850,10 @@
         <member name="M:VR.VitalRecord.RestoreReferences">
             <summary>Restores class references from a newly parsed record.</summary>
         </member>
+        <member name="M:VR.VitalRecord.GetSectionFocusId(System.String)">
+            <summary>Returns the focus id of a section in the composition.</summary>
+            <returns>the string uuid of the section focus</returns>
+        </member>
         <member name="M:VR.VitalRecord.ToXML">
             <summary>Helper method to return a XML string representation of this Vital Record.</summary>
             <returns>a string representation of this Vital Record in XML format</returns>

--- a/projects/VitalRecord/VitalRecord_constructors.cs
+++ b/projects/VitalRecord/VitalRecord_constructors.cs
@@ -107,6 +107,10 @@ namespace VR
         /// <summary>Restores class references from a newly parsed record.</summary>
         protected abstract void RestoreReferences();
 
+        /// <summary>Returns the focus id of a section in the composition.</summary>
+        /// <returns>the string uuid of the section focus</returns>
+        protected abstract string GetSectionFocusId(string section);
+
         /// <summary>Helper method to return a XML string representation of this Vital Record.</summary>
         /// <returns>a string representation of this Vital Record in XML format</returns>
         public string ToXML()
@@ -222,13 +226,19 @@ namespace VR
                     coding["system"] = CompositionSectionCodeSystem;
                     coding["code"] = code;
                     section.Code = DictToCodeableConcept(coding);
-                    if (focusId != null)
-                    {
-                        section.Focus = new ResourceReference($"urn:uuid:{focusId}");
-                    }
+
+                    // call the override GetSectionFocusId to get the section focus defined in\
+                    // TODO I think we can remove this since we set the focus when we create the default sections
+                    // focusId = GetSectionFocusId(code);
+                    // if (!String.IsNullOrEmpty(focusId))
+                    // {   
+                    //     section.Focus = new ResourceReference($"urn:uuid:{focusId}");
+                    // }
                     Composition.Section.Add(section);
                 }
                 section.Entry.Add(new ResourceReference("urn:uuid:" + reference));
+                // all sections start with an "Empty Reason" by default, since we added an entry, clear the empty reason
+                section.EmptyReason = null;
             }
         }
 

--- a/projects/VitalRecord/VitalRecord_constructors.cs
+++ b/projects/VitalRecord/VitalRecord_constructors.cs
@@ -226,14 +226,6 @@ namespace VR
                     coding["system"] = CompositionSectionCodeSystem;
                     coding["code"] = code;
                     section.Code = DictToCodeableConcept(coding);
-
-                    // call the override GetSectionFocusId to get the section focus defined in\
-                    // TODO I think we can remove this since we set the focus when we create the default sections
-                    // focusId = GetSectionFocusId(code);
-                    // if (!String.IsNullOrEmpty(focusId))
-                    // {   
-                    //     section.Focus = new ResourceReference($"urn:uuid:{focusId}");
-                    // }
                     Composition.Section.Add(section);
                 }
                 section.Entry.Add(new ResourceReference("urn:uuid:" + reference));


### PR DESCRIPTION
This PR addresses ticket [NVSS-743](https://tracker.codev.mitre.org/browse/NVSS-743)

To properly test fetal death testing with NCHS, we need to provide quality data examples with enough data for NCHS to create coded content for cause of death and demographic information. Veronique provided a list of fields to make sure are included in the test data. This PR updates the fakerecord CLI tool to add the following data to the fakerecord so we can generate quality test examples:

- Sex  
- Race and ethnicity
- Cause or condition
- Place where delivery occurs 
- Date of Birth for Mother are mapped
- Mother Residence address

The ticket also included reviewing our fetal death test fixtures and updating them to improve the data quality. Each test fixture was updated to 
- include race and ethnicity data for the mother and father
- include sex
- include a cause or condition
- include the place of delivery
- include mother birthdate
- include mother residence

A lot of the submission examples or records included coded fields. These were probably added during development, but don't make sense since coded fields aren't part of fetal death record submissions. I removed the coded sections from the fetal death record fixtures where appropriate.


UPDATE 4/11: 
These changes uncovered a flaw in how we create the sections of the composition and set the focus id to the Mother Patient ID. We rely on the focus id to parse the Mother Patient. This PR updates the natality constructors to initialize the composition sections, set the focus id, and provide a default empty reason. The empty reason is removed when an entry is added to the composition section.