### PR TITLE
fix(bfdr): ensure numeric fields are padded with leading zeroes

### DIFF
--- a/projects/BFDR.Tests/BirthRecord_Should.cs
+++ b/projects/BFDR.Tests/BirthRecord_Should.cs
@@ -744,7 +744,7 @@ namespace BFDR.Tests
       Assert.Equal(ije.BPLACEC_CNT, record.MotherPlaceOfBirth["addressCountry"]);
       Assert.Equal(ije.BPLACEC_ST_TER, record.MotherPlaceOfBirth["addressState"]);
 
-      
+
       // Exception ex = Assert.Throws<System.ArgumentException>(() => record.PlaceOfBirth = new Dictionary<string, string>{["addressState"] = "X"});
       // Assert.Equal("Code 'X' is not an allowed value for the valueset used in PlaceOfBirth", ex.Message);
     }
@@ -848,10 +848,10 @@ namespace BFDR.Tests
       // test missing family name
       Assert.Equal("Quinn", record.ChildFamilyName);
       Assert.Null(record.GetFamilyNameAbsentDataReason());
-      record.ChildFamilyName = ""; //set family name to empty 
+      record.ChildFamilyName = ""; //set family name to empty
       Assert.Equal("", record.ChildFamilyName);
       Assert.Equal("temp-unknown", record.GetFamilyNameAbsentDataReason());
-      record.ChildFamilyName = null; //set family name to null 
+      record.ChildFamilyName = null; //set family name to null
       Assert.Null(record.ChildFamilyName);
       Assert.Equal("temp-unknown", record.GetFamilyNameAbsentDataReason());
       IJEBirth ije2 = new(record);
@@ -882,7 +882,7 @@ namespace BFDR.Tests
       Assert.Equal("Mommy".PadRight(50), ije.MOMFNAME);
       Assert.Equal("D".PadRight(50), ije.MOMMIDDL);
       Assert.Equal("Quin".PadRight(50), ije.MOMLNAME);
-      
+
       Assert.Equal("Mommy".PadRight(50), ije.MOMFNAME);
       Assert.Equal("D".PadRight(50), ije.MOMMIDDL);
       Assert.Equal("Quin".PadRight(50), ije.MOMLNAME);
@@ -2273,7 +2273,7 @@ namespace BFDR.Tests
       // IJE translations
       IJEBirth ije1 = new IJEBirth(record);
       Assert.Equal("5", ije1.HFT);
-      Assert.Equal("7", ije1.HIN);
+      Assert.Equal("07", ije1.HIN);
       Assert.Equal("0", ije1.HGT_BYPASS);
     }
 
@@ -2283,7 +2283,7 @@ namespace BFDR.Tests
       BirthRecord record = new BirthRecord(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/BirthRecordBabyGQuinn.json")));
       Assert.Equal(67, record.MotherHeight);
 
-      //set after parse 
+      //set after parse
       record.MotherHeight = 68;
       Assert.Equal(68, record.MotherHeight);
     }
@@ -2552,7 +2552,7 @@ namespace BFDR.Tests
       BirthRecord record = new BirthRecord(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/BirthRecordBabyGQuinn.json")));
       Assert.Null(record.MaritalStatus);
 
-      //set after parse 
+      //set after parse
       record.MaritalStatus = "Married";
       Assert.Equal("Married", record.MaritalStatus);
     }
@@ -3940,7 +3940,7 @@ namespace BFDR.Tests
     [Fact]
     public void parseRecordZWithValidation()
     {
-      // TODO pass in the IJE and convert roundtrip so the record is up to date with the library 
+      // TODO pass in the IJE and convert roundtrip so the record is up to date with the library
       BirthRecord b = new(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/BirthRecordZ.json")));
       IJEBirth ije1 = new(b, true); // run with validation true since NCHS uses validation in their code, this confirms the record will be processed
       Console.WriteLine(ije1.ToString());
@@ -3956,14 +3956,14 @@ namespace BFDR.Tests
 
     [Fact]
     public void TestPatientFetalDeath() {
-      Assert.Null(SetterBirthRecord.PatientFetalDeath); 
-      SetterBirthRecord.PatientFetalDeath = false; 
+      Assert.Null(SetterBirthRecord.PatientFetalDeath);
+      SetterBirthRecord.PatientFetalDeath = false;
       Assert.Null(SetterBirthRecord.PatientFetalDeath); //Fetal death should only be indicated if Patient is deceased (value=true).
-      SetterBirthRecord.PatientFetalDeath = true; 
+      SetterBirthRecord.PatientFetalDeath = true;
       Assert.True(SetterBirthRecord.PatientFetalDeath);
       SetterBirthRecord.PatientFetalDeath = null;
       Assert.Null(SetterBirthRecord.PatientFetalDeath);
-      
+
       //parse
       BirthRecord record = new BirthRecord(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/BasicBirthRecord.json")));
       Assert.Null(record.PatientFetalDeath);

--- a/projects/BFDR.Tests/FetalDeathRecord_Should.cs
+++ b/projects/BFDR.Tests/FetalDeathRecord_Should.cs
@@ -184,8 +184,8 @@ namespace BFDR.Tests
         Assert.Equal("3333", ije.FWG);
         Assert.Equal("0", ije.FW_BYPASS);
         ije.FW_BYPASS = "2";
-        Assert.Equal("2", ije.FW_BYPASS); 
-    }  
+        Assert.Equal("2", ije.FW_BYPASS);
+    }
 
     [Fact]
     public void GetBirthWeight()
@@ -194,8 +194,8 @@ namespace BFDR.Tests
         Assert.Equal(BFDR.ValueSets.BirthWeightEditFlags.Off, BasicFetalDeathRecord.BirthWeightEditFlagHelper);
         Assert.Equal(BFDR.ValueSets.BirthWeightEditFlags.Off, BasicFetalDeathRecord.BirthWeightEditFlag["code"]);
         Assert.Equal(VR.CodeSystems.VRCLEditFlags, BasicFetalDeathRecord.BirthWeightEditFlag["system"]);
-        Assert.Equal("Off", BasicFetalDeathRecord.BirthWeightEditFlag["display"]); 
-    }  
+        Assert.Equal("Off", BasicFetalDeathRecord.BirthWeightEditFlag["display"]);
+    }
 
     [Fact]
     public void ParseRegistrationDate()
