### PR TITLE
fix: add us core problem-list-item category to created FHIR conditions

### DIFF
--- a/projects/BFDR.Tests/IJEFetalDeath_Should.cs
+++ b/projects/BFDR.Tests/IJEFetalDeath_Should.cs
@@ -99,6 +99,21 @@ namespace BFDR.Tests
     }
 
     [Fact]
+    public void IndependentCOD1xab()
+    {
+      IJEFetalDeath ije = new();
+      ije.COD18a8 = "foo";
+      Assert.Equal("foo", ije.COD18a8.Trim());
+      ije.COD18b8 = "bar";
+      Assert.Equal("foo", ije.COD18a8.Trim());
+      Assert.Equal("bar", ije.COD18b8.Trim());
+      ije.COD18b8 = "bar";
+      ije.COD18a8 = "foo";
+      Assert.Equal("foo", ije.COD18a8.Trim());
+      Assert.Equal("bar", ije.COD18b8.Trim());
+    }
+
+    [Fact]
     public void ParseEstimatedTimeOfFetalDeath()
     {
       IJEFetalDeath ije = new(File.ReadAllText(TestHelpers.FixturePath("fixtures/ije/FetalDeathRecord.ije")));

--- a/projects/BFDR/BFDR.xml
+++ b/projects/BFDR/BFDR.xml
@@ -374,7 +374,7 @@
             <para>ExampleFetalDeathRecord.CertifiedDay = 23;</para>
             <para>// Getter:</para>
             <para>Console.WriteLine($"Certified Day: {ExampleFetalDeathRecord.CertifiedDay}");</para>
-            </example> 
+            </example>
         </member>
         <member name="P:BFDR.FetalDeathRecord.FetusGivenNames">
             <summary>Fetus Legal Name - Given. Middle name should be the last entry.</summary>

--- a/projects/BFDR/FetalDeathRecord.cs
+++ b/projects/BFDR/FetalDeathRecord.cs
@@ -67,7 +67,7 @@ namespace BFDR
         /// <para>ExampleFetalDeathRecord.CertifiedDay = 23;</para>
         /// <para>// Getter:</para>
         /// <para>Console.WriteLine($"Certified Day: {ExampleFetalDeathRecord.CertifiedDay}");</para>
-        /// </example> 
+        /// </example>
         [Property("Certified Day", Property.Types.Int32, "Fetal Death Certification", "Certified Day", true, IGURL.EncounterMaternity, true, 4)]
         [FHIRPath("Bundle.entry.resource.where($this is Encounter).where(extension.value.coding.code='CHILD')", "")]
         public int? CertifiedDay
@@ -320,7 +320,7 @@ namespace BFDR
         {
             get
             {
-                Condition cond = GetCondition("maternalconditions", "76060-3");
+                Condition cond = GetCondition();
                 if (cond != null && cond.Code != null && cond.Code.Text != null)
                 {
                     return cond.Code.Text.ToString();
@@ -333,7 +333,7 @@ namespace BFDR
                 {
                     return;
                 }
-                Condition cond = GetCondition("maternalconditions", "76060-3");
+                Condition cond = GetCondition();
                 if (cond == null)
                 {
                     cond = (Condition)CreateEntry(GetFHIRPathAttribute(), SubjectId());
@@ -612,7 +612,7 @@ namespace BFDR
         {
             get
             {
-                Condition cond = GetCondition("membranes");
+                Condition cond = GetCondition();
                 if (cond != null && cond.Code != null && cond.Code.Text != null)
                 {
                     return cond.Code.Text.ToString();
@@ -625,7 +625,7 @@ namespace BFDR
                 {
                     return;
                 }
-                Condition cond = GetCondition("membranes");
+                Condition cond = GetCondition();
                 if (cond == null)
                 {
                     cond = (Condition)CreateEntry(GetFHIRPathAttribute(), SubjectId());
@@ -643,7 +643,7 @@ namespace BFDR
         {
             get
             {
-                Condition cond = GetCondition("obstetricalcomplications");
+                Condition cond = GetCondition();
                 if (cond != null && cond.Code != null && cond.Code.Text != null)
                 {
                     return cond.Code.Text.ToString();
@@ -656,7 +656,7 @@ namespace BFDR
                 {
                     return;
                 }
-                Condition cond = GetCondition("obstetricalcomplications");
+                Condition cond = GetCondition();
                 if (cond == null)
                 {
                     cond = (Condition)CreateEntry(GetFHIRPathAttribute(), SubjectId());
@@ -674,7 +674,7 @@ namespace BFDR
         {
             get
             {
-                Condition cond = GetCondition("702709008", "76060-3");
+                Condition cond = GetCondition();
                 if (cond != null && cond.Code != null && cond.Code.Text != null)
                 {
                     return cond.Code.Text.ToString();
@@ -687,7 +687,7 @@ namespace BFDR
                 {
                     return;
                 }
-                Condition cond = GetCondition("702709008", "76060-3");
+                Condition cond = GetCondition();
                 if (cond == null)
                 {
                     cond = (Condition)CreateEntry(GetFHIRPathAttribute(), SubjectId());
@@ -705,7 +705,7 @@ namespace BFDR
         {
             get
             {
-                Condition cond = GetCondition("277489001", "76060-3");
+                Condition cond = GetCondition();
                 if (cond != null && cond.Code != null && cond.Code.Text != null)
                 {
                     return cond.Code.Text.ToString();
@@ -718,7 +718,7 @@ namespace BFDR
                 {
                     return;
                 }
-                Condition cond = GetCondition("277489001", "76060-3");
+                Condition cond = GetCondition();
                 if (cond == null)
                 {
                     cond = (Condition)CreateEntry(GetFHIRPathAttribute(), SubjectId());
@@ -736,7 +736,7 @@ namespace BFDR
         {
             get
             {
-                Condition cond = GetCondition("128270001");
+                Condition cond = GetCondition();
                 if (cond != null && cond.Code != null && cond.Code.Text != null)
                 {
                     return cond.Code.Text.ToString();
@@ -749,7 +749,7 @@ namespace BFDR
                 {
                     return;
                 }
-                Condition cond = GetCondition("128270001");
+                Condition cond = GetCondition();
                 if (cond == null)
                 {
                     cond = (Condition)CreateEntry(GetFHIRPathAttribute(), SubjectId());
@@ -767,7 +767,7 @@ namespace BFDR
         {
             get
             {
-                Condition cond = GetCondition("fetalconditions", "76060-3");
+                Condition cond = GetCondition();
                 if (cond != null && cond.Code != null && cond.Code.Text != null)
                 {
                     return cond.Code.Text.ToString();
@@ -780,7 +780,7 @@ namespace BFDR
                 {
                     return;
                 }
-                Condition cond = GetCondition("fetalconditions", "76060-3");
+                Condition cond = GetCondition();
                 if (cond == null)
                 {
                     cond = (Condition)CreateEntry(GetFHIRPathAttribute(), SubjectId());
@@ -879,7 +879,7 @@ namespace BFDR
         {
             get
             {
-                Condition cond = GetCondition("maternalconditions", "76061-1");
+                Condition cond = GetCondition();
                 if (cond != null && cond.Code != null && cond.Code.Text != null)
                 {
                     return cond.Code.Text.ToString();
@@ -892,7 +892,7 @@ namespace BFDR
                 {
                     return;
                 }
-                Condition cond = GetCondition("maternalconditions", "76061-1");
+                Condition cond = GetCondition();
                 if (cond == null)
                 {
                     cond = (Condition)CreateEntry(GetFHIRPathAttribute(), SubjectId());
@@ -910,7 +910,7 @@ namespace BFDR
         {
             get
             {
-                Condition cond = GetCondition("membranes");
+                Condition cond = GetCondition();
                 if (cond != null && cond.Code != null && cond.Code.Text != null)
                 {
                     return cond.Code.Text.ToString();
@@ -923,7 +923,7 @@ namespace BFDR
                 {
                     return;
                 }
-                Condition cond = GetCondition("membranes");
+                Condition cond = GetCondition();
                 if (cond == null)
                 {
                     cond = (Condition)CreateEntry(GetFHIRPathAttribute(), SubjectId());
@@ -941,7 +941,7 @@ namespace BFDR
         {
             get
             {
-                Condition cond = GetCondition("obstetricalcomplications");
+                Condition cond = GetCondition();
                 if (cond != null && cond.Code != null && cond.Code.Text != null)
                 {
                     return cond.Code.Text.ToString();
@@ -954,7 +954,7 @@ namespace BFDR
                 {
                     return;
                 }
-                Condition cond = GetCondition("obstetricalcomplications");
+                Condition cond = GetCondition();
                 if (cond == null)
                 {
                     cond = (Condition)CreateEntry(GetFHIRPathAttribute(), SubjectId());
@@ -972,7 +972,7 @@ namespace BFDR
         {
             get
             {
-                Condition cond = GetCondition("702709008", "76061-1");
+                Condition cond = GetCondition();
                 if (cond != null && cond.Code != null && cond.Code.Text != null)
                 {
                     return cond.Code.Text.ToString();
@@ -985,7 +985,7 @@ namespace BFDR
                 {
                     return;
                 }
-                Condition cond = GetCondition("702709008", "76061-1");
+                Condition cond = GetCondition();
                 if (cond == null)
                 {
                     cond = (Condition)CreateEntry(GetFHIRPathAttribute(), SubjectId());
@@ -1003,7 +1003,7 @@ namespace BFDR
         {
             get
             {
-                Condition cond = GetCondition("277489001", "76061-1");
+                Condition cond = GetCondition();
                 if (cond != null && cond.Code != null && cond.Code.Text != null)
                 {
                     return cond.Code.Text.ToString();
@@ -1016,7 +1016,7 @@ namespace BFDR
                 {
                     return;
                 }
-                Condition cond = GetCondition("277489001", "76061-1");
+                Condition cond = GetCondition();
                 if (cond == null)
                 {
                     cond = (Condition)CreateEntry(GetFHIRPathAttribute(), SubjectId());
@@ -1034,7 +1034,7 @@ namespace BFDR
         {
             get
             {
-                Condition cond = GetCondition("128270001");
+                Condition cond = GetCondition();
                 if (cond != null && cond.Code != null && cond.Code.Text != null)
                 {
                     return cond.Code.Text.ToString();
@@ -1047,7 +1047,7 @@ namespace BFDR
                 {
                     return;
                 }
-                Condition cond = GetCondition("128270001");
+                Condition cond = GetCondition();
                 if (cond == null)
                 {
                     cond = (Condition)CreateEntry(GetFHIRPathAttribute(), SubjectId());
@@ -1065,7 +1065,7 @@ namespace BFDR
         {
             get
             {
-                Condition cond = GetCondition("fetalconditions", "76061-1");
+                Condition cond = GetCondition();
                 if (cond != null && cond.Code != null && cond.Code.Text != null)
                 {
                     return cond.Code.Text.ToString();
@@ -1078,7 +1078,7 @@ namespace BFDR
                 {
                     return;
                 }
-                Condition cond = GetCondition("fetalconditions", "76061-1");
+                Condition cond = GetCondition();
                 if (cond == null)
                 {
                     cond = (Condition)CreateEntry(GetFHIRPathAttribute(), SubjectId());

--- a/projects/VitalRecord/CodeSystems.cs
+++ b/projects/VitalRecord/CodeSystems.cs
@@ -189,7 +189,7 @@ namespace VR
 
         /// <summary> Date of Death Determination Methods </summary>
         public static string DateOfDeathDeterminationMethods = "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-date-of-death-determination-methods-cs";
-    
+
         /// <summary> Death Pregnancy Status </summary>
         public static string DeathPregnancyStatus = "http://hl7.org/fhir/us/vrdr/CodeSystem/CodeSystem-death-pregnancy-status";
 
@@ -206,5 +206,8 @@ namespace VR
 
         /// <summary> Discharge Disposition </summary>
         public static string DischargeDisposition = "http://terminology.hl7.org/CodeSystem/discharge-disposition";
+
+        /// <summary> US Core condition category </summary>
+        public static string ConditionCategory = "http://terminology.hl7.org/CodeSystem/condition-category";
     }
 }

--- a/projects/VitalRecord/VitalRecord.xml
+++ b/projects/VitalRecord/VitalRecord.xml
@@ -185,6 +185,9 @@
         <member name="F:VR.CodeSystems.DischargeDisposition">
             <summary> Discharge Disposition </summary>
         </member>
+        <member name="F:VR.CodeSystems.ConditionCategory">
+            <summary> US Core condition category </summary>
+        </member>
         <member name="T:VR.IJEField">
             <summary>Property attribute used to describe a field in the IJE format.</summary>
         </member>
@@ -6958,9 +6961,9 @@
             <summary>Helper to support vital record property getter helper methods for removing Observations.</summary>
             <param name="code">the code to identify the type of Observation</param>
         </member>
-        <member name="M:VR.VitalRecord.GetCondition(System.String,System.String)">
+        <member name="M:VR.VitalRecord.GetCondition(System.String)">
             <summary>Helper to support vital record property getter helper methods for values stored in Conditions.</summary>
-            <param name="code">the code to identify the type of Condition</param>
+            <param name="propertyName">the name of the C# property, must have a FHIRPath annotation, will default to the name of the calling property</param>
         </member>
         <member name="M:VR.VitalRecord.GetOrCreateObservation(System.String,System.String,System.String,System.String,System.String,System.String,System.String)">
             <summary>Helper to support vital record property setter helper methods for values stored in Observations.</summary>

--- a/projects/VitalRecord/VitalRecord_util.cs
+++ b/projects/VitalRecord/VitalRecord_util.cs
@@ -380,17 +380,24 @@ namespace VR
                 string codeSystem = fhirPath.CodeSystem ?? CodeSystems.SCT;
                 code = new CodeableConcept(codeSystem, fhirPath.Code, fhirPath.Display, null);
             }
-            CodeableConcept category = null;
+            CodeableConcept category = null, usCoreCategory = null;
             if (fhirPath.CategoryCode != null && fhirPath.CategoryCode.Length > 0)
             {
                 category = new CodeableConcept(CodeSystems.LOINC, fhirPath.CategoryCode);
+                if (fhirPath.CategoryCode == "76061-1" || fhirPath.CategoryCode == "76060-3")
+                {
+                    usCoreCategory = new CodeableConcept(CodeSystems.ConditionCategory, "encounter-diagnosis");
+                }
+                else
+                {
+                    usCoreCategory = new CodeableConcept(CodeSystems.ConditionCategory, "problem-list-item");
+                }
             }
             switch (fhirPath.FHIRType)
             {
                 case FHIRPath.FhirType.Condition:
                     Condition condition = new Condition();
                     condition.Code = code;
-                    CodeableConcept usCoreCategory = new CodeableConcept(CodeSystems.ConditionCategory, "problem-list-item");
                     condition.Category.Add(usCoreCategory);
                     condition.Category.Add(category);
                     condition.Subject = new ResourceReference($"urn:uuid:{subjectId}");

--- a/projects/VitalRecord/VitalRecord_util.cs
+++ b/projects/VitalRecord/VitalRecord_util.cs
@@ -117,17 +117,19 @@ namespace VR
         }
 
         /// <summary>Helper to support vital record property getter helper methods for values stored in Conditions.</summary>
-        /// <param name="code">the code to identify the type of Condition</param>
-        protected Condition GetCondition(string code, string categoryCode = null)
+        /// <param name="propertyName">the name of the C# property, must have a FHIRPath annotation, will default to the name of the calling property</param>
+        protected Condition GetCondition([CallerMemberName] string propertyName = null)
         {
+            FHIRPath fhirPath = GetFHIRPathAttribute(propertyName);
+
             // Find all conditions with this code
-            var entries = Bundle.Entry.Where(e => e.Resource is Condition obs && CodeableConceptToDict(obs.Code)["code"] == code);
+            var entries = Bundle.Entry.Where(e => e.Resource is Condition obs && CodeableConceptToDict(obs.Code)["code"] == fhirPath.Code);
 
             // Some conditions have the same code and require a category to differentiate
-            if (entries != null && categoryCode != null)
+            if (entries != null && fhirPath.CategoryCode != null && fhirPath.CategoryCode.Length > 0)
             {
                 // TODO categories have a required default category, there should be 2 in the list and we can't use 0 index by default
-                var entry = entries.Where(e => e.Resource is Condition obs && CodeableConceptToDict(obs.Category[0])["code"]==categoryCode).FirstOrDefault();
+                var entry = entries.Where(e => e.Resource is Condition cond && cond.Category.Any(c => c.Coding[0].Code == fhirPath.CategoryCode)).FirstOrDefault();
                 if (entry != null)
                 {
                     Condition cond = (Condition)entry.Resource;
@@ -388,6 +390,8 @@ namespace VR
                 case FHIRPath.FhirType.Condition:
                     Condition condition = new Condition();
                     condition.Code = code;
+                    CodeableConcept usCoreCategory = new CodeableConcept(CodeSystems.ConditionCategory, "problem-list-item");
+                    condition.Category.Add(usCoreCategory);
                     condition.Category.Add(category);
                     condition.Subject = new ResourceReference($"urn:uuid:{subjectId}");
                     resource = condition;
@@ -485,7 +489,7 @@ namespace VR
             }
             else if (String.IsNullOrEmpty(value))
             {
-                Extension missingValueReason = new Extension(OtherExtensionURL.DataAbsentReason, new Code(propertyName == "ChildFamilyName" ? "temp-unknown" : "unknown")); //if child, use temp-unknown, otherwise default to "unknown" 
+                Extension missingValueReason = new Extension(OtherExtensionURL.DataAbsentReason, new Code(propertyName == "ChildFamilyName" ? "temp-unknown" : "unknown")); //if child, use temp-unknown, otherwise default to "unknown"
                 if (name == null)
                 {
                     name = new HumanName
@@ -777,7 +781,7 @@ namespace VR
             // If we have a basic value as a valueDateTime use that, otherwise pull from the PartialDateTime extension
             if (value is FhirDateTime && ((FhirDateTime)value).Value != null)
             {
-                // DateTimeOffset.Parse will insert fake information where missing, 
+                // DateTimeOffset.Parse will insert fake information where missing,
                 // so TryParseExact on the partial date info first
                 if (partURL == VR.ExtensionURL.PartialDateYearVR)
                 {
@@ -1349,7 +1353,7 @@ namespace VR
             return new FhirDateTime(DateTimeOffset.MinValue.Year, DateTimeOffset.MinValue.Month, DateTimeOffset.MinValue.Day,
                 FhirTimeHour(value), FhirTimeMin(value), FhirTimeSec(value), TimeSpan.Zero);
         }
-        
+
         /// <summary>Getter helper for anything that can have a regular FHIR date/time, allowing the time to be read from the value</summary>
         protected string GetTimeFragment(Element value)
         {

--- a/projects/VitalRecord/VitalRecord_util.cs
+++ b/projects/VitalRecord/VitalRecord_util.cs
@@ -386,10 +386,19 @@ namespace VR
                 category = new CodeableConcept(CodeSystems.LOINC, fhirPath.CategoryCode);
                 if (fhirPath.CategoryCode == "76061-1" || fhirPath.CategoryCode == "76060-3")
                 {
+                    // BFDR profiles ConditionFetalDeathInitiatingCauseOrCondition and
+                    // ConditionFetalDeathOtherCauseOrCondition are based on
+                    // USCoreConditionEncounterDiagnosisProfile which require an additional
+                    // category of 'encounter-diagnosis' for conformance.
                     usCoreCategory = new CodeableConcept(CodeSystems.ConditionCategory, "encounter-diagnosis");
                 }
                 else
                 {
+                    // The remaining Conditions in the Vital Records IGs, all in BFDR for now, are based on
+                    // USCoreConditionProblemsHealthConcernsProfile which requires an additional category of
+                    // 'problem-list-item' for conformance.
+                    // If additional Conditions are supported by Vital Records IGs in the future, additional cases
+                    // would need to be defined here to ensure they get an appropriate USCore-defined category.
                     usCoreCategory = new CodeableConcept(CodeSystems.ConditionCategory, "problem-list-item");
                 }
             }


### PR DESCRIPTION
The US Core IG requires conditions to include specific category codes. This PR adds problem-list-item or encounter-diagnosis category to each created condition resource. This PR also refactors the GetCondition method to extract code and category from the caller FHIR path annotation instead of requiring those to be passed as parameters.

Fixes NVSS-721