### PR TITLE
ci: make BFDR and VRDR coverage comments visible simultaneously

### DIFF
--- a/.github/workflows/bfdr-test.yml
+++ b/.github/workflows/bfdr-test.yml
@@ -84,5 +84,6 @@ jobs:
       uses: marocchino/sticky-pull-request-comment@v2
       if: github.event_name == 'pull_request'
       with:
+        header: bfdr-test
         recreate: true
         path: code-coverage-results.md

--- a/.github/workflows/bfdr-test.yml
+++ b/.github/workflows/bfdr-test.yml
@@ -21,6 +21,7 @@ on:
       - 'projects/BFDR.CLI/**'
       - 'projects/BFDR.Messaging/**'
       - 'projects/BFDR.Tests/**'
+      - ".github/workflows/bfdr-test.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/vrdr-test.yml
+++ b/.github/workflows/vrdr-test.yml
@@ -86,5 +86,6 @@ jobs:
       uses: marocchino/sticky-pull-request-comment@v2
       if: github.event_name == 'pull_request'
       with:
+        header: vrdr-test
         recreate: true
         path: code-coverage-results.md


### PR DESCRIPTION
Add header option to github action for posting code coverage comments for BFDR and VRDR test results. This allows both comments to coexist peacefully.

Addresses Jira issue 715.