@@ -212,7 +212,7 @@ namespace BFDR.Tests
       Assert.Equal("09", ije.DOR_DY);
 
       //set after parse
-      record.FirstPrenatalCareVisit = "2024-05"; 
+      record.FirstPrenatalCareVisit = "2024-05";
       Assert.Equal("2024-05", record.FirstPrenatalCareVisit);
       Assert.Equal(2024, record.FirstPrenatalCareVisitYear);
       Assert.Equal(5, record.FirstPrenatalCareVisitMonth);
@@ -319,7 +319,7 @@ namespace BFDR.Tests
       Assert.Equal(02, (int)br2.CertifiedMonth);
       Assert.Equal(19, (int)br2.CertifiedDay);
     }
-    
+
     [Fact]
     public void TestCigarettesSmoked()
     {
@@ -399,19 +399,19 @@ namespace BFDR.Tests
       FetalDeathRecord record = new(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/FetalDeathReport.json")));
       //maternal morbidity
       Assert.False(record.NoMaternalMorbidities);
-      Assert.False(record.RupturedUterus); 
+      Assert.False(record.RupturedUterus);
       Assert.False(record.ICUAdmission);
       //risk factors
       Assert.False(record.NoPregnancyRiskFactors);
-      Assert.False(record.EclampsiaHypertension); 
-      Assert.False(record.GestationalDiabetes); 
-      Assert.False(record.GestationalHypertension); 
-      Assert.False(record.PrepregnancyDiabetes); 
-      Assert.False(record.PrepregnancyHypertension); 
-      Assert.False(record.PreviousCesarean); 
-      Assert.False(record.FertilityEnhancingDrugTherapyArtificialIntrauterineInsemination); 
-      Assert.False(record.AssistedReproductiveTechnology); 
-      Assert.False(record.InfertilityTreatment); 
+      Assert.False(record.EclampsiaHypertension);
+      Assert.False(record.GestationalDiabetes);
+      Assert.False(record.GestationalHypertension);
+      Assert.False(record.PrepregnancyDiabetes);
+      Assert.False(record.PrepregnancyHypertension);
+      Assert.False(record.PreviousCesarean);
+      Assert.False(record.FertilityEnhancingDrugTherapyArtificialIntrauterineInsemination);
+      Assert.False(record.AssistedReproductiveTechnology);
+      Assert.False(record.InfertilityTreatment);
       //set after parse
       record.NoMaternalMorbidities = true;
       Assert.True(record.NoMaternalMorbidities);
@@ -465,7 +465,7 @@ namespace BFDR.Tests
 
     [Fact]
     public void ParseFetalDeathCauseOrCondition()
-    { 
+    {
       FetalDeathRecord record = new(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/FetalDeathReport.json")));
       Assert.True(record.PrematureRuptureOfMembranes);
       Assert.False(record.AbruptioPlacenta);
@@ -483,9 +483,9 @@ namespace BFDR.Tests
       Assert.Null(record.OtherFetalConditionsDisordersLiteral);
 
       //set after parse
-      record.PrematureRuptureOfMembranes = false; 
+      record.PrematureRuptureOfMembranes = false;
       Assert.False(record.PrematureRuptureOfMembranes);
-      record.ProlapsedCord = true; 
+      record.ProlapsedCord = true;
       Assert.True(record.ProlapsedCord);
       record.MaternalConditionsDiseasesLiteral = "Complication of Placenta Cord";
       Assert.Equal("Complication of Placenta Cord", record.MaternalConditionsDiseasesLiteral);
@@ -552,7 +552,7 @@ namespace BFDR.Tests
 
       Assert.Null(SetterFetalDeathRecord.FetalInfectionLiteral);
       SetterFetalDeathRecord.FetalInfectionLiteral = "Some Fetal Infection";
-      Assert.Equal("Some Fetal Infection", SetterFetalDeathRecord.FetalInfectionLiteral); 
+      Assert.Equal("Some Fetal Infection", SetterFetalDeathRecord.FetalInfectionLiteral);
 
       Assert.Null(SetterFetalDeathRecord.OtherFetalConditionsDisordersLiteral);
       SetterFetalDeathRecord.OtherFetalConditionsDisordersLiteral = "Other Fetal Condition or Disorder";
@@ -561,7 +561,7 @@ namespace BFDR.Tests
 
     [Fact]
     public void ParseOtherFetalDeathCauseOrCondition()
-    { 
+    {
       FetalDeathRecord record = new(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/FetalDeathReport.json")));
       Assert.False(record.OtherCOD_PrematureRuptureOfMembranes);
       Assert.False(record.OtherCOD_AbruptioPlacenta);
@@ -579,9 +579,9 @@ namespace BFDR.Tests
       Assert.Null(record.OtherCOD_OtherFetalConditionsDisordersLiteral);
 
       //set after parse
-      record.OtherCOD_PlacentalInsufficiency = false; 
+      record.OtherCOD_PlacentalInsufficiency = false;
       Assert.False(record.OtherCOD_PlacentalInsufficiency);
-      record.OtherCOD_ProlapsedCord = true; 
+      record.OtherCOD_ProlapsedCord = true;
       Assert.True(record.OtherCOD_ProlapsedCord);
       record.OtherCOD_OtherFetalConditionsDisordersLiteral = "Some other fetal condition disorder";
       Assert.Equal("Some other fetal condition disorder", record.OtherCOD_OtherFetalConditionsDisordersLiteral);
@@ -648,13 +648,13 @@ namespace BFDR.Tests
 
       Assert.Null(SetterFetalDeathRecord.OtherCOD_FetalInfectionLiteral);
       SetterFetalDeathRecord.OtherCOD_FetalInfectionLiteral = "Some Fetal Infection";
-      Assert.Equal("Some Fetal Infection", SetterFetalDeathRecord.OtherCOD_FetalInfectionLiteral); 
+      Assert.Equal("Some Fetal Infection", SetterFetalDeathRecord.OtherCOD_FetalInfectionLiteral);
 
       Assert.Null(SetterFetalDeathRecord.OtherCOD_OtherFetalConditionsDisordersLiteral);
       SetterFetalDeathRecord.OtherCOD_OtherFetalConditionsDisordersLiteral = "Other Fetal Condition or Disorder";
       Assert.Equal("Other Fetal Condition or Disorder", SetterFetalDeathRecord.OtherCOD_OtherFetalConditionsDisordersLiteral);
     }
-  
+
     [Fact]
     public void SetFetalPresentation()
     {
@@ -701,7 +701,7 @@ namespace BFDR.Tests
       Assert.Equal("38", fetalDeathRecord2.GestationalAgeAtDelivery["value"]);
       Assert.Equal("wk", fetalDeathRecord2.GestationalAgeAtDelivery["code"]);
       Assert.Equal("http://unitsofmeasure.org", fetalDeathRecord2.GestationalAgeAtDelivery["system"]);
-      
+
       FetalDeathRecord fetalDeathRecord3 = new FetalDeathRecord();
       Dictionary<string, string> dict2 = new Dictionary<string, string>();
       dict2.Add("value", "48");
@@ -828,7 +828,7 @@ namespace BFDR.Tests
     }
 
     [Fact]
-    public void TestImportDeliveryLocation() 
+    public void TestImportDeliveryLocation()
     {
       FetalDeathRecord record = new(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/FetalDeathReport.json")));
       Assert.Equal("116441967701", record.FacilityNPI);
@@ -1022,7 +1022,7 @@ namespace BFDR.Tests
     }
 
     [Fact]
-    public void TestImportLastMenstrualPeriod() 
+    public void TestImportLastMenstrualPeriod()
     {
       FetalDeathRecord record = new FetalDeathRecord(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/FetalDeathReport.json")));
       Assert.Equal("2018-04-18", record.LastMenstrualPeriod);
@@ -1085,9 +1085,9 @@ namespace BFDR.Tests
         // IJE translations
         IJEFetalDeath ije1 = new IJEFetalDeath(record);
         Assert.Equal("5", ije1.HFT);
-        Assert.Equal("7", ije1.HIN);  
+        Assert.Equal("07", ije1.HIN);
         Assert.Equal("0", ije1.HGT_BYPASS);
-    }  
+    }
 
     [Fact]
     public void TestImportMotherHeightProperties()
@@ -1095,10 +1095,10 @@ namespace BFDR.Tests
         FetalDeathRecord record = new FetalDeathRecord(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/FetalDeathReport.json")));
         Assert.Equal(56, record.MotherHeight);
 
-        //set after parse 
-        record.MotherHeight = 68; 
+        //set after parse
+        record.MotherHeight = 68;
         Assert.Equal(68, record.MotherHeight);
-    } 
+    }
 
     [Fact]
     public void TestWeightPropertiesSetter()
@@ -1122,12 +1122,12 @@ namespace BFDR.Tests
         // IJE translations
         IJEFetalDeath ije1 = new IJEFetalDeath(record);
         Assert.Equal("145", ije1.PWGT);
-        Assert.Equal("0", ije1.PWGT_BYPASS); 
+        Assert.Equal("0", ije1.PWGT_BYPASS);
         // TODO: add these when fetal weight is added
         // Assert.Equal("2500", ije1.FWG);
-        // Assert.Equal("0", ije1.FW_BYPASS); 
-    }  
-  
+        // Assert.Equal("0", ije1.FW_BYPASS);
+    }
+
     [Fact]
     public void TestImportWeightProperties()
     {
@@ -1264,7 +1264,7 @@ namespace BFDR.Tests
         }
         Assert.Equal(17, b2.FatherRace.Length);
     }
-  
+
     [Fact]
     public void TestImportRace()
     {
@@ -1396,16 +1396,16 @@ namespace BFDR.Tests
     public void TestParentReportedAge()
     {
 
-      // set 
+      // set
       SetterFetalDeathRecord.MotherReportedAgeAtDelivery = 26;
       SetterFetalDeathRecord.FatherReportedAgeAtDelivery = 27;
-      Assert.Equal(26, SetterFetalDeathRecord.MotherReportedAgeAtDelivery); 
+      Assert.Equal(26, SetterFetalDeathRecord.MotherReportedAgeAtDelivery);
       Assert.Equal(27, SetterFetalDeathRecord.FatherReportedAgeAtDelivery);
 
       // parsed record
       FetalDeathRecord record = new FetalDeathRecord(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/BasicFetalDeathRecord.json")));
-      Assert.Equal(33, record.MotherReportedAgeAtDelivery); 
-      Assert.Equal(31, record.FatherReportedAgeAtDelivery); 
+      Assert.Equal(33, record.MotherReportedAgeAtDelivery);
+      Assert.Equal(31, record.FatherReportedAgeAtDelivery);
 
       // to IJE
       IJEFetalDeath ije = new(record);
@@ -1469,10 +1469,10 @@ namespace BFDR.Tests
       // test missing family name
       Assert.Equal("Quinn", record.FetusFamilyName);
       Assert.Null(record.GetFamilyNameAbsentDataReason());
-      record.FetusFamilyName = ""; //set family name to empty 
+      record.FetusFamilyName = ""; //set family name to empty
       Assert.Equal("", record.FetusFamilyName);
       Assert.Equal("unknown", record.GetFamilyNameAbsentDataReason());
-      record.FetusFamilyName = null; //set family name to null 
+      record.FetusFamilyName = null; //set family name to null
       Assert.Null(record.FetusFamilyName);
       Assert.Equal("unknown", record.GetFamilyNameAbsentDataReason());
       IJEFetalDeath ije2 = new(record);
@@ -1538,12 +1538,12 @@ namespace BFDR.Tests
       // Assert.Equal("F", firstRecord.FetalDeathSexHelper);
       // Assert.Equal(firstRecord.FetalDeathSex["code"], secondRecord.FetalDeathSexHelper);
       // Plurality
-      Assert.Equal(4, firstRecord.FetalDeathPlurality); 
+      Assert.Equal(4, firstRecord.FetalDeathPlurality);
       // Set Order
       Assert.Equal(3, firstRecord.FetalDeathSetOrder);
       Assert.Equal(firstRecord.FetalDeathSetOrder, secondRecord.FetalDeathSetOrder);
       // // Mother's Age
-      //  Assert.Equal(34, firstRecord.MotherReportedAgeAtDelivery); 
+      //  Assert.Equal(34, firstRecord.MotherReportedAgeAtDelivery);
       // // Father's Age
       //  Assert.Equal(35, firstRecord.FatherReportedAgeAtDelivery);
       // // Child's First Name
@@ -1889,7 +1889,7 @@ namespace BFDR.Tests
         Assert.Equal("BBBBBBBB", record1.EmergingIssue8_2);
         Assert.Equal("CCCCCCCC", record1.EmergingIssue8_3);
         Assert.Equal("AAAAAAAAAAAAAAAAAAAA", record1.EmergingIssue20);
-        
+
         IJEFetalDeath ije = new IJEFetalDeath(record1, false); // Don't validate since we don't care about most fields
         Assert.Equal("A", ije.PLACE1_1);
         Assert.Equal("B", ije.PLACE1_2);
@@ -2002,15 +2002,15 @@ namespace BFDR.Tests
     {
       //parse
       FetalDeathRecord record = new FetalDeathRecord(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/FetalDeathReport.json")));
-      Assert.Equal("132224986", record.MotherSocialSecurityNumber); 
-      Assert.Null(record.FatherSocialSecurityNumber); 
+      Assert.Equal("132224986", record.MotherSocialSecurityNumber);
+      Assert.Null(record.FatherSocialSecurityNumber);
 
       //set after parse
       record.MotherSocialSecurityNumber = "123456789";
       Assert.Equal("123456789", record.MotherSocialSecurityNumber);
       record.FatherSocialSecurityNumber = "123123123";
       Assert.Equal("123123123", record.FatherSocialSecurityNumber);
-      
+
       IJEFetalDeath ije = new(record);
       Assert.Equal("123456789", ije.MOM_SSN);
       Assert.Equal("123123123", ije.DAD_SSN);
@@ -2137,7 +2137,7 @@ namespace BFDR.Tests
       FetalDeathRecord record = new FetalDeathRecord(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/FetalDeathReport.json")));
       Assert.True(record.PatientFetalDeath);
 
-      SetterFetalDeathRecord.PatientFetalDeath = false; //DecedentFetus is required to have PatientFetalDeath extension = true. --> handle in business rules. 
+      SetterFetalDeathRecord.PatientFetalDeath = false; //DecedentFetus is required to have PatientFetalDeath extension = true. --> handle in business rules.
       Assert.Null(SetterFetalDeathRecord.PatientFetalDeath); //Fetal death should only be indicated if Patient is deceased (value = true).
       SetterFetalDeathRecord.PatientFetalDeath = true;
       Assert.True(SetterFetalDeathRecord.PatientFetalDeath);

--- a/projects/BFDR.Tests/IJEFetalDeath_Should.cs
+++ b/projects/BFDR.Tests/IJEFetalDeath_Should.cs
@@ -212,7 +212,7 @@ namespace BFDR.Tests
       Assert.Equal("", ije.MRACE21C.Trim());
       Assert.Equal("", ije.MRACE22C.Trim());
       Assert.Equal("", ije.MRACE23C.Trim());
-      Assert.Equal("2", ije.ATTEND); 
+      Assert.Equal("2", ije.ATTEND);
       Assert.Equal("", ije.TRAN.Trim());
       Assert.Equal("99", ije.DOFP_MO);
       Assert.Equal("99", ije.DOFP_DY);
@@ -223,7 +223,7 @@ namespace BFDR.Tests
       Assert.Equal("", ije.NPREV.Trim());
       Assert.Equal("", ije.NPREV_BYPASS.Trim());
       Assert.Equal("5", ije.HFT);
-      Assert.Equal("3", ije.HIN);
+      Assert.Equal("03", ije.HIN);
       Assert.Equal("0", ije.HGT_BYPASS);
       Assert.Equal("182", ije.PWGT);
       Assert.Equal("0", ije.PWGT_BYPASS);
@@ -318,14 +318,14 @@ namespace BFDR.Tests
       Assert.Equal("N", ije.COD18a5);
       Assert.Equal("N", ije.COD18a6);
       Assert.Equal("N", ije.COD18a7);
-      Assert.Equal("NO PRENATAL CARE", ije.COD18a8.Trim()); 
+      Assert.Equal("NO PRENATAL CARE", ije.COD18a8.Trim());
       Assert.Equal("", ije.COD18a9.Trim());
       Assert.Equal("", ije.COD18a10.Trim());
-      Assert.Equal("", ije.COD18a11.Trim()); 
+      Assert.Equal("", ije.COD18a11.Trim());
       Assert.Equal("99          0", ije.COD18a12.Trim());
       Assert.Equal("", ije.COD18a13.Trim());
       Assert.Equal("", ije.COD18a13.Trim());
-      Assert.Equal("", ije.COD18a14.Trim()); 
+      Assert.Equal("", ije.COD18a14.Trim());
       Assert.Equal("N", ije.COD18b1);
       Assert.Equal("N", ije.COD18b2);
       Assert.Equal("N", ije.COD18b3);
@@ -337,7 +337,7 @@ namespace BFDR.Tests
       Assert.Equal("", ije.COD18b9.Trim());
       Assert.Equal("", ije.COD18b10.Trim());
       Assert.Equal("NONE IDENTIFIED", ije.COD18b11.Trim());
-      Assert.Equal("", ije.COD18b12.Trim()); 
+      Assert.Equal("", ije.COD18b12.Trim());
       Assert.Equal("", ije.COD18b13.Trim());
       Assert.Equal("INTRAUTERINE FETAL DEMISE", ije.COD18b14.Trim());
       Assert.Equal("", ije.ICOD.Trim());
@@ -367,7 +367,7 @@ namespace BFDR.Tests
       Assert.Equal("", ije.ZIPCODE_D.Trim());
       Assert.Equal("", ije.CNTY_D.Trim());
       Assert.Equal("", ije.CITY_D.Trim());
-      Assert.Equal("", ije.STATE_D.Trim()); 
+      Assert.Equal("", ije.STATE_D.Trim());
       Assert.Equal("", ije.COUNTRY_D.Trim());
       Assert.Equal("", ije.LONG_D.Trim());
       Assert.Equal("", ije.LAT_D.Trim());
@@ -379,18 +379,18 @@ namespace BFDR.Tests
       Assert.Equal("", ije.MOMMMID.Trim());
       Assert.Equal("", ije.MOMMAIDN.Trim());
       Assert.Equal("", ije.MOMMSUFFIX.Trim());
-      Assert.Equal("XXXX", ije.STNUM.Trim()); 
-      Assert.Equal("S", ije.PREDIR.Trim()); 
-      Assert.Equal("14 TH", ije.STNAME.Trim()); 
-      Assert.Equal("ST", ije.STDESIG.Trim()); 
+      Assert.Equal("XXXX", ije.STNUM.Trim());
+      Assert.Equal("S", ije.PREDIR.Trim());
+      Assert.Equal("14 TH", ije.STNAME.Trim());
+      Assert.Equal("ST", ije.STDESIG.Trim());
       Assert.Equal("", ije.POSTDIR.Trim());
       Assert.Equal("", ije.APTNUMB.Trim());
-      Assert.Equal("XXXX S 14 TH ST", ije.ADDRESS.Trim()); 
-      Assert.Equal("XXXXX", ije.ZIPCODE.Trim()); 
-      Assert.Equal("XXXXXXXXX", ije.COUNTYTXT.Trim()); 
-      Assert.Equal("xxxxxx xxxx", ije.CITYTXT.Trim()); 
+      Assert.Equal("XXXX S 14 TH ST", ije.ADDRESS.Trim());
+      Assert.Equal("XXXXX", ije.ZIPCODE.Trim());
+      Assert.Equal("XXXXXXXXX", ije.COUNTYTXT.Trim());
+      Assert.Equal("xxxxxx xxxx", ije.CITYTXT.Trim());
       Assert.Equal("Delaware", ije.STATETXT.Trim());
-      Assert.Equal("United States", ije.CNTRYTXT.Trim()); 
+      Assert.Equal("United States", ije.CNTRYTXT.Trim());
       Assert.Equal("", ije.LONG.Trim());
       Assert.Equal("", ije.LAT.Trim());
       Assert.Equal("", ije.DADFNAME.Trim());
@@ -413,8 +413,8 @@ namespace BFDR.Tests
       Assert.Equal("", ije.FBPLACE_CNT_C.Trim());
       // Assert.Equal("", ije.MBPLACE_ST_TER_TXT.Trim()); // roundtrip pulls from the code to text translation for the BLPACE_ST_TER field so this isn't rountripping
       // Assert.Equal("", ije.MBPLACE_CNTRY_TXT.Trim()); // null error resolved with padding, but pulls from the code to text translation so there is a mis match
-      Assert.Equal("", ije.FBPLACE_ST_TER_TXT.Trim()); 
-      Assert.Equal("", ije.FBPLACE_CNTRY_TXT.Trim()); 
+      Assert.Equal("", ije.FBPLACE_ST_TER_TXT.Trim());
+      Assert.Equal("", ije.FBPLACE_CNTRY_TXT.Trim());
       Assert.Equal("", ije.FEDUC.Trim());
       Assert.Equal("", ije.FEDUC_BYPASS.Trim());
       Assert.Equal("U", ije.FETHNIC1.Trim()); // blanks become u when round tripped, is this correct?
@@ -537,15 +537,15 @@ namespace BFDR.Tests
       FetalDeathRecord dr = ije.ToRecord();
       Assert.Equal("HI", dr.EventLocationJurisdiction);
       ije.DSTATE = "TT";
-      Assert.Equal("TT", ije.DSTATE); 
+      Assert.Equal("TT", ije.DSTATE);
       dr = ije.ToRecord();
       Assert.Equal("TT", dr.EventLocationJurisdiction);
       ije.DSTATE = "TS";
-      Assert.Equal("TS", ije.DSTATE); 
+      Assert.Equal("TS", ije.DSTATE);
       dr = ije.ToRecord();
       Assert.Equal("TS", dr.EventLocationJurisdiction);
       ije.DSTATE = "ZZ";
-      Assert.Equal("ZZ", ije.DSTATE); 
+      Assert.Equal("ZZ", ije.DSTATE);
       dr = ije.ToRecord();
       Assert.Equal("ZZ", dr.EventLocationJurisdiction);
     }

--- a/projects/BFDR.Tests/NatalityData_Should.cs
+++ b/projects/BFDR.Tests/NatalityData_Should.cs
@@ -101,15 +101,15 @@ namespace BFDR.Tests
       BirthRecord br = ije.ToRecord();
       Assert.Equal("HI", br.EventLocationJurisdiction);
       ije.BSTATE = "TT";
-      Assert.Equal("TT", ije.BSTATE); 
+      Assert.Equal("TT", ije.BSTATE);
       br = ije.ToRecord();
       Assert.Equal("TT", br.EventLocationJurisdiction);
       ije.BSTATE = "TS";
-      Assert.Equal("TS", ije.BSTATE); 
+      Assert.Equal("TS", ije.BSTATE);
       br = ije.ToRecord();
       Assert.Equal("TS", br.EventLocationJurisdiction);
       ije.BSTATE = "ZZ";
-      Assert.Equal("ZZ", ije.BSTATE); 
+      Assert.Equal("ZZ", ije.BSTATE);
       br = ije.ToRecord();
       Assert.Equal("ZZ", br.EventLocationJurisdiction);
     }
@@ -835,7 +835,7 @@ namespace BFDR.Tests
       br = new BirthRecord();
       ije = new IJEBirth(br);
       Assert.Equal("".PadLeft(12, ' '), ije.AUXNO);
-      
+
     }
 
     [Fact]
@@ -1062,12 +1062,12 @@ namespace BFDR.Tests
         Assert.Equal("9",ije1.HFT);
         ije1.HFT = "5";
         ije1.HIN = "7";
-        Assert.Equal("7", ije1.HIN);
+        Assert.Equal("07", ije1.HIN);
         Assert.Equal("5", ije1.HFT);
         ije1.HFT = "5";
         ije1.HIN = "3";
         Assert.Equal("5", ije1.HFT);
-        Assert.Equal("3", ije1.HIN);
+        Assert.Equal("03", ije1.HIN);
         // Edit Flag
         Assert.Equal("", ije1.HGT_BYPASS);
         ije1.HGT_BYPASS = "1";

--- a/projects/BFDR/IJEBirth.cs
+++ b/projects/BFDR/IJEBirth.cs
@@ -86,7 +86,7 @@ namespace BFDR
         // Class helper methods for getting and settings IJE fields.
         //
         /////////////////////////////////////////////////////////////////////////////////
-    
+
 
         /////////////////////////////////////////////////////////////////////////////////
         //
@@ -2076,7 +2076,8 @@ namespace BFDR
                 IJEField info = FieldInfo("HFT");
                 int? value = (int?)Record.GetType().GetProperty("MotherHeight").GetValue(record);
                 if (value == -1 || value == null) return new String('9', info.Length); // Explicitly set to unknown
-                return (value / 12).ToString();
+                var valueString = (value / 12).ToString();
+                return Truncate(valueString, info.Length).PadLeft(info.Length, '0');
             }
             set
             {
@@ -2104,7 +2105,8 @@ namespace BFDR
                 IJEField info = FieldInfo("HIN");
                 int? value = (int?)Record.GetType().GetProperty("MotherHeight").GetValue(record);
                 if (value == -1 || value == null) return new String('9', info.Length); // Explicitly set to unknown
-                return (value % 12).ToString();
+                var valueString = (value % 12).ToString();
+                return Truncate(valueString, info.Length).PadLeft(info.Length, '0');
             }
             set
             {
@@ -2827,7 +2829,6 @@ namespace BFDR
                 {
                     record.LaborTrialAttempted = false;
                 }
-                return;
             }
         }
 
@@ -2920,7 +2921,7 @@ namespace BFDR
                 if (record.GestationalAgeAtDelivery != null && !String.IsNullOrEmpty(record.GestationalAgeAtDelivery["value"]))
                 {
 
-                    if (record.GestationalAgeAtDelivery["code"] == "wk") 
+                    if (record.GestationalAgeAtDelivery["code"] == "wk")
                     {
                         int weeks = (int)Convert.ToDecimal(record.GestationalAgeAtDelivery["value"]);
                         return Truncate(weeks.ToString(), info.Length).PadLeft(info.Length, '0');
@@ -2930,7 +2931,7 @@ namespace BFDR
                         int days = (int)(Convert.ToDecimal(record.GestationalAgeAtDelivery["value"])/7);
                         return Truncate(days.ToString(), info.Length).PadLeft(info.Length, '0');
                     }
-                    
+
                 }
                 return "  ";
             }
@@ -3240,7 +3241,6 @@ namespace BFDR
                 {
                     record.InfantLiving = false;
                 }
-                return;
             }
         }
 
@@ -4657,7 +4657,7 @@ namespace BFDR
             set
             {
                 if (value == "Y")
-                {   
+                {
                     record.SSNRequested = true;
                 }
                 else if (value == "N")

--- a/projects/BFDR/IJEFetalDeath.cs
+++ b/projects/BFDR/IJEFetalDeath.cs
@@ -95,7 +95,7 @@ namespace BFDR
             {
                 return "Y";
             }
-            else 
+            else
             {
                 return "N";
             }
@@ -109,7 +109,7 @@ namespace BFDR
             {
                 field(true);
             }
-            else 
+            else
             {
                 field(false);
             }
@@ -533,7 +533,7 @@ namespace BFDR
             set
             {
                 if (!String.IsNullOrWhiteSpace(value))
-                {  
+                {
                     Set_MappingIJEToFHIR(VR.Mappings.YesNoUnknown.IJEToFHIR, "LIMITS", "MotherResidenceWithinCityLimits", value);
                 }
             }
@@ -601,12 +601,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -616,12 +616,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1299,7 +1299,7 @@ namespace BFDR
         /// <summary>Attendant</summary>
         [IJEField(78, 422, 1, "Attendant", "ATTEND", 1)]
         public string ATTEND
-        {    
+        {
             get
             {
                 var ret = record.AttendantTitleHelper;
@@ -1331,12 +1331,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1388,12 +1388,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1403,12 +1403,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1418,12 +1418,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1433,12 +1433,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1448,12 +1448,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1468,7 +1468,8 @@ namespace BFDR
                 IJEField info = FieldInfo("HFT");
                 int? value = (int?)Record.GetType().GetProperty("MotherHeight").GetValue(record);
                 if (value == -1 || value == null) return new String('9', info.Length); // Explicitly set to unknown
-                return (value / 12).ToString();
+                var valueString = (value / 12).ToString();
+                return Truncate(valueString, info.Length).PadLeft(info.Length, '0');
             }
             set
             {
@@ -1496,7 +1497,8 @@ namespace BFDR
                 IJEField info = FieldInfo("HIN");
                 int? value = (int?)Record.GetType().GetProperty("MotherHeight").GetValue(record);
                 if (value == -1 || value == null) return new String('9', info.Length); // Explicitly set to unknown
-                return (value % 12).ToString();
+                var valueString = (value % 12).ToString();
+                return Truncate(valueString, info.Length).PadLeft(info.Length, '0');
             }
             set
             {
@@ -1605,12 +1607,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1648,12 +1650,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1663,12 +1665,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1808,12 +1810,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1823,12 +1825,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1838,12 +1840,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1897,12 +1899,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1912,12 +1914,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1927,12 +1929,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1942,12 +1944,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1957,12 +1959,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1972,12 +1974,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -1987,12 +1989,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2002,12 +2004,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2017,12 +2019,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2032,12 +2034,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2047,12 +2049,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2062,12 +2064,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2145,7 +2147,6 @@ namespace BFDR
                 {
                     record.LaborTrialAttempted = false;
                 }
-                return;
             }
         }
 
@@ -2155,12 +2156,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2170,12 +2171,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2185,12 +2186,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2208,12 +2209,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2231,12 +2232,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2281,7 +2282,7 @@ namespace BFDR
                 if (record.GestationalAgeAtDelivery != null && !String.IsNullOrEmpty(record.GestationalAgeAtDelivery["value"]))
                 {
 
-                    if (record.GestationalAgeAtDelivery["code"] == "wk") 
+                    if (record.GestationalAgeAtDelivery["code"] == "wk")
                     {
                         int weeks = (int)Convert.ToDecimal(record.GestationalAgeAtDelivery["value"]);
                         return Truncate(weeks.ToString(), info.Length).PadLeft(info.Length, '0');
@@ -2291,7 +2292,7 @@ namespace BFDR
                         int days = (int)(Convert.ToDecimal(record.GestationalAgeAtDelivery["value"])/7);
                         return Truncate(days.ToString(), info.Length).PadLeft(info.Length, '0');
                     }
-                    
+
                 }
                 return "  ";
             }
@@ -2433,12 +2434,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2462,12 +2463,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2477,12 +2478,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2492,12 +2493,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2507,12 +2508,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2522,12 +2523,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2537,12 +2538,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2552,12 +2553,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2567,12 +2568,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2582,12 +2583,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2597,12 +2598,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2612,12 +2613,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2627,12 +2628,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2642,12 +2643,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2657,12 +2658,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -2672,12 +2673,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -3121,12 +3122,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -3136,12 +3137,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -3151,12 +3152,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -3220,12 +3221,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -3422,7 +3423,7 @@ namespace BFDR
                 else
                 {
                     return new String(' ', 28);
-                }   
+                }
             }
             set
             {
@@ -3449,7 +3450,7 @@ namespace BFDR
                 else
                 {
                     return new String(' ', 28);
-                }   
+                }
             }
             set
             {
@@ -3467,12 +3468,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -3482,12 +3483,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -3815,7 +3816,7 @@ namespace BFDR
                 else
                 {
                     return new String(' ', 28);
-                }   
+                }
             }
             set
             {
@@ -3843,12 +3844,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -3858,12 +3859,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -3968,12 +3969,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -3983,12 +3984,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -4012,12 +4013,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -4041,12 +4042,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -4070,12 +4071,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -4086,7 +4087,6 @@ namespace BFDR
             get
             {
                 return LeftJustified_Get("DAD_IN_T", "FatherIndustry");
-                //return Truncate(LeftJustified_Get("DAD_IN_T", "FatherIndustry"), 20).Trim();
             }
             set
             {
@@ -4100,12 +4100,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -4908,12 +4908,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -4939,12 +4939,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -4954,12 +4954,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -4969,12 +4969,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -4984,12 +4984,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -4999,12 +4999,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -5022,12 +5022,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -5037,12 +5037,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -5052,12 +5052,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -5067,12 +5067,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -5082,12 +5082,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -5097,12 +5097,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -5112,12 +5112,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -5169,12 +5169,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -5184,12 +5184,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -5199,12 +5199,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -5214,12 +5214,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -5369,12 +5369,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
 
@@ -5384,12 +5384,12 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location: 
+                // TODO: Implement mapping from FHIR record location:
                 return "";
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location: 
+                // TODO: Implement mapping to FHIR record location:
             }
         }
     }


### PR DESCRIPTION
Many numeric IJE fields require leading zeros to pad the field to the required length. E.g. the HIN field is two characters and a length of four should be returned as "04" not "4". This PR fixes the return value for IJE field HIN and HFT in both birth and fetal death records.

Fixes #NVSS-781