### PR TITLE
test(bfdr): add tests for bfdr messaging classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,8 +149,10 @@ coverage*.info
 # and report generation for BFDR tests
 projects/BFDR.Tests/tools
 projects/BFDR.Tests/.config/dotnet-tools.json
+projects/BFDR.Tests/coveragereport/*
 projects/VRDR.Tests/tools
 projects/VRDR.Tests/.config/dotnet-tools.json
+projects/VRDR.Tests/coveragereport/*
 
 
 # Visual Studio code coverage results

--- a/projects/BFDR.Messaging/BFDRBaseMessage.cs
+++ b/projects/BFDR.Messaging/BFDRBaseMessage.cs
@@ -29,6 +29,9 @@ namespace BFDR
             MessageBundle = messageBundle;
 
             // Validate bundle type is message
+            // TODO: This condition is unsatisfiable due to an identical condition in the base CommonMessage constructor.
+            // In this case, the CommonMessage constructor throws a System.ArgumentException. We may want to revisit these
+            // constructors in order to provide a more useful error message to the user.
             if (messageBundle?.Type != Bundle.BundleType.Message && !ignoreBundleType)
             {
                 String actualType = messageBundle?.Type == null ? "null" : messageBundle?.Type.ToString();

--- a/projects/BFDR.Messaging/BFDRBaseMessage.cs
+++ b/projects/BFDR.Messaging/BFDRBaseMessage.cs
@@ -94,7 +94,7 @@ namespace BFDR
         /// <param name="permissive">if the parser should be permissive when parsing the given string</param>
         /// <returns>The deserialized message object</returns>
         /// <exception cref="MessageParseException">Thrown when source does not represent the same or a subtype of the type parameter.</exception>
-        public static T Parse<T>(StreamReader source, bool permissive = false) where T: BFDRBaseMessage
+        public static T Parse<T>(StreamReader source, bool permissive = false) where T : BFDRBaseMessage
         {
             BFDRBaseMessage typedMessage = Parse(source, permissive);
             if (!typeof(T).IsInstanceOfType(typedMessage))
@@ -112,7 +112,7 @@ namespace BFDR
         /// <param name="bundle">A FHIR Bundle</param>
         /// <returns>The message object of the appropriate message type</returns>
         /// <exception cref="MessageParseException">Thrown when source does not represent the same or a subtype of the type parameter.</exception>
-        public static T Parse<T>(Bundle bundle) where T: BFDRBaseMessage
+        public static T Parse<T>(Bundle bundle) where T : BFDRBaseMessage
         {
             BFDRBaseMessage typedMessage = Parse(bundle);
             if (!typeof(T).IsInstanceOfType(typedMessage))
@@ -131,7 +131,7 @@ namespace BFDR
         /// <param name="permissive">if the parser should be permissive when parsing the given string</param>
         /// <returns>the deserialized message object</returns>
         /// <exception cref="MessageParseException">thrown when source does not represent the same or a subtype of the type parameter.</exception>
-        public static T Parse<T>(string source, bool permissive = false) where T: BFDRBaseMessage
+        public static T Parse<T>(string source, bool permissive = false) where T : BFDRBaseMessage
         {
             BFDRBaseMessage typedMessage = Parse(source, permissive);
             if (!typeof(T).IsInstanceOfType(typedMessage))
@@ -258,7 +258,7 @@ namespace BFDR
         /// <returns>The natality record inside the base message</returns>
         public static NatalityRecord GetNatalityRecordFromMessage(BFDRBaseMessage message)
         {
-                
+
             Type messageType = message.GetType();
 
             NatalityRecord nr = null;
@@ -266,41 +266,41 @@ namespace BFDR
             switch (messageType.Name)
             {
                 case "BirthRecordSubmissionMessage":
-                {
-                    var brsm = message as BirthRecordSubmissionMessage;
-                    nr = brsm?.BirthRecord;
-                    break;
-                }
+                    {
+                        var brsm = message as BirthRecordSubmissionMessage;
+                        nr = brsm?.BirthRecord;
+                        break;
+                    }
                 case "BirthRecordUpdateMessage":
-                {
-                    var brsm = message as BirthRecordUpdateMessage;
-                    nr = brsm?.BirthRecord;
-                    break;
-                }
+                    {
+                        var brsm = message as BirthRecordUpdateMessage;
+                        nr = brsm?.BirthRecord;
+                        break;
+                    }
                 case "BFDRParentalDemographicsCodingMessage":
-                {
-                    var brsm = message as BFDRParentalDemographicsCodingMessage;
-                    nr = brsm?.NatalityRecord;
-                    break;
-                }
+                    {
+                        var brsm = message as BFDRParentalDemographicsCodingMessage;
+                        nr = brsm?.NatalityRecord;
+                        break;
+                    }
                 case "BFDRParentalDemographicsCodingUpdateMessage":
-                {
-                    var brsm = message as BFDRParentalDemographicsCodingUpdateMessage;
-                    nr = brsm?.NatalityRecord;
-                    break;
-                }
+                    {
+                        var brsm = message as BFDRParentalDemographicsCodingUpdateMessage;
+                        nr = brsm?.NatalityRecord;
+                        break;
+                    }
                 case "FetalDeathRecordSubmissionMessage":
-                {
-                    var brsm = message as FetalDeathRecordSubmissionMessage;
-                    nr = brsm?.FetalDeathRecord;
-                    break;
-                }
+                    {
+                        var brsm = message as FetalDeathRecordSubmissionMessage;
+                        nr = brsm?.FetalDeathRecord;
+                        break;
+                    }
                 case "FetalDeathRecordUpdateMessage":
-                {
-                    var brsm = message as FetalDeathRecordUpdateMessage;
-                    nr = brsm?.FetalDeathRecord;
-                    break;
-                }
+                    {
+                        var brsm = message as FetalDeathRecordUpdateMessage;
+                        nr = brsm?.FetalDeathRecord;
+                        break;
+                    }
             }
 
             return nr;
@@ -330,7 +330,9 @@ namespace BFDR
         public BirthRecordErrorMessage CreateBirthRecordExtractionErrorMessage()
         {
             var message = new BirthRecordErrorMessage(sourceMessage);
-            message.Issues.Add(new Issue(OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Exception, this.Message));
+            List<BFDR.Issue> issues = message.Issues;
+            issues.Add(new Issue(OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Exception, this.Message));
+            message.Issues = issues;
             return message;
         }
 
@@ -340,7 +342,9 @@ namespace BFDR
         public FetalDeathRecordErrorMessage CreateFetalDeathRecordExtractionErrorMessage()
         {
             var message = new FetalDeathRecordErrorMessage(sourceMessage);
-            message.Issues.Add(new Issue(OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Exception, this.Message));
+            List<BFDR.Issue> issues = message.Issues;
+            issues.Add(new Issue(OperationOutcome.IssueSeverity.Error, OperationOutcome.IssueType.Exception, this.Message));
+            message.Issues = issues;
             return message;
         }
     }

--- a/projects/BFDR.Tests/BFDR.Tests.csproj
+++ b/projects/BFDR.Tests/BFDR.Tests.csproj
@@ -32,13 +32,24 @@
     <None Update="fixtures/json/RaceEthnicityCaseRecord.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/RaceEthnicityCaseRecord2.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/BirthRecordSubmissionMessage.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/BirthRecordSubmissionMessageNoBundle.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/BasicFetalDeathRecordSubmissionMessage.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/BasicFetalDeathRecordSubmissionMessageNoBundle.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/BirthRecordUpdateMessage.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/FetalDeathUpdateMessage.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/BirthRecordAcknowledgementMessage.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/FetalDeathAcknowledgementMessage.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/BirthRecordVoidMessage.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/BirthRecordVoidMessageWithoutBlockCount.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/FetalDeathVoidMessage.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/BirthRecordStatusMessage.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/BirthRecordErrorMessage.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/BirthRecordErrorMessageNoOperationOutcome.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/FetalDeathErrorMessage.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/BirthRecordDemographicsCodingMessage.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/BirthRecordDemographicsCodingMessageNoNatality.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/BirthRecordDemographicsCodingUpdateMessage.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/FetalDeathDemographicsCodingUpdateMessage.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/ije/BasicBirthRecord.ije" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/ije/UnknownParentBirthDates.ije" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/ije/ConnectathonFetalDeathRecord.ije" CopyToOutputDirectory="PreserveNewest" />
@@ -57,5 +68,12 @@
     <None Update="fixtures/json/BirthRecordIndustryAndOccupationCodedContent.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/FetalDeathIndustryAndOccupationCodedContent.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="fixtures/json/FetalDeathCodedRaceAndEthnicity.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/FetalDeathCodedCauseMessage.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/FetalDeathCodedCauseMessageNoBundle.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/FetalDeathCodedCauseUpdateMessage.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/FetalDeathRecordStatusMessage.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/InvalidMessage.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/MissingMessage.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="fixtures/json/HeadlessMessage.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/projects/BFDR.Tests/Messaging_Should.cs
+++ b/projects/BFDR.Tests/Messaging_Should.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using Xunit;
 using Hl7.Fhir.Model;
 using VR;
+using Hl7.Fhir.Utility;
+using System.Collections.Concurrent;
 
 namespace BFDR.Tests
 {
@@ -115,19 +117,63 @@ namespace BFDR.Tests
             Assert.Null(submission.PayloadVersionId);
         }
 
-        // TODO need example test message
-        // [Fact]
-        // public void LoadFetalDeathSubmissionFromJSON()
-        // {
-        //     FetalDeathRecordSubmissionMessage submission = BFDRBaseMessage.Parse<FetalDeathRecordSubmissionMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordSubmissionMessage.json"));
-        //     Assert.Equal("http://nchs.cdc.gov/fd_submission", submission.MessageType);
-        //     Assert.Equal("2019UT048858", submission.NCHSIdentifier);
-        //     Assert.Equal((uint)48858, submission.CertNo);
-        //     Assert.Equal((uint)2019, submission.EventYear);
-        //     Assert.Equal("000000000042", submission.StateAuxiliaryId);
-        //     Assert.Equal(submission.JurisdictionId, submission.FetalDeathRecord.GetLocationJurisdiction());
-        //     Assert.Equal(2019, submission.FetalDeathRecord.GetYear());
-        // }
+        [Fact]
+        public void LoadFetalDeathSubmissionFromJSON()
+        {
+            FetalDeathRecordSubmissionMessage submission = BFDRBaseMessage.Parse<FetalDeathRecordSubmissionMessage>(TestHelpers.FixtureStream("fixtures/json/BasicFetalDeathRecordSubmissionMessage.json"));
+            Assert.Equal("http://nchs.cdc.gov/fd_submission", submission.MessageType);
+            Assert.Equal("2025UT453723", submission.NCHSIdentifier);
+            Assert.Equal((uint)453723, submission.CertNo);
+            Assert.Equal((uint)2025, submission.EventYear);
+            Assert.Null(submission.StateAuxiliaryId);
+            Assert.Equal("MA", submission.FetalDeathRecord.EventLocationJurisdiction);
+            Assert.Equal(2025, submission.FetalDeathRecord.DeliveryYear);
+        }
+
+        [Fact]
+        public void BirthRecordSubmissionMissingBundle()
+        {
+            MessageParseException ex = Assert.Throws<MessageParseException>(() =>
+            {
+                BFDRBaseMessage.Parse<BirthRecordSubmissionMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordSubmissionMessageNoBundle.json"));
+            });
+            Assert.Contains("Error processing BirthRecord", ex.Message);
+        }
+
+        [Fact]
+        public void FetalDeathSubmissionMissingBundle()
+        {
+            MessageParseException ex = Assert.Throws<MessageParseException>(() =>
+            {
+                BFDRBaseMessage.Parse<FetalDeathRecordSubmissionMessage>(TestHelpers.FixtureStream("fixtures/json/BasicFetalDeathRecordSubmissionMessageNoBundle.json"));
+            });
+            Assert.Contains("Error processing FetalDeathRecord", ex.Message);
+        }
+
+        [Fact]
+        public void CreateTypedMessageFromBundle()
+        {
+            Bundle bundle = CommonMessage.ParseGenericBundle(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/BirthRecordSubmissionMessage.json")));
+            BirthRecordSubmissionMessage submission = BFDRBaseMessage.Parse<BirthRecordSubmissionMessage>(bundle);
+            Assert.Equal("http://nchs.cdc.gov/birth_submission", submission.MessageType);
+            Assert.Equal("2019UT048858", submission.NCHSIdentifier);
+            Assert.Equal((uint)48858, submission.CertNo);
+            Assert.Equal((uint)2019, submission.EventYear);
+            Assert.Equal("000000000042", submission.StateAuxiliaryId);
+            Assert.Equal(submission.JurisdictionId, submission.BirthRecord.EventLocationJurisdiction);
+            Assert.Equal(2019, submission.BirthRecord.BirthYear);
+            Assert.Null(submission.PayloadVersionId);
+        }
+
+        [Fact]
+        public void WrongTypedMessageFromBundle()
+        {
+            Bundle bundle = CommonMessage.ParseGenericBundle(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/BirthRecordSubmissionMessage.json")));
+            Assert.Throws<MessageParseException>(() =>
+            {
+                BFDRBaseMessage.Parse<FetalDeathRecordSubmissionMessage>(bundle);
+            });
+        }
 
         [Fact]
         public void CreateEmptyUpdate()
@@ -222,20 +268,20 @@ namespace BFDR.Tests
             Assert.Equal("48858", submission.BirthRecord.CertificateNumber);
         }
 
-        // TODO need test example
-        // [Fact]
-        // public void LoadUpdateFetalDeathFromJSON()
-        // {
-        //     FetalDeathRecordUpdateMessage submission = BFDRBaseMessage.Parse<FetalDeathRecordUpdateMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordUpdateMessage.json"));
-        //     Assert.Equal("http://nchs.cdc.gov/birth_submission_update", submission.MessageType);
-        //     Assert.Equal("2019UT048858", submission.NCHSIdentifier);
-        //     Assert.Equal((uint)48858, submission.CertNo);
-        //     Assert.Equal((uint)2019, submission.EventYear);
-        //     Assert.Equal("000000000042", submission.StateAuxiliaryId);
-        //     Assert.Equal(submission.JurisdictionId, submission.FetalDeathRecord.EventLocationJurisdiction);
-        //     Assert.Equal(2019, submission.FetalDeathRecord.BirthYear);
-        //     Assert.Equal("48858", submission.FetalDeathRecord.CertificateNumber);
-        // }
+
+        [Fact]
+        public void LoadUpdateFetalDeathFromJSON()
+        {
+            FetalDeathRecordUpdateMessage submission = BFDRBaseMessage.Parse<FetalDeathRecordUpdateMessage>(TestHelpers.FixtureStream("fixtures/json/FetalDeathUpdateMessage.json"));
+            Assert.Equal("http://nchs.cdc.gov/fd_submission_update", submission.MessageType);
+            Assert.Equal("2020NY087366", submission.NCHSIdentifier);
+            Assert.Equal((uint)87366, submission.CertNo);
+            Assert.Equal((uint)2020, submission.EventYear);
+            Assert.Equal("444455555", submission.StateAuxiliaryId);
+            Assert.Equal(submission.JurisdictionId, submission.FetalDeathRecord.EventLocationJurisdiction);
+            Assert.Equal(2020, submission.FetalDeathRecord.DeliveryYear);
+            Assert.Equal("87366", submission.FetalDeathRecord.CertificateNumber);
+        }
 
         [Fact]
         public void CreateMultipleDestinationsMessage()
@@ -254,8 +300,8 @@ namespace BFDR.Tests
             Assert.Equal("BFDR_STU2_0", submission.PayloadVersionId);
         }
 
-       [Fact]
-        public void CreateAckForMessage()
+        [Fact]
+        public void CreateAckForBirthMessage()
         {
             BirthRecordUpdateMessage submission = new BirthRecordUpdateMessage(record);
             BirthRecordAcknowledgementMessage ack = new BirthRecordAcknowledgementMessage(submission);
@@ -284,9 +330,9 @@ namespace BFDR.Tests
         }
 
         [Fact]
-        public void LoadAckFromJSON()
+        public void LoadBirthAckFromJSON()
         {
-            BirthRecordAcknowledgementMessage ack = BFDRBaseMessage.Parse<BirthRecordAcknowledgementMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordAcknowledgementMessage.json"));
+            BirthRecordAcknowledgementMessage ack = BFDRBaseMessage.Parse<BirthRecordAcknowledgementMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordAcknowledgementMessage.json"), true);
             Assert.Equal("http://nchs.cdc.gov/birth_acknowledgement", ack.MessageType);
             Assert.Equal("0df23820-f4ad-4a29-8862-a5effb85f1c5", ack.AckedMessageId);
             Assert.Equal("http://mitre.org/bfdr", ack.MessageDestination);
@@ -298,7 +344,70 @@ namespace BFDR.Tests
         }
 
         [Fact]
-        public void CreateBFDRVoidMessage()
+        public void LoadFetalDeathAckFromJSON()
+        {
+            FetalDeathRecordAcknowledgementMessage ack = BFDRBaseMessage.Parse<FetalDeathRecordAcknowledgementMessage>(TestHelpers.FixtureStream("fixtures/json/FetalDeathAcknowledgementMessage.json"));
+            Assert.Equal("http://nchs.cdc.gov/fd_acknowledgement", ack.MessageType);
+            Assert.Equal("cd9fa913-55f2-4dfd-940d-11e77344362a", ack.AckedMessageId);
+            Assert.Equal("http://nchs.cdc.gov/fd_submission", ack.MessageSource);
+            Assert.Equal("http://mitre.org/bfdr", ack.MessageDestination);
+            Assert.Equal("2022MA874232", ack.NCHSIdentifier);
+            Assert.Equal((uint)874232, ack.CertNo);
+            Assert.Equal((uint)2022, ack.EventYear);
+            Assert.Equal("abcdef20", ack.StateAuxiliaryId);
+            Assert.Equal("VRDRSTU2.2", ack.PayloadVersionId);
+        }
+
+        [Fact]
+        public void CreateBirthAckFromParams()
+        {
+            string messageId = Guid.NewGuid().ToString();
+            BirthRecordAcknowledgementMessage ack = new BirthRecordAcknowledgementMessage(messageId, "http://some.url.com/destination", "http://different.site.com/source");
+            Assert.Equal("http://nchs.cdc.gov/birth_acknowledgement", ack.MessageType);
+            Assert.Equal(messageId, ack.AckedMessageId);
+            Assert.Equal("http://different.site.com/source", ack.MessageSource);
+            Assert.Equal("http://some.url.com/destination", ack.MessageDestination);
+            Assert.Null(ack.StateAuxiliaryId);
+            Assert.Null(ack.CertNo);
+            Assert.Null(ack.NCHSIdentifier);
+        }
+
+        [Fact]
+        public void CreateFetalDeathAckFromParams()
+        {
+            string messageId = Guid.NewGuid().ToString();
+            FetalDeathRecordAcknowledgementMessage ack = new FetalDeathRecordAcknowledgementMessage(messageId, "http://some.url.com/destination", "http://different.site.com/source");
+            Assert.Equal("http://nchs.cdc.gov/fd_acknowledgement", ack.MessageType);
+            Assert.Equal(messageId, ack.AckedMessageId);
+            Assert.Equal("http://different.site.com/source", ack.MessageSource);
+            Assert.Equal("http://some.url.com/destination", ack.MessageDestination);
+            Assert.Null(ack.StateAuxiliaryId);
+            Assert.Null(ack.CertNo);
+            Assert.Null(ack.NCHSIdentifier);
+        }
+
+        [Fact]
+        public void SetAcknowledgementMessageFields()
+        {
+            string messageId = Guid.NewGuid().ToString();
+            BirthRecordAcknowledgementMessage ack = new BirthRecordAcknowledgementMessage(null);
+            Assert.Null(ack.AckedMessageId);
+            Assert.Null(ack.BlockCount);
+            ack.BlockCount = 0;
+            Assert.Null(ack.BlockCount);
+            ack.AckedMessageId = messageId;
+            ack.BlockCount = 4;
+            Assert.Equal(messageId, ack.AckedMessageId);
+            Assert.Equal((uint)4, ack.BlockCount);
+            ack.BlockCount = 0;
+            Assert.Null(ack.BlockCount);
+            ack.BlockCount = 3;
+            ack.BlockCount = null;
+            Assert.Null(ack.BlockCount);
+        }
+
+        [Fact]
+        public void CreateEmptyBirthVoidMessage()
         {
             BirthRecordVoidMessage message = new BirthRecordVoidMessage();
             Assert.Equal("http://nchs.cdc.gov/birth_submission_void", message.MessageType);
@@ -321,41 +430,128 @@ namespace BFDR.Tests
             message.BlockCount = 0;
             Assert.Equal((uint)0, message.BlockCount);
             Assert.Equal("BFDR_STU2_0", message.PayloadVersionId);
-            FetalDeathRecordVoidMessage message2 = new FetalDeathRecordVoidMessage();
-            Assert.Equal((uint)1, message2.BlockCount);
         }
 
-        // TODO confirm if Voids exist in BFDR
-        // [Fact]
-        // public void LoadBFDRVoidMessageFromJson()
-        // {
-        //     BFDRVoidMessage message = BFDRBaseMessage.Parse<BFDRVoidMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordVoidMessage.json"));
-        //     Assert.Equal("http://nchs.cdc.gov/bfdr_submission_void", message.MessageType);
-        //     Assert.Equal((uint)48858, message.CertNo);
-        //     Assert.Equal((uint)10, message.BlockCount);
-        //     Assert.Equal("000000000042", message.StateAuxiliaryId);
-        //     Assert.Equal("2019UT048858", message.NCHSIdentifier);
-        //     Assert.Equal("http://nchs.cdc.gov/bfdr_submission", message.MessageDestination);
-        //     Assert.Equal("http://mitre.org/bfdr", message.MessageSource);
-        // }
-
-        // [Fact]
-        // public void CreateAckForBFDRVoidMessage()
-        // {
-        //     BFDRVoidMessage voidMessage = BFDRBaseMessage.Parse<BFDRVoidMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordVoidMessage.json"));
-        //     BFDRAcknowledgementMessage ack = new BFDRAcknowledgementMessage(voidMessage);
-        //     Assert.Equal("http://nchs.cdc.gov/birth_acknowledgement", ack.MessageType);
-        //     Assert.Equal(voidMessage.MessageId, ack.AckedMessageId);
-        //     Assert.Equal(voidMessage.MessageSource, ack.MessageDestination);
-        //     Assert.Equal(voidMessage.MessageDestination, ack.MessageSource);
-        //     Assert.Equal(voidMessage.StateAuxiliaryId, ack.StateAuxiliaryId);
-        //     Assert.Equal(voidMessage.CertNo, ack.CertNo);
-        //     Assert.Equal(voidMessage.NCHSIdentifier, ack.NCHSIdentifier);
-        //     Assert.Equal(voidMessage.BlockCount, ack.BlockCount);
-        // }
+        [Fact]
+        public void CreateEmptyFetalDeathVoidMessage()
+        {
+            FetalDeathRecordVoidMessage message = new FetalDeathRecordVoidMessage();
+            Assert.Equal("http://nchs.cdc.gov/fd_submission_void", message.MessageType);
+            Assert.Null(message.CertNo);
+            message.CertNo = 11;
+            Assert.Equal((uint)11, message.CertNo);
+            Assert.Null(message.EventYear);
+            message.EventYear = 2021;
+            Assert.Equal((uint)2021, message.EventYear);
+            Assert.Null(message.JurisdictionId);
+            message.JurisdictionId = "MA";
+            Assert.Equal("MA", message.JurisdictionId);
+            Assert.Equal("2021MA000011", message.NCHSIdentifier);
+            Assert.Null(message.StateAuxiliaryId);
+            message.StateAuxiliaryId = "0000123";
+            Assert.Equal("0000123", message.StateAuxiliaryId);
+            Assert.Equal((uint)1, message.BlockCount);
+            message.BlockCount = 100;
+            Assert.Equal((uint)100, message.BlockCount);
+            message.BlockCount = 0;
+            Assert.Equal((uint)0, message.BlockCount);
+            Assert.Equal("BFDR_STU2_0", message.PayloadVersionId);
+        }
 
         [Fact]
-        public void CreateStatusMessage()
+        public void CreateVoidFromBirthRecord()
+        {
+            // Test with fixture record
+            BirthRecordVoidMessage message = new BirthRecordVoidMessage(record);
+            Assert.Equal("http://nchs.cdc.gov/birth_submission_void", message.MessageType);
+            Assert.Equal((uint)15075, message.CertNo);
+            Assert.Equal((uint)2019, message.EventYear);
+        }
+
+        [Fact]
+        public void CreateVoidFromFetalDeathRecord()
+        {
+            FetalDeathRecordVoidMessage message = new FetalDeathRecordVoidMessage(fetalDeathRecord);
+            Assert.Equal("http://nchs.cdc.gov/fd_submission_void", message.MessageType);
+            Assert.Equal((uint)87366, message.CertNo);
+            Assert.Equal((uint)2020, message.EventYear);
+        }
+
+        [Fact]
+        public void LoadBFDRVoidMessageFromJson()
+        {
+            BFDRVoidMessage message = BFDRBaseMessage.Parse<BFDRVoidMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordVoidMessage.json"));
+            Assert.Equal("http://nchs.cdc.gov/birth_submission_void", message.MessageType);
+            Assert.Equal((uint)48858, message.CertNo);
+            Assert.Equal((uint)10, message.BlockCount);
+            Assert.Equal("000000000042", message.StateAuxiliaryId);
+            Assert.Equal("2019UT048858", message.NCHSIdentifier);
+            Assert.Equal("http://nchs.cdc.gov/bfdr_submission", message.MessageDestination);
+            Assert.Equal("http://mitre.org/bfdr", message.MessageSource);
+        }
+
+        [Fact]
+        public void LoadFetalDeathVoidMessageFromJson()
+        {
+            BFDRVoidMessage message = BFDRBaseMessage.Parse<BFDRVoidMessage>(TestHelpers.FixtureStream("fixtures/json/FetalDeathVoidMessage.json"));
+            Assert.Equal("http://nchs.cdc.gov/fd_submission_void", message.MessageType);
+            Assert.Equal((uint)63214, message.CertNo);
+            Assert.Equal((uint)8, message.BlockCount);
+            Assert.Equal("abc00020", message.StateAuxiliaryId);
+            Assert.Equal("2022MA063214", message.NCHSIdentifier);
+            Assert.Equal("http://nchs.cdc.gov/bfdr_submission", message.MessageDestination);
+            Assert.Equal("http://mitre.org/bfdr", message.MessageSource);
+        }
+
+        [Fact]
+        public void LoadBFDRVoidMessageWithoutBlockCount()
+        {
+            BFDRVoidMessage message = BFDRBaseMessage.Parse<BFDRVoidMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordVoidMessageWithoutBlockCount.json"));
+            Assert.Equal("http://nchs.cdc.gov/birth_submission_void", message.MessageType);
+            Assert.Equal((uint)48858, message.CertNo);
+            Assert.Equal((uint)1, message.BlockCount);
+            Assert.Equal("000000000042", message.StateAuxiliaryId);
+            Assert.Equal("2019UT048858", message.NCHSIdentifier);
+            Assert.Equal("http://nchs.cdc.gov/bfdr_submission", message.MessageDestination);
+            Assert.Equal("http://mitre.org/bfdr", message.MessageSource);
+        }
+
+        [Fact]
+        public void CreateAckForBFDRVoidMessage()
+        {
+            BFDRVoidMessage voidMessage = BFDRBaseMessage.Parse<BFDRVoidMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordVoidMessage.json"));
+            BirthRecordAcknowledgementMessage ack = new BirthRecordAcknowledgementMessage(voidMessage);
+            Assert.Equal("http://nchs.cdc.gov/birth_acknowledgement", ack.MessageType);
+            Assert.Equal(voidMessage.MessageId, ack.AckedMessageId);
+            Assert.Equal(voidMessage.MessageSource, ack.MessageDestination);
+            Assert.Equal(voidMessage.MessageDestination, ack.MessageSource);
+            Assert.Equal(voidMessage.StateAuxiliaryId, ack.StateAuxiliaryId);
+            Assert.Equal(voidMessage.CertNo, ack.CertNo);
+            Assert.Equal(voidMessage.NCHSIdentifier, ack.NCHSIdentifier);
+            Assert.Equal(voidMessage.BlockCount, ack.BlockCount);
+        }
+
+        [Fact]
+        public void CreateEmptyBirthRecordStatusMessage()
+        {
+            BirthRecordStatusMessage status = new BirthRecordStatusMessage();
+            Assert.Equal("http://nchs.cdc.gov/birth_status", status.MessageType);
+            Assert.Null(status.Status);
+            Assert.Null(status.StatusedMessageId);
+            Assert.Equal("http://nchs.cdc.gov/bfdr_submission", status.MessageDestination); // http://nchs.cdc.gov/bfdr_submission
+            Assert.Null(status.MessageSource);
+            Assert.Null(status.StateAuxiliaryId);
+            Assert.Null(status.CertNo);
+            Assert.Null(status.NCHSIdentifier);
+            Assert.Equal("BFDR_STU2_0", status.PayloadVersionId);
+            string differentMessageId = Guid.NewGuid().ToString();
+            status.StatusedMessageId = differentMessageId;
+            Assert.Equal(differentMessageId, status.StatusedMessageId);
+
+        }
+
+        [Fact]
+        public void CreateBirthRecordStatusMessage()
         {
             BirthRecordSubmissionMessage submission = new BirthRecordSubmissionMessage(record);
             BirthRecordStatusMessage status = new BirthRecordStatusMessage(submission, "manualDemographicCoding");
@@ -372,7 +568,23 @@ namespace BFDR.Tests
         }
 
         [Fact]
-        public void CreateAckForStatusMessage()
+        public void CreateBirthRecordStatusMessageFromParams()
+        {
+            string messageId = Guid.NewGuid().ToString();
+            BirthRecordStatusMessage status = new BirthRecordStatusMessage(messageId, "http://some.url.com/destination", "manualDemographicCoding", "http://different.website.com/source");
+            Assert.Equal("http://nchs.cdc.gov/birth_status", status.MessageType);
+            Assert.Equal("manualDemographicCoding", status.Status);
+            Assert.Equal(messageId, status.StatusedMessageId);
+            Assert.Equal("http://some.url.com/destination", status.MessageDestination);
+            Assert.Equal("http://different.website.com/source", status.MessageSource);
+            Assert.Null(status.StateAuxiliaryId);
+            Assert.Null(status.CertNo);
+            Assert.Null(status.NCHSIdentifier);
+            Assert.Equal("BFDR_STU2_0", status.PayloadVersionId);
+        }
+
+        [Fact]
+        public void CreateAckForBirthRecordStatusMessage()
         {
             BirthRecordStatusMessage statusMessage = BFDRBaseMessage.Parse<BirthRecordStatusMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordStatusMessage.json"));
             BirthRecordAcknowledgementMessage ack = new BirthRecordAcknowledgementMessage(statusMessage);
@@ -388,7 +600,7 @@ namespace BFDR.Tests
         }
 
         [Fact]
-        public void CreateExtractionErrorForMessage()
+        public void CreateBirthExtractionErrorForMessage()
         {
             BirthRecordSubmissionMessage submission = BFDRBaseMessage.Parse<BirthRecordSubmissionMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordSubmissionMessage.json"));
             BirthRecordErrorMessage err = new BirthRecordErrorMessage(submission);
@@ -415,10 +627,45 @@ namespace BFDR.Tests
             Assert.Equal(OperationOutcome.IssueSeverity.Warning, issues[1].Severity);
             Assert.Equal(OperationOutcome.IssueType.Expired, issues[1].Type);
             Assert.Equal("The message was very old", issues[1].Description);
+            string differentMessageId = Guid.NewGuid().ToString();
+            err.FailedMessageId = differentMessageId;
+            Assert.Equal(differentMessageId, err.FailedMessageId);
         }
 
         [Fact]
-        public void LoadExtractionErrorFromJson()
+        public void CreateFetalDeathExtractionErrorForMessage()
+        {
+            FetalDeathRecordSubmissionMessage submission = BFDRBaseMessage.Parse<FetalDeathRecordSubmissionMessage>(TestHelpers.FixtureStream("fixtures/json/BasicFetalDeathRecordSubmissionMessage.json"));
+            FetalDeathRecordErrorMessage err = new FetalDeathRecordErrorMessage(submission);
+            Assert.Equal("http://nchs.cdc.gov/fd_extraction_error", err.MessageType);
+            Assert.Equal(submission.MessageId, err.FailedMessageId);
+            Assert.Equal(submission.MessageSource, err.MessageDestination);
+            Assert.Equal(submission.StateAuxiliaryId, err.StateAuxiliaryId);
+            Assert.Equal(submission.CertNo, err.CertNo);
+            Assert.Equal(submission.NCHSIdentifier, err.NCHSIdentifier);
+            Assert.Equal("BFDR_STU2_0", err.PayloadVersionId);
+            Assert.Empty(err.Issues);
+            var issues = new List<Issue>();
+            var issue = new Issue(OperationOutcome.IssueSeverity.Fatal, OperationOutcome.IssueType.Invalid, "The message was invalid");
+            issues.Add(issue);
+            issue = new Issue(OperationOutcome.IssueSeverity.Warning, OperationOutcome.IssueType.Expired, "The message was very old");
+            issues.Add(issue);
+            err.Issues = issues;
+            issues = err.Issues;
+            Assert.Equal(2, (int)issues.Count);
+            Assert.Equal(OperationOutcome.IssueSeverity.Fatal, issues[0].Severity);
+            Assert.Equal(OperationOutcome.IssueType.Invalid, issues[0].Type);
+            Assert.Equal("The message was invalid", issues[0].Description);
+            Assert.Equal(OperationOutcome.IssueSeverity.Warning, issues[1].Severity);
+            Assert.Equal(OperationOutcome.IssueType.Expired, issues[1].Type);
+            Assert.Equal("The message was very old", issues[1].Description);
+            string differentMessageId = Guid.NewGuid().ToString();
+            err.FailedMessageId = differentMessageId;
+            Assert.Equal(differentMessageId, err.FailedMessageId);
+        }
+
+        [Fact]
+        public void LoadBirthExtractionErrorFromJson()
         {
             BirthRecordErrorMessage err = BFDRBaseMessage.Parse<BirthRecordErrorMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordErrorMessage.json"));
             Assert.Equal("http://nchs.cdc.gov/birth_extraction_error", err.MessageType);
@@ -436,9 +683,126 @@ namespace BFDR.Tests
             Assert.Equal("The message was very old", issues[1].Description);
         }
 
-        // TODO: Once we have a real implementation of a demographic coding message implement real tests as well
         [Fact]
-        public void CreateDemographicForMessage()
+        public void LoadFetalDeathExtractionErrorFromJson()
+        {
+            FetalDeathRecordErrorMessage err = BFDRBaseMessage.Parse<FetalDeathRecordErrorMessage>(TestHelpers.FixtureStream("fixtures/json/FetalDeathErrorMessage.json"));
+            Assert.Equal("http://nchs.cdc.gov/fd_extraction_error", err.MessageType);
+            Assert.Equal((uint)874343, err.CertNo);
+            Assert.Equal("abcdef20", err.StateAuxiliaryId);
+            Assert.Equal("2022MA874343", err.NCHSIdentifier);
+            Assert.Equal("VRDRSTU2.2", err.PayloadVersionId);
+            var issues = err.Issues;
+            Assert.Single(issues);
+            Assert.Equal(OperationOutcome.IssueSeverity.Error, issues[0].Severity);
+            Assert.Equal(OperationOutcome.IssueType.Required, issues[0].Type);
+            Assert.Equal("something was not correct.", issues[0].Description);
+        }
+
+        [Fact]
+        public void BirthExtractionErrorMissingOperationOutcome()
+        {
+            MessageParseException ex = Assert.Throws<MessageParseException>(() =>
+            {
+                BFDRBaseMessage.Parse<BirthRecordErrorMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordErrorMessageNoOperationOutcome.json"));
+            });
+            Assert.Contains("Error processing OperationOutcome", ex.Message);
+        }
+
+        [Fact]
+        public void CreateBirthExtractionErrorFromParams()
+        {
+            string messageId = Guid.NewGuid().ToString();
+            BirthRecordErrorMessage err = new BirthRecordErrorMessage(messageId, "http://different.site.com/source", "http://different.site.com/source");
+            Assert.Equal("http://nchs.cdc.gov/birth_extraction_error", err.MessageType);
+            Assert.Equal(messageId, err.FailedMessageId);
+            Assert.Null(err.CertNo);
+            Assert.Null(err.StateAuxiliaryId);
+            Assert.Null(err.NCHSIdentifier);
+            Assert.Equal("BFDR_STU2_0", err.PayloadVersionId);
+            Assert.Empty(err.Issues);
+        }
+
+        [Fact]
+        public void CreateFetalDeathExtractionErrorFromParams()
+        {
+            string messageId = Guid.NewGuid().ToString();
+            FetalDeathRecordErrorMessage err = new FetalDeathRecordErrorMessage(messageId, "http://different.site.com/source", "http://different.site.com/source");
+            Assert.Equal("http://nchs.cdc.gov/fd_extraction_error", err.MessageType);
+            Assert.Equal(messageId, err.FailedMessageId);
+            Assert.Null(err.CertNo);
+            Assert.Null(err.StateAuxiliaryId);
+            Assert.Null(err.NCHSIdentifier);
+            Assert.Equal("BFDR_STU2_0", err.PayloadVersionId);
+            Assert.Empty(err.Issues);
+        }
+
+        [Fact]
+        public void CreateEmptyFetalDeathStatusMessage()
+        {
+            FetalDeathRecordStatusMessage status = new FetalDeathRecordStatusMessage();
+            Assert.Equal("http://nchs.cdc.gov/fd_status", status.MessageType);
+            Assert.Null(status.Status);
+            Assert.Null(status.StatusedMessageId);
+            Assert.Equal("http://nchs.cdc.gov/bfdr_submission", status.MessageDestination); // http://nchs.cdc.gov/bfdr_submission
+            Assert.Null(status.MessageSource);
+            Assert.Null(status.StateAuxiliaryId);
+            Assert.Null(status.CertNo);
+            Assert.Null(status.NCHSIdentifier);
+            Assert.Equal("BFDR_STU2_0", status.PayloadVersionId);
+        }
+
+        [Fact]
+        public void CreateFetalDeathStatusMessage()
+        {
+            FetalDeathRecordSubmissionMessage submission = new FetalDeathRecordSubmissionMessage(fetalDeathRecord);
+            FetalDeathRecordStatusMessage status = new FetalDeathRecordStatusMessage(submission, "manualCauseOfDeathCoding");
+            Assert.Equal("http://nchs.cdc.gov/fd_status", status.MessageType);
+            Assert.Equal("manualCauseOfDeathCoding", status.Status);
+            Assert.Equal(submission.MessageId, status.StatusedMessageId);
+            Assert.Equal(submission.MessageSource, status.MessageDestination);
+            Assert.Equal(submission.MessageDestination, status.MessageSource);
+            Assert.Equal(submission.StateAuxiliaryId, status.StateAuxiliaryId);
+            Assert.Equal(submission.CertNo, status.CertNo);
+            Assert.Equal(submission.NCHSIdentifier, status.NCHSIdentifier);
+            Assert.Equal(submission.PayloadVersionId, status.PayloadVersionId);
+            Assert.Equal("BFDR_STU2_0", status.PayloadVersionId);
+        }
+
+        [Fact]
+        public void CreateFetalDeathStatusMessageFromParams()
+        {
+            string messageId = Guid.NewGuid().ToString();
+            FetalDeathRecordStatusMessage status = new FetalDeathRecordStatusMessage(messageId, "http://some.url.com/destination", "manualCauseOfDeathCoding", "http://different.website.com/source");
+            Assert.Equal("http://nchs.cdc.gov/fd_status", status.MessageType);
+            Assert.Equal("manualCauseOfDeathCoding", status.Status);
+            Assert.Equal(messageId, status.StatusedMessageId);
+            Assert.Equal("http://some.url.com/destination", status.MessageDestination);
+            Assert.Equal("http://different.website.com/source", status.MessageSource);
+            Assert.Null(status.StateAuxiliaryId);
+            Assert.Null(status.CertNo);
+            Assert.Null(status.NCHSIdentifier);
+            Assert.Equal("BFDR_STU2_0", status.PayloadVersionId);
+        }
+
+        [Fact]
+        public void CreateAckForFetalDeathStatusMessage()
+        {
+            FetalDeathRecordStatusMessage statusMessage = BFDRBaseMessage.Parse<FetalDeathRecordStatusMessage>(TestHelpers.FixtureStream("fixtures/json/FetalDeathRecordStatusMessage.json"));
+            FetalDeathRecordAcknowledgementMessage ack = new FetalDeathRecordAcknowledgementMessage(statusMessage);
+            Assert.Equal("http://nchs.cdc.gov/fd_acknowledgement", ack.MessageType);
+            Assert.Equal(statusMessage.MessageId, ack.AckedMessageId);
+            Assert.Equal(statusMessage.MessageSource, ack.MessageDestination);
+            Assert.Equal(statusMessage.MessageDestination, ack.MessageSource);
+            Assert.Equal(statusMessage.StateAuxiliaryId, ack.StateAuxiliaryId);
+            Assert.Equal(statusMessage.CertNo, ack.CertNo);
+            Assert.Equal(statusMessage.NCHSIdentifier, ack.NCHSIdentifier);
+            Assert.Null(statusMessage.PayloadVersionId);
+            Assert.Equal("BFDR_STU2_0", ack.PayloadVersionId);
+        }
+
+        [Fact]
+        public void CreateBirthRecordParentalDemographicFromSubmissionMessage()
         {
             BirthRecordSubmissionMessage submission = BFDRBaseMessage.Parse<BirthRecordSubmissionMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordSubmissionMessage.json"));
             BirthRecordParentalDemographicsCodingMessage coding = new BirthRecordParentalDemographicsCodingMessage(submission);
@@ -454,7 +818,34 @@ namespace BFDR.Tests
         }
 
         [Fact]
-        public void CreateDemographicCodingResponseFromJSON()
+        public void ModifyCodedMessageIdForBirthRecordParentalDemographicsCodingMessage()
+        {
+            BirthRecordSubmissionMessage submission = BFDRBaseMessage.Parse<BirthRecordSubmissionMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordSubmissionMessage.json"));
+            BirthRecordParentalDemographicsCodingMessage coding = new BirthRecordParentalDemographicsCodingMessage(submission);
+            Assert.Equal(submission.MessageId, coding.CodedMessageId);
+            string differentMessageId = Guid.NewGuid().ToString();
+            coding.CodedMessageId = differentMessageId;
+            Assert.Equal(differentMessageId, coding.CodedMessageId);
+        }
+
+        [Fact]
+        public void CreateFetalDeathParentalDemographicFromSubmissionMessage()
+        {
+            FetalDeathRecordSubmissionMessage submission = BFDRBaseMessage.Parse<FetalDeathRecordSubmissionMessage>(TestHelpers.FixtureStream("fixtures/json/BasicFetalDeathRecordSubmissionMessage.json"));
+            FetalDeathRecordParentalDemographicsCodingMessage coding = new FetalDeathRecordParentalDemographicsCodingMessage(submission);
+            Assert.Equal("http://nchs.cdc.gov/fd_demographics_coding", coding.MessageType);
+            Assert.Equal(submission.MessageId, coding.CodedMessageId);
+            Assert.Equal(submission.MessageSource, coding.MessageDestination);
+            Assert.Equal(submission.MessageDestination, coding.MessageSource);
+            Assert.Equal(submission.StateAuxiliaryId, coding.StateAuxiliaryId);
+            Assert.Equal(submission.CertNo, coding.CertNo);
+            Assert.Equal(submission.NCHSIdentifier, coding.NCHSIdentifier);
+            Assert.Equal("BFDR_STU2_0", submission.PayloadVersionId);
+            Assert.Equal("BFDR_STU2_0", coding.PayloadVersionId);
+        }
+
+        [Fact]
+        public void CreateParentalDemographicCodingResponseFromJSON()
         {
             BirthRecordParentalDemographicsCodingMessage message = BFDRBaseMessage.Parse<BirthRecordParentalDemographicsCodingMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordDemographicsCodingMessage.json"));
             Assert.Equal(BirthRecordParentalDemographicsCodingMessage.MESSAGE_TYPE, message.MessageType);
@@ -468,7 +859,7 @@ namespace BFDR.Tests
         }
 
         [Fact]
-        public void CreateDemographicsCodingUpdateFromJSON()
+        public void CreateBirthRecordParentalDemographicsCodingUpdateFromJSON()
         {
             BirthRecordParentalDemographicsCodingUpdateMessage message = BFDRBaseMessage.Parse<BirthRecordParentalDemographicsCodingUpdateMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordDemographicsCodingUpdateMessage.json"));
             Assert.Equal(BirthRecordParentalDemographicsCodingUpdateMessage.MESSAGE_TYPE, message.MessageType);
@@ -481,8 +872,22 @@ namespace BFDR.Tests
             // TODO: Check demographic coding fields once implemented
         }
 
-       [Fact]
-        public void CreateDemographicCodingResponse()
+        [Fact]
+        public void CreateFetalDeathParentalDemographicsCodingUpdateFromJSON()
+        {
+            FetalDeathRecordParentalDemographicsCodingUpdateMessage message = BFDRBaseMessage.Parse<FetalDeathRecordParentalDemographicsCodingUpdateMessage>(TestHelpers.FixtureStream("fixtures/json/FetalDeathDemographicsCodingUpdateMessage.json"));
+            Assert.Equal("http://nchs.cdc.gov/fd_demographics_coding_update", message.MessageType);
+            Assert.Equal("http://nchs.cdc.gov/bfdr_submission", message.MessageSource);
+            Assert.Equal("https://example.com/jurisdiction/message/endpoint", message.MessageDestination);
+            Assert.Equal((uint)55123, message.CertNo);
+            Assert.Equal((uint)2022, message.EventYear);
+            Assert.Equal("abcdef20", message.StateAuxiliaryId);
+            Assert.Equal("2022MA055123", message.NCHSIdentifier);
+            Assert.Equal("VRDRSTU2.2", message.PayloadVersionId);
+        }
+
+        [Fact]
+        public void CreateParentalDemographicCodingResponse()
         {
             // This test creates a response using the approach NCHS will use via IJE setters
             IJEBirth ije = new IJEBirth();
@@ -504,71 +909,103 @@ namespace BFDR.Tests
         }
 
         [Fact]
-        public void CreateDemographicCodingResponseForBirthJson()
+        public void CreateParentalDemographicCodingResponseForBirthJson()
         {
-                // create an IJE birth message, convert it to FHIR, round trip the FHIR to json and back to make sure the bundles are all added to the json correctly
-                IJEBirth ijeb = new IJEBirth();
-                ijeb.MRACE1E = "199";
-                ijeb.MRACE2E = "";
-                ijeb.MRACE3E = "";
-                ijeb.MRACE4E = "";
-                ijeb.MRACE5E = "";
-                ijeb.MRACE6E = "";
-                ijeb.MRACE7E = "";
-                ijeb.MRACE8E = "";
+            // create an IJE birth message, convert it to FHIR, round trip the FHIR to json and back to make sure the bundles are all added to the json correctly
+            IJEBirth ijeb = new IJEBirth();
+            ijeb.MRACE1E = "199";
+            ijeb.MRACE2E = "";
+            ijeb.MRACE3E = "";
+            ijeb.MRACE4E = "";
+            ijeb.MRACE5E = "";
+            ijeb.MRACE6E = "";
+            ijeb.MRACE7E = "";
+            ijeb.MRACE8E = "";
 
-                ijeb.METHNIC1 = "N";
-                ijeb.METHNIC2 = "N";                
-                ijeb.METHNIC3 = "N";
-                ijeb.METHNIC4 = "N";
-                ijeb.METHNIC5 = "";
-                ijeb.METHNICE = "100";
-                ijeb.METHNIC5C = "";
+            ijeb.METHNIC1 = "N";
+            ijeb.METHNIC2 = "N";
+            ijeb.METHNIC3 = "N";
+            ijeb.METHNIC4 = "N";
+            ijeb.METHNIC5 = "";
+            ijeb.METHNICE = "100";
+            ijeb.METHNIC5C = "";
 
-                BirthRecord br = ijeb.ToRecord();
-                BirthRecordParentalDemographicsCodingMessage msg = new BirthRecordParentalDemographicsCodingMessage(br);
-                String msgJson = msg.ToJson();
-                // parse the json and make sure the bundles are present
-                BirthRecordParentalDemographicsCodingMessage message = BFDRBaseMessage.Parse<BirthRecordParentalDemographicsCodingMessage>(msgJson);
-                NatalityRecord br2 = message.NatalityRecord;
-                Assert.Equal("100", br2.MotherEthnicityEditedCodeHelper);
-                Assert.Equal("199", br2.MotherRaceTabulation1EHelper);
+            BirthRecord br = ijeb.ToRecord();
+            BirthRecordParentalDemographicsCodingMessage msg = new BirthRecordParentalDemographicsCodingMessage(br);
+            String msgJson = msg.ToJson();
+            // parse the json and make sure the bundles are present
+            BirthRecordParentalDemographicsCodingMessage message = BFDRBaseMessage.Parse<BirthRecordParentalDemographicsCodingMessage>(msgJson);
+            NatalityRecord br2 = message.NatalityRecord;
+            Assert.Equal("100", br2.MotherEthnicityEditedCodeHelper);
+            Assert.Equal("199", br2.MotherRaceTabulation1EHelper);
         }
 
         [Fact]
-        public void CreateDemographicCodingResponseForFetalDeathJson()
+        public void CreateParentalDemographicCodingResponseForFetalDeathJson()
         {
-                // create an IJE birth message, convert it to FHIR, round trip the FHIR to json and back to make sure the bundles are all added to the json correctly
-                IJEFetalDeath ijefd = new IJEFetalDeath();
-                ijefd.MRACE1E = "199";
-                ijefd.MRACE2E = "";
-                ijefd.MRACE3E = "";
-                ijefd.MRACE4E = "";
-                ijefd.MRACE5E = "";
-                ijefd.MRACE6E = "";
-                ijefd.MRACE7E = "";
-                ijefd.MRACE8E = "";
+            // create an IJE birth message, convert it to FHIR, round trip the FHIR to json and back to make sure the bundles are all added to the json correctly
+            IJEFetalDeath ijefd = new IJEFetalDeath();
+            ijefd.MRACE1E = "199";
+            ijefd.MRACE2E = "";
+            ijefd.MRACE3E = "";
+            ijefd.MRACE4E = "";
+            ijefd.MRACE5E = "";
+            ijefd.MRACE6E = "";
+            ijefd.MRACE7E = "";
+            ijefd.MRACE8E = "";
 
-                ijefd.METHNIC1 = "N";
-                ijefd.METHNIC2 = "N";                
-                ijefd.METHNIC3 = "N";
-                ijefd.METHNIC4 = "N";
-                ijefd.METHNIC5 = "";
-                ijefd.METHNICE = "100";
-                ijefd.METHNIC5C = "";
+            ijefd.METHNIC1 = "N";
+            ijefd.METHNIC2 = "N";
+            ijefd.METHNIC3 = "N";
+            ijefd.METHNIC4 = "N";
+            ijefd.METHNIC5 = "";
+            ijefd.METHNICE = "100";
+            ijefd.METHNIC5C = "";
 
-                FetalDeathRecord fdr = ijefd.ToRecord();
-                FetalDeathRecordParentalDemographicsCodingMessage msg = new FetalDeathRecordParentalDemographicsCodingMessage(fdr);
-                String msgJson = msg.ToJson();
-                // parse the json and make sure the bundles are present
-                FetalDeathRecordParentalDemographicsCodingMessage message = BFDRBaseMessage.Parse<FetalDeathRecordParentalDemographicsCodingMessage>(msgJson);
-                NatalityRecord fdr2 = message.NatalityRecord;
-                Assert.Equal("100", fdr2.MotherEthnicityEditedCodeHelper);
-                Assert.Equal("199", fdr2.MotherRaceTabulation1EHelper);
+            FetalDeathRecord fdr = ijefd.ToRecord();
+            FetalDeathRecordParentalDemographicsCodingMessage msg = new FetalDeathRecordParentalDemographicsCodingMessage(fdr);
+            String msgJson = msg.ToJson();
+            // parse the json and make sure the bundles are present
+            FetalDeathRecordParentalDemographicsCodingMessage message = BFDRBaseMessage.Parse<FetalDeathRecordParentalDemographicsCodingMessage>(msgJson);
+            NatalityRecord fdr2 = message.NatalityRecord;
+            Assert.Equal("100", fdr2.MotherEthnicityEditedCodeHelper);
+            Assert.Equal("199", fdr2.MotherRaceTabulation1EHelper);
         }
 
         [Fact]
-        public void CreateDemographicCodingUpdate()
+        public void ParentalDemographicsCodingMessageWithoutNatalityRecord()
+        {
+            MessageParseException ex = Assert.Throws<MessageParseException>(() =>
+            {
+                BFDRBaseMessage.Parse<BirthRecordParentalDemographicsCodingMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordDemographicsCodingMessageNoNatality.json"));
+            });
+            Assert.Contains("Error processing entry as BirthRecord or FetalDeathRecord", ex.Message);
+        }
+
+        [Fact]
+        public void CreateBirthRecordParentalDemographicMessageFromParams()
+        {
+            string messageId = Guid.NewGuid().ToString();
+            BirthRecordParentalDemographicsCodingMessage message = new BirthRecordParentalDemographicsCodingMessage(messageId, "https://example.org/jurisdiction/endpoint", "manualDemographicCoding", "http://nchs.cdc.gov/bfdr_submission");
+            Assert.Equal("http://nchs.cdc.gov/birth_demographics_coding", message.MessageType);
+            Assert.Equal("http://nchs.cdc.gov/bfdr_submission", message.MessageSource);
+            Assert.Equal("https://example.org/jurisdiction/endpoint", message.MessageDestination);
+            Assert.Equal(messageId, message.CodedMessageId);
+        }
+
+        [Fact]
+        public void CreateFetalDeathParentalDemographicMessageFromParams()
+        {
+            string messageId = Guid.NewGuid().ToString();
+            FetalDeathRecordParentalDemographicsCodingMessage message = new FetalDeathRecordParentalDemographicsCodingMessage(messageId, "https://example.org/jurisdiction/endpoint", "manualDemographicCoding", "http://nchs.cdc.gov/bfdr_submission");
+            Assert.Equal("http://nchs.cdc.gov/fd_demographics_coding", message.MessageType);
+            Assert.Equal("http://nchs.cdc.gov/bfdr_submission", message.MessageSource);
+            Assert.Equal("https://example.org/jurisdiction/endpoint", message.MessageDestination);
+            Assert.Equal(messageId, message.CodedMessageId);
+        }
+
+        [Fact]
+        public void CreateBirthRecordDemographicCodingUpdate()
         {
             // This test creates a response using the approach NCHS will use via IJE setters
             IJEBirth ije = new IJEBirth();
@@ -590,19 +1027,202 @@ namespace BFDR.Tests
         }
 
         [Fact]
+        public void CreateFetalDeathDemographicCodingUpdate()
+        {
+            IJEFetalDeath ije = new IJEFetalDeath();
+            ije.FDOD_YR = "2022";
+            ije.DSTATE = "TX";
+            ije.FILENO = "234";
+            FetalDeathRecordParentalDemographicsCodingUpdateMessage message = new FetalDeathRecordParentalDemographicsCodingUpdateMessage(ije.ToRecord());
+            message.MessageSource = "http://nchs.cdc.gov/bfdr_demographics_coding_update";
+            message.MessageDestination = "https://example.org/jurisdiction/endpoint";
+            Assert.Equal(FetalDeathRecordParentalDemographicsCodingUpdateMessage.MESSAGE_TYPE, message.MessageType);
+            Assert.Equal("http://nchs.cdc.gov/bfdr_demographics_coding_update", message.MessageSource);
+            Assert.Equal("https://example.org/jurisdiction/endpoint", message.MessageDestination);
+            Assert.Equal((uint)234, message.CertNo);
+            Assert.Equal((uint)2022, message.EventYear);
+            Assert.Equal("2022TX000234", message.NCHSIdentifier);
+            Assert.Equal("BFDR_STU2_0", message.PayloadVersionId);
+        }
+
+        [Fact]
+        public void CreateEmptyCodedCauseOfFetalDeathMessage()
+        {
+            CodedCauseOfFetalDeathMessage message = new CodedCauseOfFetalDeathMessage();
+            Assert.Equal("http://nchs.cdc.gov/fd_causeofdeath_coding", message.MessageType);
+            Assert.Null(message.FetalDeathRecord);
+            Assert.Equal("http://nchs.cdc.gov/bfdr_submission", message.MessageDestination);
+            Assert.Null(message.MessageSource);
+            Assert.NotNull(message.MessageTimestamp);
+            Assert.NotNull(message.MessageId);
+            Assert.Null(message.CertNo);
+            Assert.Null(message.StateAuxiliaryId);
+            Assert.Null(message.NCHSIdentifier);
+            Assert.Equal("BFDR_STU2_0", message.PayloadVersionId);
+        }
+
+        [Fact]
+        public void CreateCodedCauseOfFetalDeathMessageFromFetalDeathRecord()
+        {
+            CodedCauseOfFetalDeathMessage message = new CodedCauseOfFetalDeathMessage(fetalDeathRecord);
+            Assert.NotNull(message.FetalDeathRecord);
+            Assert.Equal("http://nchs.cdc.gov/fd_causeofdeath_coding", message.MessageType);
+            Assert.Equal((uint)87366, message.CertNo);
+            Assert.Equal((uint)2020, message.EventYear);
+            Assert.Equal("444455555", message.StateAuxiliaryId);
+            Assert.Equal("NY", message.JurisdictionId);
+            Assert.Equal("2020NY087366", message.NCHSIdentifier);
+            Assert.Equal((uint)2020, message.FetalDeathRecord.GetYear());
+            Assert.Equal("87366", message.FetalDeathRecord.CertificateNumber);
+        }
+
+        [Fact]
+        public void LoadCodedCauseOfFetalDeathMessageFromJson()
+        {
+            CodedCauseOfFetalDeathMessage message = BFDRBaseMessage.Parse<CodedCauseOfFetalDeathMessage>(TestHelpers.FixtureStream("fixtures/json/FetalDeathCodedCauseMessage.json"));
+            Assert.Equal("http://nchs.cdc.gov/fd_causeofdeath_coding", message.MessageType);
+            Assert.Equal((uint)874232, message.CertNo);
+            Assert.Equal("abcdef20", message.StateAuxiliaryId);
+            Assert.Equal("2022MA874232", message.NCHSIdentifier);
+            Assert.Equal("https://example.com/jurisdiction/message/endpoint", message.MessageDestination);
+            Assert.Equal("http://nchs.cdc.gov/bfdr_submission", message.MessageSource);
+            FetalDeathRecord fdr = message.FetalDeathRecord;
+            Assert.NotNull(fdr);
+        }
+
+        [Fact]
+        public void CodedCauseOfFetalDeathMessageMissingFetalDeathRecord()
+        {
+            MessageParseException ex = Assert.Throws<MessageParseException>(() =>
+            {
+                BFDRBaseMessage.Parse<BirthRecordErrorMessage>(TestHelpers.FixtureStream("fixtures/json/FetalDeathCodedCauseMessageNoBundle.json"));
+            });
+            Assert.Contains("Error processing FetalDeathRecord", ex.Message);
+        }
+
+        [Fact]
+        public void CreateEmptyCodedCauseOfDeathUpdateMessage()
+        {
+            CodedCauseOfFetalDeathUpdateMessage message = new CodedCauseOfFetalDeathUpdateMessage();
+            Assert.Equal("http://nchs.cdc.gov/fd_causeofdeath_coding_update", message.MessageType);
+            Assert.Null(message.FetalDeathRecord);
+            Assert.Equal("http://nchs.cdc.gov/bfdr_submission", message.MessageDestination);
+            Assert.Null(message.MessageSource);
+            Assert.NotNull(message.MessageTimestamp);
+            Assert.NotNull(message.MessageId);
+            Assert.Null(message.CertNo);
+            Assert.Null(message.StateAuxiliaryId);
+            Assert.Null(message.NCHSIdentifier);
+            Assert.Equal("BFDR_STU2_0", message.PayloadVersionId);
+        }
+
+        [Fact]
+        public void CreateCodedCauseOfDeathUpdateMessageFromFetalDeathRecord()
+        {
+            CodedCauseOfFetalDeathUpdateMessage message = new CodedCauseOfFetalDeathUpdateMessage(fetalDeathRecord);
+            Assert.NotNull(message.FetalDeathRecord);
+            Assert.Equal("http://nchs.cdc.gov/fd_causeofdeath_coding_update", message.MessageType);
+            Assert.Equal((uint)87366, message.CertNo);
+            Assert.Equal((uint)2020, message.EventYear);
+            Assert.Equal("444455555", message.StateAuxiliaryId);
+            Assert.Equal("NY", message.JurisdictionId);
+            Assert.Equal("2020NY087366", message.NCHSIdentifier);
+            Assert.Equal((uint)2020, message.FetalDeathRecord.GetYear());
+            Assert.Equal("87366", message.FetalDeathRecord.CertificateNumber);
+        }
+
+        [Fact]
+        public void LoadCodedCauseOfDeathUpdateMessageFromJson()
+        {
+            CodedCauseOfFetalDeathUpdateMessage message = BFDRBaseMessage.Parse<CodedCauseOfFetalDeathUpdateMessage>(TestHelpers.FixtureStream("fixtures/json/FetalDeathCodedCauseUpdateMessage.json"));
+            Assert.Equal("http://nchs.cdc.gov/fd_causeofdeath_coding_update", message.MessageType);
+            Assert.Equal((uint)874232, message.CertNo);
+            Assert.Equal("abcdef20", message.StateAuxiliaryId);
+            Assert.Equal("2022MA874232", message.NCHSIdentifier);
+            Assert.Equal("https://example.com/jurisdiction/message/endpoint", message.MessageDestination);
+            Assert.Equal("http://nchs.cdc.gov/bfdr_submission", message.MessageSource);
+            FetalDeathRecord fdr = message.FetalDeathRecord;
+            Assert.NotNull(fdr);
+        }
+
+        [Fact]
+        public void WrongMessageTypeWhenParsingJson()
+        {
+            Assert.Throws<MessageParseException>(() =>
+            {
+                BFDRBaseMessage.Parse<FetalDeathRecordSubmissionMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordSubmissionMessage.json"));
+            });
+        }
+
+        [Fact(Skip = "Throws an ArgumentException, but maybe it shouldn't?")]
+        public void HeadlessMessageCausesException()
+        {
+            Assert.Throws<MessageParseException>(() =>
+            {
+                BFDRBaseMessage.Parse(TestHelpers.FixtureStream("fixtures/json/HeadlessMessage.json"));
+            });
+        }
+
+        [Fact]
+        public void MissingMessageTypeCausesException()
+        {
+            Assert.Throws<MessageParseException>(() =>
+            {
+                BFDRBaseMessage.Parse(TestHelpers.FixtureStream("fixtures/json/MissingMessage.json"));
+            });
+        }
+
+        [Fact]
+        public void InvalidMessageTypeCausesException()
+        {
+            Assert.Throws<MessageParseException>(() =>
+            {
+                BFDRBaseMessage.Parse(TestHelpers.FixtureStream("fixtures/json/InvalidMessage.json"));
+            });
+        }
+
+        [Fact]
+        public void CreateBirthRecordErrorMessageFromException()
+        {
+            MessageParseException ex = Assert.Throws<MessageParseException>(() =>
+            {
+                BFDRBaseMessage.Parse(TestHelpers.FixtureStream("fixtures/json/InvalidMessage.json"));
+            });
+            BirthRecordErrorMessage message = ex.CreateBirthRecordExtractionErrorMessage();
+            Assert.Single(message.Issues);
+            Assert.Equal(OperationOutcome.IssueSeverity.Error, message.Issues[0].Severity);
+            Assert.Equal(OperationOutcome.IssueType.Exception, message.Issues[0].Type);
+            Assert.Equal(ex.Message, message.Issues[0].Description);
+        }
+
+        [Fact]
+        public void CreateFetalDeathErrorMessageFromException()
+        {
+            MessageParseException ex = Assert.Throws<MessageParseException>(() =>
+            {
+                BFDRBaseMessage.Parse(TestHelpers.FixtureStream("fixtures/json/InvalidMessage.json"));
+            });
+            FetalDeathRecordErrorMessage message = ex.CreateFetalDeathRecordExtractionErrorMessage();
+            Assert.Single(message.Issues);
+            Assert.Equal(OperationOutcome.IssueSeverity.Error, message.Issues[0].Severity);
+            Assert.Equal(OperationOutcome.IssueType.Exception, message.Issues[0].Type);
+            Assert.Equal(ex.Message, message.Issues[0].Description);
+        }
+
+        [Fact]
         public void CreateCodedCauseOfFetalDeathMessageJson()
         {
-                // create an IJE birth message, convert it to FHIR, round trip the FHIR to json and back to make sure the bundles are all added to the json correctly
-                IJEFetalDeath ijefd = new IJEFetalDeath();
-                ijefd.ICOD = "P011";
+            // create an IJE birth message, convert it to FHIR, round trip the FHIR to json and back to make sure the bundles are all added to the json correctly
+            IJEFetalDeath ijefd = new IJEFetalDeath();
+            ijefd.ICOD = "P011";
 
-                FetalDeathRecord fdr = ijefd.ToRecord();
-                CodedCauseOfFetalDeathMessage msg = new CodedCauseOfFetalDeathMessage(fdr);
-                String msgJson = msg.ToJson();
-                // parse the json and make sure the bundles are present
-                CodedCauseOfFetalDeathMessage message = BFDRBaseMessage.Parse<CodedCauseOfFetalDeathMessage>(msgJson);
-                FetalDeathRecord fdr2 = message.FetalDeathRecord;
-                Assert.Equal("P01.1", fdr2.CodedInitiatingFetalCOD);
+            FetalDeathRecord fdr = ijefd.ToRecord();
+            CodedCauseOfFetalDeathMessage msg = new CodedCauseOfFetalDeathMessage(fdr);
+            String msgJson = msg.ToJson();
+            // parse the json and make sure the bundles are present
+            CodedCauseOfFetalDeathMessage message = BFDRBaseMessage.Parse<CodedCauseOfFetalDeathMessage>(msgJson);
+            FetalDeathRecord fdr2 = message.FetalDeathRecord;
+            Assert.Equal("P01.1", fdr2.CodedInitiatingFetalCOD);
         }
 
         /// <summary>
@@ -647,6 +1267,47 @@ namespace BFDR.Tests
             MessageRuleException ex = Assert.Throws<MessageRuleException>(() => CommonMessage.ValidateMessageHeader(msg));
             Assert.Equal("Message event year cannot be null.", ex.Message);
             Assert.IsType<BirthRecordSubmissionMessage>(ex.SourceMessage);
+        }
+
+        [Fact]
+        public void GetNatalityRecordFromBirthRecordSubmissionMessage()
+        {
+            BirthRecordSubmissionMessage submission = new BirthRecordSubmissionMessage(record);
+            NatalityRecord natality = BFDRBaseMessage.GetNatalityRecordFromMessage(submission);
+            Assert.Equal(natality, record);
+        }
+
+        [Fact]
+        public void GetNatalityRecordFromBirthRecordUpdateMessage()
+        {
+            BirthRecordUpdateMessage submission = new BirthRecordUpdateMessage(record);
+            NatalityRecord natality = BFDRBaseMessage.GetNatalityRecordFromMessage(submission);
+            Assert.Equal(natality, record);
+        }
+
+        [Fact(Skip = "GetNatalityRecordFromMessage needs fixing")]
+        public void GetNatalityRecordFromBirthRecordParentalDemographicsCodingMessage()
+        {
+            BirthRecordSubmissionMessage submission = BFDRBaseMessage.Parse<BirthRecordSubmissionMessage>(TestHelpers.FixtureStream("fixtures/json/BirthRecordSubmissionMessage.json"));
+            BirthRecordParentalDemographicsCodingMessage coding = new BirthRecordParentalDemographicsCodingMessage(submission);
+            NatalityRecord natality = BFDRBaseMessage.GetNatalityRecordFromMessage(coding);
+            Assert.Equal(natality, submission.BirthRecord);
+        }
+
+        [Fact]
+        public void GetNatalityRecordFromFetalDeathRecordSubmissionMessage()
+        {
+            FetalDeathRecordSubmissionMessage submission = new FetalDeathRecordSubmissionMessage(fetalDeathRecord);
+            NatalityRecord natality = BFDRBaseMessage.GetNatalityRecordFromMessage(submission);
+            Assert.Equal(natality, fetalDeathRecord);
+        }
+
+        [Fact]
+        public void GetNatalityRecordFromFetalDeathRecordUpdateMessage()
+        {
+            FetalDeathRecordUpdateMessage submission = new FetalDeathRecordUpdateMessage(fetalDeathRecord);
+            NatalityRecord natality = BFDRBaseMessage.GetNatalityRecordFromMessage(submission);
+            Assert.Equal(natality, fetalDeathRecord);
         }
     }
 }

--- a/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecordSubmissionMessageNoBundle.json
+++ b/projects/BFDR.Tests/fixtures/json/BasicFetalDeathRecordSubmissionMessageNoBundle.json
@@ -1,0 +1,54 @@
+{
+  "resourceType": "Bundle",
+  "id": "aec351eb-e7bf-4dc2-9f2a-bcf842a98303",
+  "type": "message",
+  "timestamp": "2025-02-06T19:42:48.418908+00:00",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:41f14a27-b079-4c76-ab04-a27c8046b2af",
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "41f14a27-b079-4c76-ab04-a27c8046b2af",
+        "eventUri": "http://nchs.cdc.gov/fd_submission",
+        "destination": [
+          {
+            "endpoint": "http://nchs.cdc.gov/bfdr_submission"
+          }
+        ],
+        "source": {
+          "endpoint": "https://example.com/jurisdiction/message/endpoint"
+        },
+        "focus": [
+          {
+            "reference": "urn:uuid:93ab2ba3-3aa8-4132-a6cb-7e935186eaf3"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:6b60d4eb-5e14-449a-bd4e-665e7aeb8c8c",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "6b60d4eb-5e14-449a-bd4e-665e7aeb8c8c",
+        "parameter": [
+          {
+            "name": "payload_version_id",
+            "valueString": "BFDR_STU2_0"
+          },
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 453723
+          },
+          {
+            "name": "event_year",
+            "valueUnsignedInt": 2025
+          },
+          {
+            "name": "jurisdiction_id",
+            "valueString": "UT"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/projects/BFDR.Tests/fixtures/json/BirthRecordDemographicsCodingMessageNoNatality.json
+++ b/projects/BFDR.Tests/fixtures/json/BirthRecordDemographicsCodingMessageNoNatality.json
@@ -1,0 +1,51 @@
+{
+  "resourceType": "Bundle",
+  "id": "b86878b8-6428-4467-be61-47be71884ce0",
+  "type": "message",
+  "timestamp": "2023-12-21T17:29:07.589702-05:00",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:acba0c0a-6b83-464c-aa52-ce9cfb4ea7bc",
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "acba0c0a-6b83-464c-aa52-ce9cfb4ea7bc",
+        "eventUri": "http://nchs.cdc.gov/birth_demographics_coding",
+        "destination": [
+          {
+            "endpoint": "http://nchs.cdc.gov/bfdr_submission"
+          }
+        ],
+        "focus": [
+          {
+            "reference": "urn:uuid:c90e2253-3fb7-46d8-81ec-23329e9ed2fb"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:06c643ee-dd9e-4738-bdc8-5de512c7d94c",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "06c643ee-dd9e-4738-bdc8-5de512c7d94c",
+        "parameter": [
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 100
+          },
+          {
+            "name": "state_auxiliary_id",
+            "valueString": "123"
+          },
+          {
+            "name": "event_year",
+            "valueUnsignedInt": 2023
+          },
+          {
+            "name": "jurisdiction_id",
+            "valueString": "YC"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/projects/BFDR.Tests/fixtures/json/BirthRecordErrorMessageNoOperationOutcome.json
+++ b/projects/BFDR.Tests/fixtures/json/BirthRecordErrorMessageNoOperationOutcome.json
@@ -1,0 +1,61 @@
+{
+  "resourceType": "Bundle",
+  "id": "6d46a5c6-b370-4eb0-82dd-e004bbd651d4",
+  "timestamp": "2020-04-09T09:36:05.899558-04:00",
+  "type": "message",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:b27d6803-86bc-4ec5-bd43-173951ce362b",
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "b27d6803-86bc-4ec5-bd43-173951ce362b",
+        "eventUri": "http://nchs.cdc.gov/birth_extraction_error",
+        "destination": [
+          {
+            "endpoint": "nightingale"
+          }
+        ],
+        "source": {
+          "endpoint": "http://nchs.cdc.gov/bfdr_submission"
+        },
+        "response": {
+          "identifier": "a9d66d2e-2480-4e8d-bab3-4e4c761da1b7",
+          "code": "fatal-error",
+          "details": {
+            "reference": "28b5b3b5-25a2-4fc4-9dd6-21162b290787"
+          }
+        },
+        "focus": [
+          {
+            "reference": "urn:uuid:df6f9785-1f00-4af8-bd5d-56c1b024691d"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:df6f9785-1f00-4af8-bd5d-56c1b024691d",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "df6f9785-1f00-4af8-bd5d-56c1b024691d",
+        "parameter": [
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 1
+          },
+          {
+            "name": "state_auxiliary_id",
+            "valueString": "42"
+          },
+          {
+            "name": "event_year",
+            "valueUnsignedInt": 2018
+          },
+          {
+            "name": "jurisdiction_id",
+            "valueString": "MA"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/projects/BFDR.Tests/fixtures/json/BirthRecordSubmissionMessageNoBundle.json
+++ b/projects/BFDR.Tests/fixtures/json/BirthRecordSubmissionMessageNoBundle.json
@@ -1,15 +1,15 @@
 {
   "resourceType": "Bundle",
-  "id": "8549fd98-7edd-4137-a176-7d11ea6d094c",
+  "id": "9750e180-e24b-4946-abcf-e9b730965826",
   "type": "message",
-  "timestamp": "2023-12-13T13:01:30.368827-05:00",
+  "timestamp": "2024-01-09T17:36:45.264648-05:00",
   "entry": [
     {
-      "fullUrl": "urn:uuid:fcf931ba-4434-43c0-8ea8-04c31a9fd850",
+      "fullUrl": "urn:uuid:c36cfa0d-f3d4-4b1a-9df4-410f640b50c3",
       "resource": {
         "resourceType": "MessageHeader",
-        "id": "fcf931ba-4434-43c0-8ea8-04c31a9fd850",
-        "eventUri": "http://nchs.cdc.gov/birth_submission_void",
+        "id": "c36cfa0d-f3d4-4b1a-9df4-410f640b50c3",
+        "eventUri": "http://nchs.cdc.gov/birth_submission",
         "destination": [
           {
             "endpoint": "http://nchs.cdc.gov/bfdr_submission"
@@ -17,14 +17,19 @@
         ],
         "source": {
           "endpoint": "http://mitre.org/bfdr"
-        }
+        },
+        "focus": [
+          {
+            "reference": "urn:uuid:f731ac90-1e21-4744-9a02-f996c7a967b5"
+          }
+        ]
       }
     },
     {
-      "fullUrl": "urn:uuid:7e4f847d-0233-4dd8-95fd-b6f22043cf7c",
+      "fullUrl": "urn:uuid:18cf3dbd-6cab-413f-9074-9462c66a3ce1",
       "resource": {
         "resourceType": "Parameters",
-        "id": "7e4f847d-0233-4dd8-95fd-b6f22043cf7c",
+        "id": "18cf3dbd-6cab-413f-9074-9462c66a3ce1",
         "parameter": [
           {
             "name": "cert_no",
@@ -41,10 +46,6 @@
           {
             "name": "jurisdiction_id",
             "valueString": "UT"
-          },
-          {
-            "name": "block_count",
-            "valueUnsignedInt": 10
           }
         ]
       }

--- a/projects/BFDR.Tests/fixtures/json/BirthRecordVoidMessageWithoutBlockCount.json
+++ b/projects/BFDR.Tests/fixtures/json/BirthRecordVoidMessageWithoutBlockCount.json
@@ -41,10 +41,6 @@
           {
             "name": "jurisdiction_id",
             "valueString": "UT"
-          },
-          {
-            "name": "block_count",
-            "valueUnsignedInt": 10
           }
         ]
       }

--- a/projects/BFDR.Tests/fixtures/json/FetalDeathAcknowledgementMessage.json
+++ b/projects/BFDR.Tests/fixtures/json/FetalDeathAcknowledgementMessage.json
@@ -1,0 +1,75 @@
+{
+  "resourceType": "Bundle",
+  "id": "FDAckMessage",
+  "meta": {
+    "profile": [
+      "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-AcknowledgementMessage"
+    ]
+  },
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "FDAckHeader",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-AcknowledgementHeader"
+          ]
+        },
+        "source": {
+          "endpoint": "http://nchs.cdc.gov/fd_submission"
+        },
+        "destination": [
+          {
+            "endpoint": "http://mitre.org/bfdr"
+          }
+        ],
+        "response": {
+          "code": "ok",
+          "identifier": "cd9fa913-55f2-4dfd-940d-11e77344362a"
+        },
+        "focus": [
+          {
+            "reference": "Parameters/148f66f7-49fa-4118-947e-636bd89d5dbc"
+          }
+        ],
+        "eventUri": "http://nchs.cdc.gov/fd_acknowledgement"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "148f66f7-49fa-4118-947e-636bd89d5dbc",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-MessageParameters"
+          ]
+        },
+        "parameter": [
+          {
+            "name": "jurisdiction_id",
+            "valueString": "MA"
+          },
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 874232
+          },
+          {
+            "name": "event_year",
+            "valueUnsignedInt": 2022
+          },
+          {
+            "name": "state_auxiliary_id",
+            "valueString": "abcdef20"
+          },
+          {
+            "name": "payload_version_id",
+            "valueString": "VRDRSTU2.2"
+          }
+        ]
+      }
+    }
+  ],
+  "type": "message",
+  "timestamp": "2022-04-12T00:00:00Z"
+}

--- a/projects/BFDR.Tests/fixtures/json/FetalDeathCodedCauseMessage.json
+++ b/projects/BFDR.Tests/fixtures/json/FetalDeathCodedCauseMessage.json
@@ -1,0 +1,131 @@
+{
+  "resourceType": "Bundle",
+  "id": "CodedCauseMessage",
+  "meta": {
+    "profile": [
+      "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-CauseOfDeathCodingMessage"
+    ]
+  },
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "CodedCauseMessageHeader",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-CauseOfDeathCodingHeader"
+          ]
+        },
+        "source": {
+          "endpoint": "http://nchs.cdc.gov/bfdr_submission"
+        },
+        "destination": [
+          {
+            "endpoint": "https://example.com/jurisdiction/message/endpoint"
+          }
+        ],
+        "focus": [
+          {
+            "reference": "Bundle/cd9fa913-55f2-4dfd-940d-11e77344362a"
+          }
+        ],
+        "eventUri": "http://nchs.cdc.gov/fd_causeofdeath_coding"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "CodedCauseMessageParameters",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-MessageParameters"
+          ]
+        },
+        "parameter": [
+          {
+            "name": "jurisdiction_id",
+            "valueString": "MA"
+          },
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 874232
+          },
+          {
+            "name": "event_year",
+            "valueUnsignedInt": 2022
+          },
+          {
+            "name": "state_auxiliary_id",
+            "valueString": "abcdef20"
+          },
+          {
+            "name": "payload_version_id",
+            "valueString": "VRDRSTU2.2"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Bundle",
+        "id": "cd9fa913-55f2-4dfd-940d-11e77344362a",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/bfdr/StructureDefinition/Bundle-document-coded-cause-of-fetal-death"
+          ]
+        },
+        "identifier": {
+          "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-ije-vr",
+          "value": "2022MA874232"
+        },
+        "entry": [
+          {
+            "resource": {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "86804-2"
+                  }
+                ]
+              },
+              "section": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "86804-2"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "resourceType": "Composition",
+              "id": "CompositionCodedCauseExample",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Composition-coded-cause-of-fetal-death"
+                ]
+              },
+              "subject": {
+                "display": "Patient - Decedent Fetus (Fetus Not Named)"
+              },
+              "author": [
+                {
+                  "display": "National Center for Health Statistics"
+                }
+              ],
+              "status": "final",
+              "title": "Coded Cause of Fetal Death",
+              "date": "2022-04-11"
+            }
+          }
+        ],
+        "type": "document"
+      }
+    }
+  ],
+  "type": "message",
+  "timestamp": "2022-04-11T00:00:00Z"
+}

--- a/projects/BFDR.Tests/fixtures/json/FetalDeathCodedCauseMessageNoBundle.json
+++ b/projects/BFDR.Tests/fixtures/json/FetalDeathCodedCauseMessageNoBundle.json
@@ -1,0 +1,71 @@
+{
+  "resourceType": "Bundle",
+  "id": "CodedCauseMessage",
+  "meta": {
+    "profile": [
+      "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-CauseOfDeathCodingMessage"
+    ]
+  },
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "CodedCauseMessageHeader",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-CauseOfDeathCodingHeader"
+          ]
+        },
+        "source": {
+          "endpoint": "http://nchs.cdc.gov/bfdr_submission"
+        },
+        "destination": [
+          {
+            "endpoint": "https://example.com/jurisdiction/message/endpoint"
+          }
+        ],
+        "focus": [
+          {
+            "reference": "Bundle/cd9fa913-55f2-4dfd-940d-11e77344362a"
+          }
+        ],
+        "eventUri": "http://nchs.cdc.gov/fd_causeofdeath_coding"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "CodedCauseMessageParameters",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-MessageParameters"
+          ]
+        },
+        "parameter": [
+          {
+            "name": "jurisdiction_id",
+            "valueString": "MA"
+          },
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 874232
+          },
+          {
+            "name": "event_year",
+            "valueUnsignedInt": 2022
+          },
+          {
+            "name": "state_auxiliary_id",
+            "valueString": "abcdef20"
+          },
+          {
+            "name": "payload_version_id",
+            "valueString": "VRDRSTU2.2"
+          }
+        ]
+      }
+    }
+  ],
+  "type": "message",
+  "timestamp": "2022-04-11T00:00:00Z"
+}

--- a/projects/BFDR.Tests/fixtures/json/FetalDeathCodedCauseUpdateMessage.json
+++ b/projects/BFDR.Tests/fixtures/json/FetalDeathCodedCauseUpdateMessage.json
@@ -1,0 +1,136 @@
+{
+  "resourceType": "Bundle",
+  "id": "CodedCauseOfFetalDeathUpdateMessageExample",
+  "meta": {
+    "profile": [
+      "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-CodedCauseOfFetalDeathUpdateMessage"
+    ]
+  },
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "CauseOfDeathCodingUpdateHeaderExample",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-CauseOfDeathCodingUpdateHeader"
+          ]
+        },
+        "source": {
+          "endpoint": "http://nchs.cdc.gov/bfdr_submission"
+        },
+        "destination": [
+          {
+            "endpoint": "https://example.com/jurisdiction/message/endpoint"
+          }
+        ],
+        "focus": [
+          {
+            "reference": "Bundle/cd9fa913-55f2-4dfd-940d-11e77344362a"
+          }
+        ],
+        "eventUri": "http://nchs.cdc.gov/fd_causeofdeath_coding_update"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "CodedCauseUpdateMessageParameters",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-MessageParameters"
+          ]
+        },
+        "parameter": [
+          {
+            "name": "jurisdiction_id",
+            "valueString": "MA"
+          },
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 874232
+          },
+          {
+            "name": "event_year",
+            "valueUnsignedInt": 2022
+          },
+          {
+            "name": "state_auxiliary_id",
+            "valueString": "abcdef20"
+          },
+          {
+            "name": "payload_version_id",
+            "valueString": "VRDRSTU2.2"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Bundle",
+        "id": "cd9fa913-55f2-4dfd-940d-11e77344362a",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/bfdr/StructureDefinition/Bundle-document-coded-cause-of-fetal-death"
+          ]
+        },
+        "identifier": {
+          "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-ije-vr",
+          "value": "2022MA874232"
+        },
+        "entry": [
+          {
+            "resource": {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "86804-2"
+                  }
+                ]
+              },
+              "section": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "86804-2"
+                      }
+                    ]
+                  },
+                  "entry": [
+                    {
+                      "reference": "Observation/TheObservedCause"
+                    }
+                  ]
+                }
+              ],
+              "resourceType": "Composition",
+              "id": "CompositionCodedCauseExample",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Composition-coded-cause-of-fetal-death"
+                ]
+              },
+              "subject": {
+                "display": "Patient - Decedent Fetus (Fetus Not Named)"
+              },
+              "author": [
+                {
+                  "display": "National Center for Health Statistics"
+                }
+              ],
+              "status": "final",
+              "title": "Coded Cause of Fetal Death",
+              "date": "2022-04-11"
+            }
+          }
+        ],
+        "type": "document"
+      }
+    }
+  ],
+  "type": "message",
+  "timestamp": "2022-04-11T00:00:00Z"
+}

--- a/projects/BFDR.Tests/fixtures/json/FetalDeathDemographicsCodingUpdateMessage.json
+++ b/projects/BFDR.Tests/fixtures/json/FetalDeathDemographicsCodingUpdateMessage.json
@@ -1,0 +1,131 @@
+{
+  "resourceType": "Bundle",
+  "id": "FDDemographicsUpdateMsg",
+  "meta": {
+    "profile": [
+      "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-DemographicsCodingUpdateMessage"
+    ]
+  },
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "FDDemoUpdateHeader",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-DemographicsCodingUpdateHeader"
+          ]
+        },
+        "source": {
+          "endpoint": "http://nchs.cdc.gov/bfdr_submission"
+        },
+        "destination": [
+          {
+            "endpoint": "https://example.com/jurisdiction/message/endpoint"
+          }
+        ],
+        "focus": [
+          {
+            "reference": "Bundle/guid"
+          }
+        ],
+        "eventUri": "http://nchs.cdc.gov/fd_demographics_coding_update"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "FDDemoUpdateParams",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-MessageParameters"
+          ]
+        },
+        "parameter": [
+          {
+            "name": "jurisdiction_id",
+            "valueString": "MA"
+          },
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 55123
+          },
+          {
+            "name": "event_year",
+            "valueUnsignedInt": 2022
+          },
+          {
+            "name": "state_auxiliary_id",
+            "valueString": "abcdef20"
+          },
+          {
+            "name": "payload_version_id",
+            "valueString": "VRDRSTU2.2"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Bundle",
+        "id": "guid",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/bfdr/StructureDefinition/Bundle-document-demographic-coded-content"
+          ]
+        },
+        "identifier": {
+          "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-ije-vr",
+          "value": "2022MA055123"
+        },
+        "entry": [
+          {
+            "resource": {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "86805-9"
+                  }
+                ]
+              },
+              "resourceType": "Composition",
+              "id": "DemographicComp",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Composition-coded-race-and-ethnicity"
+                ]
+              },
+              "subject": {
+                "display": "Patient - Decedent Fetus (Fetus Not Named)"
+              },
+              "author": [
+                {
+                  "display": "Demographic Services"
+                }
+              ],
+              "section": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                        "code": "MTH"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "status": "final",
+              "date": "2022-04-15",
+              "title": "Demographic information and details"
+            }
+          }
+        ],
+        "type": "document"
+      }
+    }
+  ],
+  "type": "message",
+  "timestamp": "2022-04-15T00:00:00Z"
+}

--- a/projects/BFDR.Tests/fixtures/json/FetalDeathErrorMessage.json
+++ b/projects/BFDR.Tests/fixtures/json/FetalDeathErrorMessage.json
@@ -1,0 +1,89 @@
+{
+  "resourceType": "Bundle",
+  "id": "SampleFetalDeathErrorMessage",
+  "meta": {
+    "profile": [
+      "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-ExtractionErrorMessage"
+    ]
+  },
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "6f91de53-36f7-474a-bc79-cc2f61fdb211",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-ExtractionErrorHeader"
+          ]
+        },
+        "source": {
+          "endpoint": "http://nchs.cdc.gov/bfdr_submission"
+        },
+        "destination": [
+          {
+            "endpoint": "https://example.com/jurisdiction/message/endpoint"
+          }
+        ],
+        "focus": [
+          {
+            "reference": "Parameters/SampleErrorParams"
+          }
+        ],
+        "eventUri": "http://nchs.cdc.gov/fd_extraction_error"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "SampleErrorParams",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-MessageParameters"
+          ]
+        },
+        "parameter": [
+          {
+            "name": "jurisdiction_id",
+            "valueString": "MA"
+          },
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 874343
+          },
+          {
+            "name": "event_year",
+            "valueUnsignedInt": 2022
+          },
+          {
+            "name": "state_auxiliary_id",
+            "valueString": "abcdef20"
+          },
+          {
+            "name": "payload_version_id",
+            "valueString": "VRDRSTU2.2"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "OperationOutcome",
+        "id": "SampleFDErrorOutcome",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-Outcome"
+          ]
+        },
+        "issue": [
+          {
+            "severity": "error",
+            "code": "required",
+            "diagnostics": "something was not correct."
+          }
+        ]
+      }
+    }
+  ],
+  "type": "message",
+  "timestamp": "2022-04-13T00:00:00Z"
+}

--- a/projects/BFDR.Tests/fixtures/json/FetalDeathRecordStatusMessage.json
+++ b/projects/BFDR.Tests/fixtures/json/FetalDeathRecordStatusMessage.json
@@ -1,0 +1,73 @@
+{
+  "resourceType": "Bundle",
+  "id": "StatusMessage-Example2",
+  "meta": {
+    "profile": [
+      "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-StatusMessage"
+    ]
+  },
+  "type": "message",
+  "timestamp": "2021-05-20T00:00:00Z",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "StatusHeader-Example2",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-StatusHeader"
+          ]
+        },
+        "eventUri": "http://nchs.cdc.gov/fd_status",
+        "destination": [
+          {
+            "endpoint": "https://sos.nh.gov/vitalrecords"
+          }
+        ],
+        "source": {
+          "endpoint": "http://nchs.cdc.gov/bfdr_submission"
+        },
+        "focus": [
+          {
+            "reference": "Parameters/StatusParameters-Example2"
+          }
+        ]
+      },
+      "fullUrl": "http://www.example.org/fhir/Header/StatusHeader-Example2"
+    },
+    {
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "StatusParameters-Example2",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-StatusParameters"
+          ]
+        },
+        "parameter": [
+          {
+            "name": "status",
+            "valueString": "manualCauseOfDeathCoding"
+          },
+          {
+            "name": "jurisdiction_id",
+            "valueString": "NY"
+          },
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 123456
+          },
+          {
+            "name": "event_year",
+            "valueUnsignedInt": 2018
+          },
+          {
+            "name": "state_auxiliary_id",
+            "valueString": "abcdef10"
+          }
+        ]
+      },
+      "fullUrl": "http://www.example.org/fhir/Parameters/StatusParameters-Example2"
+    }
+  ]
+}

--- a/projects/BFDR.Tests/fixtures/json/FetalDeathUpdateMessage.json
+++ b/projects/BFDR.Tests/fixtures/json/FetalDeathUpdateMessage.json
@@ -1,0 +1,677 @@
+{
+  "resourceType": "Bundle",
+  "id": "FDUpdate",
+  "meta": {
+    "profile": [
+      "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-FetalDeathReportUpdateMessage"
+    ]
+  },
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "FDUpdateHeader",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-UpdateHeader"
+          ]
+        },
+        "source": {
+          "endpoint": "http://mitre.org/bfdr"
+        },
+        "destination": [
+          {
+            "endpoint": "http://nchs.cdc.gov/bfdr_submission"
+          }
+        ],
+        "focus": [
+          {
+            "reference": "Bundle/894e3dc4-ef5d-4b9d-ab07-9c235f748737"
+          }
+        ],
+        "eventUri": "http://nchs.cdc.gov/fd_submission_update"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "FDSubmissionParams",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-MessageParameters"
+          ]
+        },
+        "parameter": [
+          {
+            "name": "jurisdiction_id",
+            "valueString": "NY"
+          },
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 87366
+          },
+          {
+            "name": "event_year",
+            "valueUnsignedInt": 2020
+          },
+          {
+            "name": "state_auxiliary_id",
+            "valueString": "444455555"
+          },
+          {
+            "name": "payload_version_id",
+            "valueString": "VRDRSTU2.2"
+          }
+        ]
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Bundle",
+        "id": "43ec7dfc-a767-4990-8b28-fef56f90f856",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/bfdr/StructureDefinition/Bundle-document-fetal-death-report"
+          ]
+        },
+        "identifier": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/CertificateNumber",
+              "valueString": "87366"
+            },
+            {
+              "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/AuxiliaryStateIdentifier1",
+              "valueString": "444455555"
+            }
+          ],
+          "system": "http://nchs.cdc.gov/bfdr_id",
+          "value": "2020NY087366"
+        },
+        "type": "document",
+        "timestamp": "2024-04-18T12:34:03.591881-04:00",
+        "entry": [
+          {
+            "fullUrl": "urn:uuid:de56d24e-6c85-44a2-8519-f8dbc989a82b",
+            "resource": {
+              "resourceType": "Composition",
+              "id": "de56d24e-6c85-44a2-8519-f8dbc989a82b",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Composition-jurisdiction-fetal-death-report"
+                ]
+              },
+              "status": "final",
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "92010-8",
+                    "display": "Jurisdiction fetal death report Document"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "urn:uuid:fbdfe5ae-f40f-4119-b435-c23a5d8bb4ed"
+              },
+              "encounter": {
+                "reference": "urn:uuid:d0801c32-d417-41b7-a461-70f9cf163055"
+              },
+              "title": "Fetal Death Report",
+              "section": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "92014-0"
+                      }
+                    ]
+                  },
+                  "focus": {
+                    "reference": "urn:uuid:18ef120e-0b0b-49d5-85f7-acb8f3a583b7"
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://loinc.org",
+                        "code": "55752-0"
+                      }
+                    ]
+                  },
+                  "focus": {
+                    "reference": "urn:uuid:18ef120e-0b0b-49d5-85f7-acb8f3a583b7"
+                  }
+                }
+              ],
+              "attester": [
+                {
+                  "mode": "legal"
+                }
+              ],
+              "event": [
+                {
+                  "code": [
+                    {
+                      "coding": [
+                        {
+                          "system": "http://snomed.info/sct",
+                          "code": "103693007",
+                          "display": "Diagnostic procedure (procedure)"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:fbdfe5ae-f40f-4119-b435-c23a5d8bb4ed",
+            "resource": {
+              "resourceType": "Patient",
+              "id": "fbdfe5ae-f40f-4119-b435-c23a5d8bb4ed",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Patient-decedent-fetus"
+                ]
+              },
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+                      "valueCode": "M"
+                    },
+                    {
+                      "url": "motherOrFather",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                            "code": "MTH"
+                          }
+                        ],
+                        "text": "mother"
+                      }
+                    },
+                    {
+                      "url": "reportedAge",
+                      "valueQuantity": {
+                        "value": 33,
+                        "unit": "a",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "a"
+                      }
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-reported-parent-age-at-delivery-vr"
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+                  "valueAddress": {
+                    "city": "Buffalo",
+                    "district": "buffalo",
+                    "state": "NY",
+                    "_district": {
+                      "extension": [
+                        {
+                          "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/DistrictCode",
+                          "valueString": "035"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "motherOrFather",
+                      "valueCodeableConcept": {
+                        "coding": [
+                          {
+                            "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                            "code": "FTH"
+                          }
+                        ],
+                        "text": "father"
+                      }
+                    },
+                    {
+                      "url": "reportedAge",
+                      "valueQuantity": {
+                        "value": 31,
+                        "unit": "a",
+                        "system": "http://unitsofmeasure.org",
+                        "code": "a"
+                      }
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-reported-parent-age-at-delivery-vr"
+                }
+              ],
+              "name": [
+                {
+                  "use": "official",
+                  "family": "Quinn",
+                  "given": ["Baby", "G"]
+                }
+              ],
+              "birthDate": "2020-02-12"
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:18ef120e-0b0b-49d5-85f7-acb8f3a583b7",
+            "resource": {
+              "resourceType": "Patient",
+              "id": "18ef120e-0b0b-49d5-85f7-acb8f3a583b7",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Patient-mother-vr"
+                ]
+              },
+              "birthDate": "1992-01-12",
+              "address": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-within-city-limits-indicator-vr"
+                    }
+                  ],
+                  "use": "home",
+                  "line": ["7 Blue Street"],
+                  "city": "Milford",
+                  "district": "New Haven",
+                  "state": "CT",
+                  "postalCode": "06460",
+                  "country": "US"
+                }
+              ]
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:ab2f7329-95a9-41fe-9356-931619dad692",
+            "resource": {
+              "resourceType": "RelatedPerson",
+              "id": "ab2f7329-95a9-41fe-9356-931619dad692",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/RelatedPerson-father-natural-vr"
+                ]
+              },
+              "relationship": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                      "code": "NFTH"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "fullUrl": "http://www.example.org/fhir/Location/location-south-hospital",
+            "resource": {
+              "resourceType": "Location",
+              "id": "location-south-hospital",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Location-bfdr"
+                ]
+              },
+              "text": {
+                "status": "generated",
+                "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><a name=\"Location_location-south-hospital\"> </a><p><b>Generated Narrative: Location </b><a name=\"location-south-hospital\"> </a><a name=\"hclocation-south-hospital\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">ResourceLocation &quot;location-south-hospital&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-Location-bfdr.html\">Birth and Fetal Death Location</a></p></div><p><b>identifier</b>: <a href=\"http://terminology.hl7.org/5.0.0/NamingSystem-npi.html\" title=\"National Provider Identifier\">NPI</a>/116441967701</p><p><b>status</b>: active</p><p><b>name</b>: South Hospital</p><p><b>type</b>: Hospital <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.5.0/CodeSystem-v3-RoleCode.html\">RoleCode</a>#HOSP)</span>, Birth Location <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"CodeSystem-CodeSystem-local-bfdr-codes.html\">Local BFDR Codes</a>#loc_birth)</span></p><p><b>address</b>: 2100 North Ave Salt Lake City UT 84116 US </p><h3>Positions</h3><table class=\"grid\"><tr><td style=\"display: none\">-</td><td><b>Longitude</b></td><td><b>Latitude</b></td></tr><tr><td style=\"display: none\">*</td><td>40.8</td><td>111.9</td></tr></table><p><b>managingOrganization</b>: See on this page: Organization/organization-south-hospital: Organization - South Hospital</p></div>"
+              },
+              "identifier": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/us/bfdr/StructureDefinition/Extension-jurisdictional-facility-identifier",
+                      "valueString": "UT12"
+                    }
+                  ],
+                  "system": "http://hl7.org/fhir/sid/us-npi",
+                  "value": "116441967701"
+                }
+              ],
+              "status": "active",
+              "name": "South Hospital",
+              "type": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                      "code": "HOSP",
+                      "display": "Hospital"
+                    }
+                  ]
+                },
+                {
+                  "coding": [
+                    {
+                      "system": "http://hl7.org/fhir/us/bfdr/CodeSystem/CodeSystem-local-bfdr-codes",
+                      "code": "loc_birth",
+                      "display": "Birth Location"
+                    }
+                  ]
+                }
+              ],
+              "address": {
+                "line": ["2100 North Ave"],
+                "city": "Salt Lake City",
+                "district": "Made Up",
+                "state": "UT",
+                "postalCode": "84116",
+                "country": "US"
+              },
+              "position": {
+                "longitude": 40.8,
+                "latitude": 111.9
+              },
+              "managingOrganization": {
+                "reference": "Organization/organization-south-hospital",
+                "display": "Organization - South Hospital"
+              }
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:139fd854-780b-4427-b3cf-6c85f41e6f35",
+            "resource": {
+              "resourceType": "Practitioner",
+              "id": "139fd854-780b-4427-b3cf-6c85f41e6f35",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Practitioner-vr"
+                ]
+              },
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/us/bfdr/StructureDefinition/Extension-role",
+                  "valueCode": "certifier"
+                }
+              ]
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:348f658f-b005-4136-9831-08c7b197d474",
+            "resource": {
+              "resourceType": "Practitioner",
+              "id": "348f658f-b005-4136-9831-08c7b197d474",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Practitioner-vr"
+                ]
+              },
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/us/bfdr/StructureDefinition/Extension-role",
+                  "valueCode": "attendant"
+                }
+              ]
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:a31bf759-1f3a-4bf0-aa3a-aa3f1ec94140",
+            "resource": {
+              "resourceType": "Observation",
+              "id": "a31bf759-1f3a-4bf0-aa3a-aa3f1ec94140",
+              "category": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                      "code": "vital-signs"
+                    }
+                  ]
+                }
+              ],
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "8339-4"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "urn:uuid:fbdfe5ae-f40f-4119-b435-c23a5d8bb4ed"
+              },
+              "valueQuantity": {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/BypassEditFlag",
+                    "valueCodeableConcept": {
+                      "coding": [
+                        {
+                          "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-vr-edit-flags",
+                          "code": "0off",
+                          "display": "Off"
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "value": 3333,
+                "unit": "g",
+                "code": "g"
+              }
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:8ebfaaa0-aa3e-49fd-aed4-45c93f8e292a",
+            "resource": {
+              "resourceType": "Observation",
+              "id": "8ebfaaa0-aa3e-49fd-aed4-45c93f8e292a",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Observation-autopsy-histological-exam-results-used"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "74498-7",
+                    "display": "Were autopsy or histological placental examinations results used in determining the cause of fetal death?"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "urn:uuid:18ef120e-0b0b-49d5-85f7-acb8f3a583b7"
+              },
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                    "code": "Y",
+                    "display": "Yes"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:32ca4848-9803-4f64-817d-88459703b772",
+            "resource": {
+              "resourceType": "Observation",
+              "id": "32ca4848-9803-4f64-817d-88459703b772",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Observation-autopsy-performed-indicator-vr"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "85699-7",
+                    "display": "Autopsy Performed Indicator"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "urn:uuid:18ef120e-0b0b-49d5-85f7-acb8f3a583b7"
+              },
+              "valueCodeableConcept": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "398166005",
+                    "display": "Performed"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:3fe557f1-4928-466e-bc4e-7e6dc71c74ed",
+            "resource": {
+              "resourceType": "Condition",
+              "id": "3fe557f1-4928-466e-bc4e-7e6dc71c74ed",
+              "category": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://loinc.org",
+                      "code": "76060-3"
+                    }
+                  ]
+                }
+              ],
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "44223004"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "urn:uuid:5f76fab9-6fb0-4901-9c4a-dcedab7e1ef4"
+              }
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:3819b92a-8906-4370-8326-7f8088fcb722",
+            "resource": {
+              "resourceType": "Observation",
+              "id": "3819b92a-8906-4370-8326-7f8088fcb722",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/input-race-and-ethnicity-vr"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-local-observation-codes-vr",
+                    "code": "inputraceandethnicityMother",
+                    "display": "Input Race and Ethnicity Person"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "urn:uuid:9c4ca888-c4dc-4aa6-9673-828923445ce8"
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicLiteral",
+                        "display": "Hispanic Literal"
+                      }
+                    ]
+                  },
+                  "valueString": "Colombian"
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicCuban",
+                        "display": "Hispanic Cuban"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "code": "Y",
+                        "display": "Yes"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "BlackOrAfricanAmerican",
+                        "display": "Black Or African American"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                }
+              ]
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:c2a5861e-9b5f-4837-826d-38d9a24d71c3",
+            "resource": {
+              "resourceType": "Observation",
+              "id": "c2a5861e-9b5f-4837-826d-38d9a24d71c3",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/input-race-and-ethnicity-vr"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-local-observation-codes-vr",
+                    "code": "inputraceandethnicityFather",
+                    "display": "Input Race and Ethnicity Person"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "urn:uuid:9c4ca888-c4dc-4aa6-9673-828923445ce8"
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "White",
+                        "display": "White"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "type": "message",
+  "timestamp": "2022-04-21T00:00:00Z"
+}

--- a/projects/BFDR.Tests/fixtures/json/FetalDeathVoidMessage.json
+++ b/projects/BFDR.Tests/fixtures/json/FetalDeathVoidMessage.json
@@ -1,0 +1,75 @@
+{
+  "resourceType": "Bundle",
+  "id": "FDVoidMessage",
+  "meta": {
+    "profile": [
+      "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-VoidMessage"
+    ]
+  },
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "FDVoidHeader",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-VoidHeader"
+          ]
+        },
+        "source": {
+          "endpoint": "http://mitre.org/bfdr"
+        },
+        "destination": [
+          {
+            "endpoint": "http://nchs.cdc.gov/bfdr_submission"
+          }
+        ],
+        "focus": [
+          {
+            "display": "Header for FD Void Message"
+          }
+        ],
+        "eventUri": "http://nchs.cdc.gov/fd_submission_void"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "FDVoidParams",
+        "meta": {
+          "profile": [
+            "http://cdc.gov/nchs/nvss/fhir/vital-records-messaging/StructureDefinition/VRM-VoidParameters"
+          ]
+        },
+        "parameter": [
+          {
+            "name": "jurisdiction_id",
+            "valueString": "MA"
+          },
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 63214
+          },
+          {
+            "name": "event_year",
+            "valueUnsignedInt": 2022
+          },
+          {
+            "name": "state_auxiliary_id",
+            "valueString": "abc00020"
+          },
+          {
+            "name": "payload_version_id",
+            "valueString": "VRDRSTU2.2"
+          },
+          {
+            "name": "block_count",
+            "valueUnsignedInt": 8
+          }
+        ]
+      }
+    }
+  ],
+  "type": "message",
+  "timestamp": "2022-04-18T00:00:00Z"
+}

--- a/projects/BFDR.Tests/fixtures/json/HeadlessMessage.json
+++ b/projects/BFDR.Tests/fixtures/json/HeadlessMessage.json
@@ -1,0 +1,1008 @@
+{
+  "resourceType": "Bundle",
+  "id": "9750e180-e24b-4946-abcf-e9b730965826",
+  "type": "message",
+  "timestamp": "2024-01-09T17:36:45.264648-05:00",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:18cf3dbd-6cab-413f-9074-9462c66a3ce1",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "18cf3dbd-6cab-413f-9074-9462c66a3ce1",
+        "parameter": [
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 48858
+          },
+          {
+            "name": "state_auxiliary_id",
+            "valueString": "000000000042"
+          },
+          {
+            "name": "event_year",
+            "valueUnsignedInt": 2019
+          },
+          {
+            "name": "jurisdiction_id",
+            "valueString": "UT"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:f731ac90-1e21-4744-9a02-f996c7a967b5",
+      "resource": {
+        "resourceType": "Bundle",
+        "id": "f731ac90-1e21-4744-9a02-f996c7a967b5",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/bfdr/StructureDefinition/Bundle-document-birth-report"
+          ]
+        },
+        "identifier": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/CertificateNumber",
+              "valueString": "48858"
+            },
+            {
+              "url": "http://hl7.org/fhir/us/bfdr/StructureDefinition/AuxiliaryStateIdentifier1",
+              "valueString": "000000000042"
+            }
+          ],
+          "system": "http://nchs.cdc.gov/bfdr_id",
+          "value": "2019UT48858"
+        },
+        "type": "document",
+        "timestamp": "2023-10-25T09:53:34.356012-04:00",
+        "entry": [
+          {
+            "fullUrl": "urn:uuid:2b03f731-a589-4190-b907-6fe6eddcec60",
+            "resource": {
+              "resourceType": "Composition",
+              "id": "2b03f731-a589-4190-b907-6fe6eddcec60",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Composition-jurisdiction-live-birth-report"
+                ]
+              },
+              "status": "final",
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "92011-6",
+                    "display": "Jurisdiction live birth report Document"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198930"
+              },
+              "title": "Birth Certificate",
+              "attester": [
+                {
+                  "mode": "legal"
+                }
+              ],
+              "event": [
+                {
+                  "code": [
+                    {
+                      "coding": [
+                        {
+                          "system": "http://snomed.info/sct",
+                          "code": "103693007",
+                          "display": "Diagnostic procedure (procedure)"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "section": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-document-section-cs",
+                        "code": "ChildDemographics"
+                      }
+                    ]
+                  },
+                  "entry": [
+                    {
+                      "reference": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198930"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198930",
+            "resource": {
+              "resourceType": "Patient",
+              "id": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198930",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Patient-child-vr"
+                ]
+              },
+              "text": {
+                "status": "generated",
+                "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p style=\"border: 1px #661aff solid; background-color: #e6e6ff; padding: 10px;\"><b>Baby G Quinn </b> female, DoB: 2019-02-12 ( Medical Record Number: 9932702 (use: USUAL))</p><hr/><table class=\"grid\"><tr><td style=\"background-color: #f3f5da\" title=\"Known multipleBirth status of Patient\">Multiple Birth:</td><td colspan=\"3\">1</td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.\">US Core Ethnicity Extension:</td><td colspan=\"3\"><ul><li>ombCategory: <a href=\"http://hl7.org/fhir/us/core/STU3.1.1/CodeSystem-cdcrec.html#cdcrec-2186-5\">Race &amp; Ethnicity - CDC</a> 2186-5: Not Hispanic or Latino</li><li>text: Not Hispanic or Latino</li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"The registered place of birth of the patient. A sytem may use the address.text if they don't store the birthPlace address in discrete elements.\"><a href=\"http://hl7.org/fhir/R4/extension-patient-birthplace.html\">Birth Place:</a></td><td colspan=\"3\"><ul><li>Salt Lake City UT </li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc). This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9).\"><a href=\"http://hl7.org/fhir/us/core/STU5.0.1/StructureDefinition-us-core-birthsex.html\">US Core Birth Sex Extension:</a></td><td colspan=\"3\"><ul><li>F</li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n - American Indian or Alaska Native\n - Asian\n - Black or African American\n - Native Hawaiian or Other Pacific Islander\n - White.\">US Core Race Extension:</td><td colspan=\"3\"><ul><li>ombCategory: <a href=\"http://hl7.org/fhir/us/core/STU3.1.1/CodeSystem-cdcrec.html#cdcrec-2106-3\">Race &amp; Ethnicity - CDC</a> 2106-3: White</li><li>text: White</li></ul></td></tr></table></div>"
+              },
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "ombCategory",
+                      "valueCoding": {
+                        "system": "urn:oid:2.16.840.1.113883.6.238",
+                        "code": "2106-3",
+                        "display": "White"
+                      }
+                    },
+                    {
+                      "url": "text",
+                      "valueString": "White"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "ombCategory",
+                      "valueCoding": {
+                        "system": "urn:oid:2.16.840.1.113883.6.238",
+                        "code": "2186-5",
+                        "display": "Not Hispanic or Latino"
+                      }
+                    },
+                    {
+                      "url": "text",
+                      "valueString": "Not Hispanic or Latino"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+                },
+                {
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+                  "valueCode": "F"
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+                  "valueAddress": {
+                    "city": "Salt Lake City",
+                    "district": "Salt Lake",
+                    "state": "UT"
+                  }
+                }
+              ],
+              "identifier": [
+                {
+                  "use": "usual",
+                  "type": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                        "code": "MR",
+                        "display": "Medical Record Number"
+                      }
+                    ]
+                  },
+                  "system": "http://hospital.smarthealthit.org",
+                  "value": "9932702"
+                }
+              ],
+              "name": [
+                {
+                  "use": "official",
+                  "family": "Quinn",
+                  "given": ["Baby", "G"],
+                  "suffix": ["III"]
+                }
+              ],
+              "gender": "female",
+              "birthDate": "2019-02-25",
+              "_birthDate": {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+                    "valueDateTime": "2019-02-25T13:00:00-07:00"
+                  }
+                ]
+              },
+              "multipleBirthInteger": 1
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198930-mother",
+            "resource": {
+              "resourceType": "Patient",
+              "id": "patient-mother-vr-jada-ann-quinn-common",
+              "meta": {
+                "profile": [
+                  "http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-Patient-mother-vr"
+                ]
+              },
+              "text": {
+                "status": "generated",
+                "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p style=\"border: 1px #661aff solid; background-color: #e6e6ff; padding: 10px;\"><b>Jada Ann Quinn (OFFICIAL)</b> female, DoB: 1985-01-15 ( Social Security number: <a href=\"http://terminology.hl7.org/5.0.0/NamingSystem-ssn.html\">#</a>132225986 (use: USUAL))</p><hr/><table class=\"grid\"><tr><td style=\"background-color: #f3f5da\" title=\"Other Ids (see the one above)\">Other Id:</td><td colspan=\"3\">Medical Record Number: 1032702 (use: USUAL)</td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Alternate names (see the one above)\">Alt. Name:</td><td colspan=\"3\">Jada Ann King (MAIDEN)</td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Ways to contact the Patient\">Contact Details:</td><td colspan=\"3\"><ul><li>ph: 1-(404)555-1212(HOME)</li><li><a href=\"mailto:jadaann.quinn@example.com\">jadaann.quinn@example.com</a></li><li>1875 West Morton Avenue Salt Lake City UT 84116 US (HOME)</li><li>1848 South 1300 East Salt Lake City UT 84401 US (BILLING)</li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.\">US Core Ethnicity Extension:</td><td colspan=\"3\"><ul><li>ombCategory: <a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-CDCREC.html#CDCREC-2186-5\">CDC Race and Ethnicity</a> 2186-5: Not Hispanic or Latino</li><li>text: Not Hispanic or Latino</li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"The registered place of birth of the patient. A sytem may use the address.text if they don't store the birthPlace address in discrete elements.\"><a href=\"http://hl7.org/fhir/R4/extension-patient-birthplace.html\">Birth Place:</a></td><td colspan=\"3\"><ul><li>UT </li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc). This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9).\"><a href=\"http://hl7.org/fhir/us/core/STU5.0.1/StructureDefinition-us-core-birthsex.html\">US Core Birth Sex Extension:</a></td><td colspan=\"3\"><ul><li>F</li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n - American Indian or Alaska Native\n - Asian\n - Black or African American\n - Native Hawaiian or Other Pacific Islander\n - White.\">US Core Race Extension:</td><td colspan=\"3\"><ul><li>ombCategory: <a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-CDCREC.html#CDCREC-1002-5\">CDC Race and Ethnicity</a> 1002-5: American Indian or Alaska Native</li><li>text: White, American Indian or Alaska Native</li></ul></td></tr></table></div>"
+              },
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "ombCategory",
+                      "valueCoding": {
+                        "system": "urn:oid:2.16.840.1.113883.6.238",
+                        "code": "1002-5",
+                        "display": "American Indian or Alaska Native"
+                      }
+                    },
+                    {
+                      "url": "text",
+                      "valueString": "White, American Indian or Alaska Native"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "ombCategory",
+                      "valueCoding": {
+                        "system": "urn:oid:2.16.840.1.113883.6.238",
+                        "code": "2186-5",
+                        "display": "Not Hispanic or Latino"
+                      }
+                    },
+                    {
+                      "url": "text",
+                      "valueString": "Not Hispanic or Latino"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+                },
+                {
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+                  "valueCode": "F"
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+                  "valueAddress": {
+                    "state": "UT"
+                  }
+                }
+              ],
+              "identifier": [
+                {
+                  "use": "usual",
+                  "type": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                        "code": "SS",
+                        "display": "Social Security number"
+                      }
+                    ]
+                  },
+                  "system": "http://hl7.org/fhir/sid/us-ssn",
+                  "value": "132225986"
+                },
+                {
+                  "use": "usual",
+                  "type": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                        "code": "MR",
+                        "display": "Medical Record Number"
+                      }
+                    ]
+                  },
+                  "system": "http://hospital.smarthealthit.org",
+                  "value": "1032702"
+                }
+              ],
+              "name": [
+                {
+                  "use": "official",
+                  "family": "Quinn",
+                  "given": ["Jada", "Ann"]
+                },
+                {
+                  "use": "maiden",
+                  "family": "King",
+                  "given": ["Jada", "Ann"]
+                }
+              ],
+              "telecom": [
+                {
+                  "system": "phone",
+                  "value": "1-(404)555-1212",
+                  "use": "home"
+                },
+                {
+                  "system": "email",
+                  "value": "jadaann.quinn@example.com"
+                }
+              ],
+              "gender": "female",
+              "birthDate": "1985-01-15",
+              "address": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-within-city-limits-indicator-vr",
+                      "valueCoding": {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "code": "Y",
+                        "display": "Yes"
+                      }
+                    }
+                  ],
+                  "use": "home",
+                  "line": ["1875 West Morton Avenue"],
+                  "city": "Salt Lake City",
+                  "district": "Salt Lake",
+                  "state": "UT",
+                  "postalCode": "84116",
+                  "country": "US"
+                },
+                {
+                  "use": "billing",
+                  "line": ["1848 South 1300 East"],
+                  "city": "Salt Lake City",
+                  "state": "UT",
+                  "postalCode": "84401",
+                  "country": "US"
+                }
+              ]
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198930-father",
+            "resource": {
+              "resourceType": "RelatedPerson",
+              "id": "relatedperson-father-natural-vr-james-brandon-quinn-common",
+              "meta": {
+                "profile": [
+                  "http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-RelatedPerson-father-natural-vr"
+                ]
+              },
+              "text": {
+                "status": "extensions",
+                "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: RelatedPerson</b><a name=\"relatedperson-father-natural-vr-james-brandon-quinn-common\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource RelatedPerson &quot;relatedperson-father-natural-vr-james-brandon-quinn-common&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-RelatedPerson-father-natural-vr.html\">RelatedPerson - Father Natural Vital Records</a></p></div><blockquote><p><b>US Core Race Extension</b></p><blockquote><p><b>url</b></p><code>ombCategory</code></blockquote><p><b>value</b>: White (Details: urn:oid:2.16.840.1.113883.6.238 code 2106-3 = '2106-3', stated as 'White')</p><blockquote><p><b>url</b></p><code>text</code></blockquote><p><b>value</b>: White</p></blockquote><blockquote><p><b>US Core Ethnicity Extension</b></p><blockquote><p><b>url</b></p><code>ombCategory</code></blockquote><p><b>value</b>: Not Hispanic or Latino (Details: urn:oid:2.16.840.1.113883.6.238 code 2186-5 = '2186-5', stated as 'Not Hispanic or Latino')</p><blockquote><p><b>url</b></p><code>text</code></blockquote><p><b>value</b>: Not Hispanic or Latino</p></blockquote><p><b>Extension - RelatedPerson Birth Place Vital Records</b>: NY </p><p><b>identifier</b>: Social Security number: <a href=\"http://terminology.hl7.org/5.0.0/NamingSystem-ssn.html\">#</a>132225987</p><p><b>active</b>: true</p><p><b>patient</b>: <a href=\"Patient-patient-child-vr-babyg-quinn-common.html\">Patient/patient-child-vr-babyg-quinn-common</a> &quot; QUINN&quot;</p><p><b>relationship</b>: Natural Father <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-v3-RoleCode.html\">RoleCode</a>#NFTH &quot;natural father&quot;)</span></p><p><b>name</b>: James Brandon Quinn (OFFICIAL)</p><p><b>gender</b>: male</p><p><b>birthDate</b>: 1972-11-24</p></div>"
+              },
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "ombCategory",
+                      "valueCoding": {
+                        "system": "urn:oid:2.16.840.1.113883.6.238",
+                        "code": "2106-3",
+                        "display": "White"
+                      }
+                    },
+                    {
+                      "url": "text",
+                      "valueString": "White"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "ombCategory",
+                      "valueCoding": {
+                        "system": "urn:oid:2.16.840.1.113883.6.238",
+                        "code": "2186-5",
+                        "display": "Not Hispanic or Latino"
+                      }
+                    },
+                    {
+                      "url": "text",
+                      "valueString": "Not Hispanic or Latino"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+                },
+                {
+                  "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-relatedperson-birthplace-vr",
+                  "valueAddress": {
+                    "state": "NY"
+                  }
+                }
+              ],
+              "identifier": [
+                {
+                  "type": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                        "code": "SS"
+                      }
+                    ]
+                  },
+                  "system": "http://hl7.org/fhir/sid/us-ssn",
+                  "value": "132225987"
+                }
+              ],
+              "active": true,
+              "patient": {
+                "reference": "Patient/patient-child-vr-babyg-quinn-common"
+              },
+              "relationship": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                      "code": "NFTH",
+                      "display": "natural father"
+                    }
+                  ],
+                  "text": "Natural Father"
+                }
+              ],
+              "name": [
+                {
+                  "use": "official",
+                  "family": "Quinn",
+                  "given": ["James", "Brandon"]
+                }
+              ],
+              "gender": "male",
+              "birthDate": "1972-11-24"
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198932",
+            "resource": {
+              "resourceType": "Observation",
+              "id": "observation-input-race-and-ethnicity-carmen-teresa-lee",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/input-race-and-ethnicity-vr"
+                ]
+              },
+              "text": {
+                "status": "generated",
+                "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: Observation</b><a name=\"observation-input-race-and-ethnicity-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-input-race-and-ethnicity-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/StructureDefinition-input-race-and-ethnicity-vr.html\">Observation - Input Race and Ethnicity Vital Records</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Race and Ethnicity Data submitted by Jurisdictions to NCHS <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-CodeSystem-local-observation-codes-vr.html\">CodeSystem - Local Observation Codes Vital Records</a>#inputraceandethnicityMother)</span></p><p><b>subject</b>: <a href=\"Patient-patient-mother-carmen-teresa-lee.html\">Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee)</a> &quot; LEE&quot;</p><blockquote><p><b>component</b></p><p><b>code</b>: White <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#White)</span></p><p><b>value</b>: true</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Black Or African American <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#BlackOrAfricanAmerican)</span></p><p><b>value</b>: true</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: American Indian Or Alaska Native <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#AmericanIndianOrAlaskanNative)</span></p><p><b>value</b>: true</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Asian Indian <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#AsianIndian)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Chinese <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Chinese)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Filipino <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Filipino)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Japanese <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Japanese)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Korean <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Korean)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Vietnamese <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Vietnamese)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Other Asian <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#OtherAsian)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Native Hawaiian <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#NativeHawaiian)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Guamanian Or Chamorro <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#GuamanianOrChamorro)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Samoan <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Samoan)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Other Pacific Islander <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#OtherPacificIslander)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Other Race <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#OtherRace)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: First Other Asian Literal <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#FirstOtherAsianLiteral)</span></p><p><b>value</b>: Malaysian</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: First American Indian Or Alaska Native Literal <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#FirstAmericanIndianOrAlaskanNativeLiteral)</span></p><p><b>value</b>: Arikara</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Hispanic Mexican <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#HispanicMexican)</span></p><p><b>value</b>: Yes <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#Y)</span></p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Hispanic Cuban <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#HispanicCuban)</span></p><p><b>value</b>: Yes <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#Y)</span></p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Hispanic Puerto Rican <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#HispanicPuertoRican)</span></p><p><b>value</b>: Yes <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#Y)</span></p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Hispanic Other <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#HispanicOther)</span></p><p><b>value</b>: No <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#N)</span></p></blockquote></div>"
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-local-observation-codes-vr",
+                    "code": "inputraceandethnicityMother"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/patient-mother-carmen-teresa-lee",
+                "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "White"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "BlackOrAfricanAmerican"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "AmericanIndianOrAlaskanNative"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "AsianIndian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Chinese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Filipino"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Japanese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Korean"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Vietnamese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "OtherAsian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "NativeHawaiian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "GuamanianOrChamorro"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Samoan"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "OtherPacificIslander"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "OtherRace"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicMexican"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "code": "Y",
+                        "display": "Yes"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicCuban"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "code": "UNK",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicPuertoRican"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "code": "UNK",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicOther"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "code": "UNK",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198936",
+            "resource": {
+              "resourceType": "Observation",
+              "id": "observation-input-race-and-ethnicity-bob-ray-lee",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/input-race-and-ethnicity-vr"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-local-observation-codes-vr",
+                    "code": "inputraceandethnicityFather"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/patient-father-bob-ray-lee",
+                "display": "Patient - Father (Bob Ray Lee)"
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "White"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "BlackOrAfricanAmerican"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "AmericanIndianOrAlaskanNative"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "AsianIndian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Chinese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Filipino"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Japanese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Korean"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Vietnamese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "OtherAsian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "NativeHawaiian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "GuamanianOrChamorro"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Samoan"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "OtherPacificIslander"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "OtherRace"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicMexican"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "code": "Y",
+                        "display": "Yes"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicCuban"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "code": "UNK",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicPuertoRican"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "code": "UNK",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicOther"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "code": "UNK",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/projects/BFDR.Tests/fixtures/json/InvalidMessage.json
+++ b/projects/BFDR.Tests/fixtures/json/InvalidMessage.json
@@ -1,0 +1,1029 @@
+{
+  "resourceType": "Bundle",
+  "id": "9750e180-e24b-4946-abcf-e9b730965826",
+  "type": "message",
+  "timestamp": "2024-01-09T17:36:45.264648-05:00",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:c36cfa0d-f3d4-4b1a-9df4-410f640b50c3",
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "c36cfa0d-f3d4-4b1a-9df4-410f640b50c3",
+        "eventUri": "http://nchs.cdc.gov/bogus_uri",
+        "destination": [
+          {
+            "endpoint": "http://nchs.cdc.gov/bfdr_submission"
+          }
+        ],
+        "source": {
+          "endpoint": "http://mitre.org/bfdr"
+        },
+        "focus": [
+          {
+            "reference": "urn:uuid:f731ac90-1e21-4744-9a02-f996c7a967b5"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:18cf3dbd-6cab-413f-9074-9462c66a3ce1",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "18cf3dbd-6cab-413f-9074-9462c66a3ce1",
+        "parameter": [
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 48858
+          },
+          {
+            "name": "state_auxiliary_id",
+            "valueString": "000000000042"
+          },
+          {
+            "name": "event_year",
+            "valueUnsignedInt": 2019
+          },
+          {
+            "name": "jurisdiction_id",
+            "valueString": "UT"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:f731ac90-1e21-4744-9a02-f996c7a967b5",
+      "resource": {
+        "resourceType": "Bundle",
+        "id": "f731ac90-1e21-4744-9a02-f996c7a967b5",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/bfdr/StructureDefinition/Bundle-document-birth-report"
+          ]
+        },
+        "identifier": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/CertificateNumber",
+              "valueString": "48858"
+            },
+            {
+              "url": "http://hl7.org/fhir/us/bfdr/StructureDefinition/AuxiliaryStateIdentifier1",
+              "valueString": "000000000042"
+            }
+          ],
+          "system": "http://nchs.cdc.gov/bfdr_id",
+          "value": "2019UT48858"
+        },
+        "type": "document",
+        "timestamp": "2023-10-25T09:53:34.356012-04:00",
+        "entry": [
+          {
+            "fullUrl": "urn:uuid:2b03f731-a589-4190-b907-6fe6eddcec60",
+            "resource": {
+              "resourceType": "Composition",
+              "id": "2b03f731-a589-4190-b907-6fe6eddcec60",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Composition-jurisdiction-live-birth-report"
+                ]
+              },
+              "status": "final",
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "92011-6",
+                    "display": "Jurisdiction live birth report Document"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198930"
+              },
+              "title": "Birth Certificate",
+              "attester": [
+                {
+                  "mode": "legal"
+                }
+              ],
+              "event": [
+                {
+                  "code": [
+                    {
+                      "coding": [
+                        {
+                          "system": "http://snomed.info/sct",
+                          "code": "103693007",
+                          "display": "Diagnostic procedure (procedure)"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "section": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-document-section-cs",
+                        "code": "ChildDemographics"
+                      }
+                    ]
+                  },
+                  "entry": [
+                    {
+                      "reference": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198930"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198930",
+            "resource": {
+              "resourceType": "Patient",
+              "id": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198930",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Patient-child-vr"
+                ]
+              },
+              "text": {
+                "status": "generated",
+                "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p style=\"border: 1px #661aff solid; background-color: #e6e6ff; padding: 10px;\"><b>Baby G Quinn </b> female, DoB: 2019-02-12 ( Medical Record Number: 9932702 (use: USUAL))</p><hr/><table class=\"grid\"><tr><td style=\"background-color: #f3f5da\" title=\"Known multipleBirth status of Patient\">Multiple Birth:</td><td colspan=\"3\">1</td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.\">US Core Ethnicity Extension:</td><td colspan=\"3\"><ul><li>ombCategory: <a href=\"http://hl7.org/fhir/us/core/STU3.1.1/CodeSystem-cdcrec.html#cdcrec-2186-5\">Race &amp; Ethnicity - CDC</a> 2186-5: Not Hispanic or Latino</li><li>text: Not Hispanic or Latino</li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"The registered place of birth of the patient. A sytem may use the address.text if they don't store the birthPlace address in discrete elements.\"><a href=\"http://hl7.org/fhir/R4/extension-patient-birthplace.html\">Birth Place:</a></td><td colspan=\"3\"><ul><li>Salt Lake City UT </li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc). This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9).\"><a href=\"http://hl7.org/fhir/us/core/STU5.0.1/StructureDefinition-us-core-birthsex.html\">US Core Birth Sex Extension:</a></td><td colspan=\"3\"><ul><li>F</li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n - American Indian or Alaska Native\n - Asian\n - Black or African American\n - Native Hawaiian or Other Pacific Islander\n - White.\">US Core Race Extension:</td><td colspan=\"3\"><ul><li>ombCategory: <a href=\"http://hl7.org/fhir/us/core/STU3.1.1/CodeSystem-cdcrec.html#cdcrec-2106-3\">Race &amp; Ethnicity - CDC</a> 2106-3: White</li><li>text: White</li></ul></td></tr></table></div>"
+              },
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "ombCategory",
+                      "valueCoding": {
+                        "system": "urn:oid:2.16.840.1.113883.6.238",
+                        "code": "2106-3",
+                        "display": "White"
+                      }
+                    },
+                    {
+                      "url": "text",
+                      "valueString": "White"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "ombCategory",
+                      "valueCoding": {
+                        "system": "urn:oid:2.16.840.1.113883.6.238",
+                        "code": "2186-5",
+                        "display": "Not Hispanic or Latino"
+                      }
+                    },
+                    {
+                      "url": "text",
+                      "valueString": "Not Hispanic or Latino"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+                },
+                {
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+                  "valueCode": "F"
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+                  "valueAddress": {
+                    "city": "Salt Lake City",
+                    "district": "Salt Lake",
+                    "state": "UT"
+                  }
+                }
+              ],
+              "identifier": [
+                {
+                  "use": "usual",
+                  "type": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                        "code": "MR",
+                        "display": "Medical Record Number"
+                      }
+                    ]
+                  },
+                  "system": "http://hospital.smarthealthit.org",
+                  "value": "9932702"
+                }
+              ],
+              "name": [
+                {
+                  "use": "official",
+                  "family": "Quinn",
+                  "given": ["Baby", "G"],
+                  "suffix": ["III"]
+                }
+              ],
+              "gender": "female",
+              "birthDate": "2019-02-25",
+              "_birthDate": {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+                    "valueDateTime": "2019-02-25T13:00:00-07:00"
+                  }
+                ]
+              },
+              "multipleBirthInteger": 1
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198930-mother",
+            "resource": {
+              "resourceType": "Patient",
+              "id": "patient-mother-vr-jada-ann-quinn-common",
+              "meta": {
+                "profile": [
+                  "http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-Patient-mother-vr"
+                ]
+              },
+              "text": {
+                "status": "generated",
+                "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p style=\"border: 1px #661aff solid; background-color: #e6e6ff; padding: 10px;\"><b>Jada Ann Quinn (OFFICIAL)</b> female, DoB: 1985-01-15 ( Social Security number: <a href=\"http://terminology.hl7.org/5.0.0/NamingSystem-ssn.html\">#</a>132225986 (use: USUAL))</p><hr/><table class=\"grid\"><tr><td style=\"background-color: #f3f5da\" title=\"Other Ids (see the one above)\">Other Id:</td><td colspan=\"3\">Medical Record Number: 1032702 (use: USUAL)</td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Alternate names (see the one above)\">Alt. Name:</td><td colspan=\"3\">Jada Ann King (MAIDEN)</td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Ways to contact the Patient\">Contact Details:</td><td colspan=\"3\"><ul><li>ph: 1-(404)555-1212(HOME)</li><li><a href=\"mailto:jadaann.quinn@example.com\">jadaann.quinn@example.com</a></li><li>1875 West Morton Avenue Salt Lake City UT 84116 US (HOME)</li><li>1848 South 1300 East Salt Lake City UT 84401 US (BILLING)</li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.\">US Core Ethnicity Extension:</td><td colspan=\"3\"><ul><li>ombCategory: <a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-CDCREC.html#CDCREC-2186-5\">CDC Race and Ethnicity</a> 2186-5: Not Hispanic or Latino</li><li>text: Not Hispanic or Latino</li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"The registered place of birth of the patient. A sytem may use the address.text if they don't store the birthPlace address in discrete elements.\"><a href=\"http://hl7.org/fhir/R4/extension-patient-birthplace.html\">Birth Place:</a></td><td colspan=\"3\"><ul><li>UT </li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc). This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9).\"><a href=\"http://hl7.org/fhir/us/core/STU5.0.1/StructureDefinition-us-core-birthsex.html\">US Core Birth Sex Extension:</a></td><td colspan=\"3\"><ul><li>F</li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n - American Indian or Alaska Native\n - Asian\n - Black or African American\n - Native Hawaiian or Other Pacific Islander\n - White.\">US Core Race Extension:</td><td colspan=\"3\"><ul><li>ombCategory: <a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-CDCREC.html#CDCREC-1002-5\">CDC Race and Ethnicity</a> 1002-5: American Indian or Alaska Native</li><li>text: White, American Indian or Alaska Native</li></ul></td></tr></table></div>"
+              },
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "ombCategory",
+                      "valueCoding": {
+                        "system": "urn:oid:2.16.840.1.113883.6.238",
+                        "code": "1002-5",
+                        "display": "American Indian or Alaska Native"
+                      }
+                    },
+                    {
+                      "url": "text",
+                      "valueString": "White, American Indian or Alaska Native"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "ombCategory",
+                      "valueCoding": {
+                        "system": "urn:oid:2.16.840.1.113883.6.238",
+                        "code": "2186-5",
+                        "display": "Not Hispanic or Latino"
+                      }
+                    },
+                    {
+                      "url": "text",
+                      "valueString": "Not Hispanic or Latino"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+                },
+                {
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+                  "valueCode": "F"
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+                  "valueAddress": {
+                    "state": "UT"
+                  }
+                }
+              ],
+              "identifier": [
+                {
+                  "use": "usual",
+                  "type": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                        "code": "SS",
+                        "display": "Social Security number"
+                      }
+                    ]
+                  },
+                  "system": "http://hl7.org/fhir/sid/us-ssn",
+                  "value": "132225986"
+                },
+                {
+                  "use": "usual",
+                  "type": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                        "code": "MR",
+                        "display": "Medical Record Number"
+                      }
+                    ]
+                  },
+                  "system": "http://hospital.smarthealthit.org",
+                  "value": "1032702"
+                }
+              ],
+              "name": [
+                {
+                  "use": "official",
+                  "family": "Quinn",
+                  "given": ["Jada", "Ann"]
+                },
+                {
+                  "use": "maiden",
+                  "family": "King",
+                  "given": ["Jada", "Ann"]
+                }
+              ],
+              "telecom": [
+                {
+                  "system": "phone",
+                  "value": "1-(404)555-1212",
+                  "use": "home"
+                },
+                {
+                  "system": "email",
+                  "value": "jadaann.quinn@example.com"
+                }
+              ],
+              "gender": "female",
+              "birthDate": "1985-01-15",
+              "address": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-within-city-limits-indicator-vr",
+                      "valueCoding": {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "code": "Y",
+                        "display": "Yes"
+                      }
+                    }
+                  ],
+                  "use": "home",
+                  "line": ["1875 West Morton Avenue"],
+                  "city": "Salt Lake City",
+                  "district": "Salt Lake",
+                  "state": "UT",
+                  "postalCode": "84116",
+                  "country": "US"
+                },
+                {
+                  "use": "billing",
+                  "line": ["1848 South 1300 East"],
+                  "city": "Salt Lake City",
+                  "state": "UT",
+                  "postalCode": "84401",
+                  "country": "US"
+                }
+              ]
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198930-father",
+            "resource": {
+              "resourceType": "RelatedPerson",
+              "id": "relatedperson-father-natural-vr-james-brandon-quinn-common",
+              "meta": {
+                "profile": [
+                  "http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-RelatedPerson-father-natural-vr"
+                ]
+              },
+              "text": {
+                "status": "extensions",
+                "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: RelatedPerson</b><a name=\"relatedperson-father-natural-vr-james-brandon-quinn-common\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource RelatedPerson &quot;relatedperson-father-natural-vr-james-brandon-quinn-common&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-RelatedPerson-father-natural-vr.html\">RelatedPerson - Father Natural Vital Records</a></p></div><blockquote><p><b>US Core Race Extension</b></p><blockquote><p><b>url</b></p><code>ombCategory</code></blockquote><p><b>value</b>: White (Details: urn:oid:2.16.840.1.113883.6.238 code 2106-3 = '2106-3', stated as 'White')</p><blockquote><p><b>url</b></p><code>text</code></blockquote><p><b>value</b>: White</p></blockquote><blockquote><p><b>US Core Ethnicity Extension</b></p><blockquote><p><b>url</b></p><code>ombCategory</code></blockquote><p><b>value</b>: Not Hispanic or Latino (Details: urn:oid:2.16.840.1.113883.6.238 code 2186-5 = '2186-5', stated as 'Not Hispanic or Latino')</p><blockquote><p><b>url</b></p><code>text</code></blockquote><p><b>value</b>: Not Hispanic or Latino</p></blockquote><p><b>Extension - RelatedPerson Birth Place Vital Records</b>: NY </p><p><b>identifier</b>: Social Security number: <a href=\"http://terminology.hl7.org/5.0.0/NamingSystem-ssn.html\">#</a>132225987</p><p><b>active</b>: true</p><p><b>patient</b>: <a href=\"Patient-patient-child-vr-babyg-quinn-common.html\">Patient/patient-child-vr-babyg-quinn-common</a> &quot; QUINN&quot;</p><p><b>relationship</b>: Natural Father <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-v3-RoleCode.html\">RoleCode</a>#NFTH &quot;natural father&quot;)</span></p><p><b>name</b>: James Brandon Quinn (OFFICIAL)</p><p><b>gender</b>: male</p><p><b>birthDate</b>: 1972-11-24</p></div>"
+              },
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "ombCategory",
+                      "valueCoding": {
+                        "system": "urn:oid:2.16.840.1.113883.6.238",
+                        "code": "2106-3",
+                        "display": "White"
+                      }
+                    },
+                    {
+                      "url": "text",
+                      "valueString": "White"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "ombCategory",
+                      "valueCoding": {
+                        "system": "urn:oid:2.16.840.1.113883.6.238",
+                        "code": "2186-5",
+                        "display": "Not Hispanic or Latino"
+                      }
+                    },
+                    {
+                      "url": "text",
+                      "valueString": "Not Hispanic or Latino"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+                },
+                {
+                  "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-relatedperson-birthplace-vr",
+                  "valueAddress": {
+                    "state": "NY"
+                  }
+                }
+              ],
+              "identifier": [
+                {
+                  "type": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                        "code": "SS"
+                      }
+                    ]
+                  },
+                  "system": "http://hl7.org/fhir/sid/us-ssn",
+                  "value": "132225987"
+                }
+              ],
+              "active": true,
+              "patient": {
+                "reference": "Patient/patient-child-vr-babyg-quinn-common"
+              },
+              "relationship": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                      "code": "NFTH",
+                      "display": "natural father"
+                    }
+                  ],
+                  "text": "Natural Father"
+                }
+              ],
+              "name": [
+                {
+                  "use": "official",
+                  "family": "Quinn",
+                  "given": ["James", "Brandon"]
+                }
+              ],
+              "gender": "male",
+              "birthDate": "1972-11-24"
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198932",
+            "resource": {
+              "resourceType": "Observation",
+              "id": "observation-input-race-and-ethnicity-carmen-teresa-lee",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/input-race-and-ethnicity-vr"
+                ]
+              },
+              "text": {
+                "status": "generated",
+                "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: Observation</b><a name=\"observation-input-race-and-ethnicity-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-input-race-and-ethnicity-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/StructureDefinition-input-race-and-ethnicity-vr.html\">Observation - Input Race and Ethnicity Vital Records</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Race and Ethnicity Data submitted by Jurisdictions to NCHS <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-CodeSystem-local-observation-codes-vr.html\">CodeSystem - Local Observation Codes Vital Records</a>#inputraceandethnicityMother)</span></p><p><b>subject</b>: <a href=\"Patient-patient-mother-carmen-teresa-lee.html\">Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee)</a> &quot; LEE&quot;</p><blockquote><p><b>component</b></p><p><b>code</b>: White <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#White)</span></p><p><b>value</b>: true</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Black Or African American <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#BlackOrAfricanAmerican)</span></p><p><b>value</b>: true</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: American Indian Or Alaska Native <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#AmericanIndianOrAlaskanNative)</span></p><p><b>value</b>: true</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Asian Indian <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#AsianIndian)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Chinese <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Chinese)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Filipino <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Filipino)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Japanese <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Japanese)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Korean <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Korean)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Vietnamese <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Vietnamese)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Other Asian <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#OtherAsian)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Native Hawaiian <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#NativeHawaiian)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Guamanian Or Chamorro <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#GuamanianOrChamorro)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Samoan <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Samoan)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Other Pacific Islander <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#OtherPacificIslander)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Other Race <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#OtherRace)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: First Other Asian Literal <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#FirstOtherAsianLiteral)</span></p><p><b>value</b>: Malaysian</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: First American Indian Or Alaska Native Literal <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#FirstAmericanIndianOrAlaskanNativeLiteral)</span></p><p><b>value</b>: Arikara</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Hispanic Mexican <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#HispanicMexican)</span></p><p><b>value</b>: Yes <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#Y)</span></p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Hispanic Cuban <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#HispanicCuban)</span></p><p><b>value</b>: Yes <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#Y)</span></p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Hispanic Puerto Rican <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#HispanicPuertoRican)</span></p><p><b>value</b>: Yes <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#Y)</span></p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Hispanic Other <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#HispanicOther)</span></p><p><b>value</b>: No <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#N)</span></p></blockquote></div>"
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-local-observation-codes-vr",
+                    "code": "inputraceandethnicityMother"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/patient-mother-carmen-teresa-lee",
+                "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "White"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "BlackOrAfricanAmerican"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "AmericanIndianOrAlaskanNative"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "AsianIndian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Chinese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Filipino"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Japanese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Korean"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Vietnamese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "OtherAsian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "NativeHawaiian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "GuamanianOrChamorro"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Samoan"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "OtherPacificIslander"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "OtherRace"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicMexican"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "code": "Y",
+                        "display": "Yes"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicCuban"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "code": "UNK",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicPuertoRican"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "code": "UNK",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicOther"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "code": "UNK",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198936",
+            "resource": {
+              "resourceType": "Observation",
+              "id": "observation-input-race-and-ethnicity-bob-ray-lee",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/input-race-and-ethnicity-vr"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-local-observation-codes-vr",
+                    "code": "inputraceandethnicityFather"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/patient-father-bob-ray-lee",
+                "display": "Patient - Father (Bob Ray Lee)"
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "White"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "BlackOrAfricanAmerican"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "AmericanIndianOrAlaskanNative"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "AsianIndian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Chinese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Filipino"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Japanese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Korean"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Vietnamese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "OtherAsian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "NativeHawaiian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "GuamanianOrChamorro"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Samoan"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "OtherPacificIslander"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "OtherRace"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicMexican"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "code": "Y",
+                        "display": "Yes"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicCuban"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "code": "UNK",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicPuertoRican"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "code": "UNK",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicOther"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "code": "UNK",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/projects/BFDR.Tests/fixtures/json/MissingMessage.json
+++ b/projects/BFDR.Tests/fixtures/json/MissingMessage.json
@@ -1,0 +1,1028 @@
+{
+  "resourceType": "Bundle",
+  "id": "9750e180-e24b-4946-abcf-e9b730965826",
+  "type": "message",
+  "timestamp": "2024-01-09T17:36:45.264648-05:00",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:c36cfa0d-f3d4-4b1a-9df4-410f640b50c3",
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "c36cfa0d-f3d4-4b1a-9df4-410f640b50c3",
+        "destination": [
+          {
+            "endpoint": "http://nchs.cdc.gov/bfdr_submission"
+          }
+        ],
+        "source": {
+          "endpoint": "http://mitre.org/bfdr"
+        },
+        "focus": [
+          {
+            "reference": "urn:uuid:f731ac90-1e21-4744-9a02-f996c7a967b5"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:18cf3dbd-6cab-413f-9074-9462c66a3ce1",
+      "resource": {
+        "resourceType": "Parameters",
+        "id": "18cf3dbd-6cab-413f-9074-9462c66a3ce1",
+        "parameter": [
+          {
+            "name": "cert_no",
+            "valueUnsignedInt": 48858
+          },
+          {
+            "name": "state_auxiliary_id",
+            "valueString": "000000000042"
+          },
+          {
+            "name": "event_year",
+            "valueUnsignedInt": 2019
+          },
+          {
+            "name": "jurisdiction_id",
+            "valueString": "UT"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:f731ac90-1e21-4744-9a02-f996c7a967b5",
+      "resource": {
+        "resourceType": "Bundle",
+        "id": "f731ac90-1e21-4744-9a02-f996c7a967b5",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/us/bfdr/StructureDefinition/Bundle-document-birth-report"
+          ]
+        },
+        "identifier": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/CertificateNumber",
+              "valueString": "48858"
+            },
+            {
+              "url": "http://hl7.org/fhir/us/bfdr/StructureDefinition/AuxiliaryStateIdentifier1",
+              "valueString": "000000000042"
+            }
+          ],
+          "system": "http://nchs.cdc.gov/bfdr_id",
+          "value": "2019UT48858"
+        },
+        "type": "document",
+        "timestamp": "2023-10-25T09:53:34.356012-04:00",
+        "entry": [
+          {
+            "fullUrl": "urn:uuid:2b03f731-a589-4190-b907-6fe6eddcec60",
+            "resource": {
+              "resourceType": "Composition",
+              "id": "2b03f731-a589-4190-b907-6fe6eddcec60",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/bfdr/StructureDefinition/Composition-jurisdiction-live-birth-report"
+                ]
+              },
+              "status": "final",
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://loinc.org",
+                    "code": "92011-6",
+                    "display": "Jurisdiction live birth report Document"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198930"
+              },
+              "title": "Birth Certificate",
+              "attester": [
+                {
+                  "mode": "legal"
+                }
+              ],
+              "event": [
+                {
+                  "code": [
+                    {
+                      "coding": [
+                        {
+                          "system": "http://snomed.info/sct",
+                          "code": "103693007",
+                          "display": "Diagnostic procedure (procedure)"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "section": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vrdr/CodeSystem/vrdr-document-section-cs",
+                        "code": "ChildDemographics"
+                      }
+                    ]
+                  },
+                  "entry": [
+                    {
+                      "reference": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198930"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198930",
+            "resource": {
+              "resourceType": "Patient",
+              "id": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198930",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Patient-child-vr"
+                ]
+              },
+              "text": {
+                "status": "generated",
+                "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p style=\"border: 1px #661aff solid; background-color: #e6e6ff; padding: 10px;\"><b>Baby G Quinn </b> female, DoB: 2019-02-12 ( Medical Record Number: 9932702 (use: USUAL))</p><hr/><table class=\"grid\"><tr><td style=\"background-color: #f3f5da\" title=\"Known multipleBirth status of Patient\">Multiple Birth:</td><td colspan=\"3\">1</td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.\">US Core Ethnicity Extension:</td><td colspan=\"3\"><ul><li>ombCategory: <a href=\"http://hl7.org/fhir/us/core/STU3.1.1/CodeSystem-cdcrec.html#cdcrec-2186-5\">Race &amp; Ethnicity - CDC</a> 2186-5: Not Hispanic or Latino</li><li>text: Not Hispanic or Latino</li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"The registered place of birth of the patient. A sytem may use the address.text if they don't store the birthPlace address in discrete elements.\"><a href=\"http://hl7.org/fhir/R4/extension-patient-birthplace.html\">Birth Place:</a></td><td colspan=\"3\"><ul><li>Salt Lake City UT </li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc). This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9).\"><a href=\"http://hl7.org/fhir/us/core/STU5.0.1/StructureDefinition-us-core-birthsex.html\">US Core Birth Sex Extension:</a></td><td colspan=\"3\"><ul><li>F</li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n - American Indian or Alaska Native\n - Asian\n - Black or African American\n - Native Hawaiian or Other Pacific Islander\n - White.\">US Core Race Extension:</td><td colspan=\"3\"><ul><li>ombCategory: <a href=\"http://hl7.org/fhir/us/core/STU3.1.1/CodeSystem-cdcrec.html#cdcrec-2106-3\">Race &amp; Ethnicity - CDC</a> 2106-3: White</li><li>text: White</li></ul></td></tr></table></div>"
+              },
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "ombCategory",
+                      "valueCoding": {
+                        "system": "urn:oid:2.16.840.1.113883.6.238",
+                        "code": "2106-3",
+                        "display": "White"
+                      }
+                    },
+                    {
+                      "url": "text",
+                      "valueString": "White"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "ombCategory",
+                      "valueCoding": {
+                        "system": "urn:oid:2.16.840.1.113883.6.238",
+                        "code": "2186-5",
+                        "display": "Not Hispanic or Latino"
+                      }
+                    },
+                    {
+                      "url": "text",
+                      "valueString": "Not Hispanic or Latino"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+                },
+                {
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+                  "valueCode": "F"
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+                  "valueAddress": {
+                    "city": "Salt Lake City",
+                    "district": "Salt Lake",
+                    "state": "UT"
+                  }
+                }
+              ],
+              "identifier": [
+                {
+                  "use": "usual",
+                  "type": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                        "code": "MR",
+                        "display": "Medical Record Number"
+                      }
+                    ]
+                  },
+                  "system": "http://hospital.smarthealthit.org",
+                  "value": "9932702"
+                }
+              ],
+              "name": [
+                {
+                  "use": "official",
+                  "family": "Quinn",
+                  "given": ["Baby", "G"],
+                  "suffix": ["III"]
+                }
+              ],
+              "gender": "female",
+              "birthDate": "2019-02-25",
+              "_birthDate": {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/patient-birthTime",
+                    "valueDateTime": "2019-02-25T13:00:00-07:00"
+                  }
+                ]
+              },
+              "multipleBirthInteger": 1
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198930-mother",
+            "resource": {
+              "resourceType": "Patient",
+              "id": "patient-mother-vr-jada-ann-quinn-common",
+              "meta": {
+                "profile": [
+                  "http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-Patient-mother-vr"
+                ]
+              },
+              "text": {
+                "status": "generated",
+                "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p style=\"border: 1px #661aff solid; background-color: #e6e6ff; padding: 10px;\"><b>Jada Ann Quinn (OFFICIAL)</b> female, DoB: 1985-01-15 ( Social Security number: <a href=\"http://terminology.hl7.org/5.0.0/NamingSystem-ssn.html\">#</a>132225986 (use: USUAL))</p><hr/><table class=\"grid\"><tr><td style=\"background-color: #f3f5da\" title=\"Other Ids (see the one above)\">Other Id:</td><td colspan=\"3\">Medical Record Number: 1032702 (use: USUAL)</td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Alternate names (see the one above)\">Alt. Name:</td><td colspan=\"3\">Jada Ann King (MAIDEN)</td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Ways to contact the Patient\">Contact Details:</td><td colspan=\"3\"><ul><li>ph: 1-(404)555-1212(HOME)</li><li><a href=\"mailto:jadaann.quinn@example.com\">jadaann.quinn@example.com</a></li><li>1875 West Morton Avenue Salt Lake City UT 84116 US (HOME)</li><li>1848 South 1300 East Salt Lake City UT 84401 US (BILLING)</li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The ethnicity codes used to represent these concepts are based upon the [CDC ethnicity and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 43 reference ethnicity.  The ethnicity concepts are grouped by and pre-mapped to the 2 OMB ethnicity categories: - Hispanic or Latino - Not Hispanic or Latino.\">US Core Ethnicity Extension:</td><td colspan=\"3\"><ul><li>ombCategory: <a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-CDCREC.html#CDCREC-2186-5\">CDC Race and Ethnicity</a> 2186-5: Not Hispanic or Latino</li><li>text: Not Hispanic or Latino</li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"The registered place of birth of the patient. A sytem may use the address.text if they don't store the birthPlace address in discrete elements.\"><a href=\"http://hl7.org/fhir/R4/extension-patient-birthplace.html\">Birth Place:</a></td><td colspan=\"3\"><ul><li>UT </li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"A code classifying the person's sex assigned at birth  as specified by the [Office of the National Coordinator for Health IT (ONC)](https://www.healthit.gov/newsroom/about-onc). This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9).\"><a href=\"http://hl7.org/fhir/us/core/STU5.0.1/StructureDefinition-us-core-birthsex.html\">US Core Birth Sex Extension:</a></td><td colspan=\"3\"><ul><li>F</li></ul></td></tr><tr><td style=\"background-color: #f3f5da\" title=\"Concepts classifying the person into a named category of humans sharing common history, traits, geographical origin or nationality.  The race codes used to represent these concepts are based upon the [CDC Race and Ethnicity Code Set Version 1.0](http://www.cdc.gov/phin/resources/vocabulary/index.html) which includes over 900 concepts for representing race and ethnicity of which 921 reference race.  The race concepts are grouped by and pre-mapped to the 5 OMB race categories:\n\n - American Indian or Alaska Native\n - Asian\n - Black or African American\n - Native Hawaiian or Other Pacific Islander\n - White.\">US Core Race Extension:</td><td colspan=\"3\"><ul><li>ombCategory: <a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-CDCREC.html#CDCREC-1002-5\">CDC Race and Ethnicity</a> 1002-5: American Indian or Alaska Native</li><li>text: White, American Indian or Alaska Native</li></ul></td></tr></table></div>"
+              },
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "ombCategory",
+                      "valueCoding": {
+                        "system": "urn:oid:2.16.840.1.113883.6.238",
+                        "code": "1002-5",
+                        "display": "American Indian or Alaska Native"
+                      }
+                    },
+                    {
+                      "url": "text",
+                      "valueString": "White, American Indian or Alaska Native"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "ombCategory",
+                      "valueCoding": {
+                        "system": "urn:oid:2.16.840.1.113883.6.238",
+                        "code": "2186-5",
+                        "display": "Not Hispanic or Latino"
+                      }
+                    },
+                    {
+                      "url": "text",
+                      "valueString": "Not Hispanic or Latino"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+                },
+                {
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+                  "valueCode": "F"
+                },
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+                  "valueAddress": {
+                    "state": "UT"
+                  }
+                }
+              ],
+              "identifier": [
+                {
+                  "use": "usual",
+                  "type": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                        "code": "SS",
+                        "display": "Social Security number"
+                      }
+                    ]
+                  },
+                  "system": "http://hl7.org/fhir/sid/us-ssn",
+                  "value": "132225986"
+                },
+                {
+                  "use": "usual",
+                  "type": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                        "code": "MR",
+                        "display": "Medical Record Number"
+                      }
+                    ]
+                  },
+                  "system": "http://hospital.smarthealthit.org",
+                  "value": "1032702"
+                }
+              ],
+              "name": [
+                {
+                  "use": "official",
+                  "family": "Quinn",
+                  "given": ["Jada", "Ann"]
+                },
+                {
+                  "use": "maiden",
+                  "family": "King",
+                  "given": ["Jada", "Ann"]
+                }
+              ],
+              "telecom": [
+                {
+                  "system": "phone",
+                  "value": "1-(404)555-1212",
+                  "use": "home"
+                },
+                {
+                  "system": "email",
+                  "value": "jadaann.quinn@example.com"
+                }
+              ],
+              "gender": "female",
+              "birthDate": "1985-01-15",
+              "address": [
+                {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-within-city-limits-indicator-vr",
+                      "valueCoding": {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "code": "Y",
+                        "display": "Yes"
+                      }
+                    }
+                  ],
+                  "use": "home",
+                  "line": ["1875 West Morton Avenue"],
+                  "city": "Salt Lake City",
+                  "district": "Salt Lake",
+                  "state": "UT",
+                  "postalCode": "84116",
+                  "country": "US"
+                },
+                {
+                  "use": "billing",
+                  "line": ["1848 South 1300 East"],
+                  "city": "Salt Lake City",
+                  "state": "UT",
+                  "postalCode": "84401",
+                  "country": "US"
+                }
+              ]
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198930-father",
+            "resource": {
+              "resourceType": "RelatedPerson",
+              "id": "relatedperson-father-natural-vr-james-brandon-quinn-common",
+              "meta": {
+                "profile": [
+                  "http://build.fhir.org/ig/HL7/vr-common-library/StructureDefinition-RelatedPerson-father-natural-vr"
+                ]
+              },
+              "text": {
+                "status": "extensions",
+                "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: RelatedPerson</b><a name=\"relatedperson-father-natural-vr-james-brandon-quinn-common\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource RelatedPerson &quot;relatedperson-father-natural-vr-james-brandon-quinn-common&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-RelatedPerson-father-natural-vr.html\">RelatedPerson - Father Natural Vital Records</a></p></div><blockquote><p><b>US Core Race Extension</b></p><blockquote><p><b>url</b></p><code>ombCategory</code></blockquote><p><b>value</b>: White (Details: urn:oid:2.16.840.1.113883.6.238 code 2106-3 = '2106-3', stated as 'White')</p><blockquote><p><b>url</b></p><code>text</code></blockquote><p><b>value</b>: White</p></blockquote><blockquote><p><b>US Core Ethnicity Extension</b></p><blockquote><p><b>url</b></p><code>ombCategory</code></blockquote><p><b>value</b>: Not Hispanic or Latino (Details: urn:oid:2.16.840.1.113883.6.238 code 2186-5 = '2186-5', stated as 'Not Hispanic or Latino')</p><blockquote><p><b>url</b></p><code>text</code></blockquote><p><b>value</b>: Not Hispanic or Latino</p></blockquote><p><b>Extension - RelatedPerson Birth Place Vital Records</b>: NY </p><p><b>identifier</b>: Social Security number: <a href=\"http://terminology.hl7.org/5.0.0/NamingSystem-ssn.html\">#</a>132225987</p><p><b>active</b>: true</p><p><b>patient</b>: <a href=\"Patient-patient-child-vr-babyg-quinn-common.html\">Patient/patient-child-vr-babyg-quinn-common</a> &quot; QUINN&quot;</p><p><b>relationship</b>: Natural Father <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://terminology.hl7.org/5.0.0/CodeSystem-v3-RoleCode.html\">RoleCode</a>#NFTH &quot;natural father&quot;)</span></p><p><b>name</b>: James Brandon Quinn (OFFICIAL)</p><p><b>gender</b>: male</p><p><b>birthDate</b>: 1972-11-24</p></div>"
+              },
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "ombCategory",
+                      "valueCoding": {
+                        "system": "urn:oid:2.16.840.1.113883.6.238",
+                        "code": "2106-3",
+                        "display": "White"
+                      }
+                    },
+                    {
+                      "url": "text",
+                      "valueString": "White"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+                },
+                {
+                  "extension": [
+                    {
+                      "url": "ombCategory",
+                      "valueCoding": {
+                        "system": "urn:oid:2.16.840.1.113883.6.238",
+                        "code": "2186-5",
+                        "display": "Not Hispanic or Latino"
+                      }
+                    },
+                    {
+                      "url": "text",
+                      "valueString": "Not Hispanic or Latino"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+                },
+                {
+                  "url": "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/Extension-relatedperson-birthplace-vr",
+                  "valueAddress": {
+                    "state": "NY"
+                  }
+                }
+              ],
+              "identifier": [
+                {
+                  "type": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                        "code": "SS"
+                      }
+                    ]
+                  },
+                  "system": "http://hl7.org/fhir/sid/us-ssn",
+                  "value": "132225987"
+                }
+              ],
+              "active": true,
+              "patient": {
+                "reference": "Patient/patient-child-vr-babyg-quinn-common"
+              },
+              "relationship": [
+                {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
+                      "code": "NFTH",
+                      "display": "natural father"
+                    }
+                  ],
+                  "text": "Natural Father"
+                }
+              ],
+              "name": [
+                {
+                  "use": "official",
+                  "family": "Quinn",
+                  "given": ["James", "Brandon"]
+                }
+              ],
+              "gender": "male",
+              "birthDate": "1972-11-24"
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198932",
+            "resource": {
+              "resourceType": "Observation",
+              "id": "observation-input-race-and-ethnicity-carmen-teresa-lee",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/input-race-and-ethnicity-vr"
+                ]
+              },
+              "text": {
+                "status": "generated",
+                "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: Observation</b><a name=\"observation-input-race-and-ethnicity-carmen-teresa-lee\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource Observation &quot;observation-input-race-and-ethnicity-carmen-teresa-lee&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/StructureDefinition-input-race-and-ethnicity-vr.html\">Observation - Input Race and Ethnicity Vital Records</a></p></div><p><b>status</b>: final</p><p><b>code</b>: Race and Ethnicity Data submitted by Jurisdictions to NCHS <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-CodeSystem-local-observation-codes-vr.html\">CodeSystem - Local Observation Codes Vital Records</a>#inputraceandethnicityMother)</span></p><p><b>subject</b>: <a href=\"Patient-patient-mother-carmen-teresa-lee.html\">Patient/patient-mother-carmen-teresa-lee: Patient - Mother (Carmen Teresa Lee)</a> &quot; LEE&quot;</p><blockquote><p><b>component</b></p><p><b>code</b>: White <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#White)</span></p><p><b>value</b>: true</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Black Or African American <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#BlackOrAfricanAmerican)</span></p><p><b>value</b>: true</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: American Indian Or Alaska Native <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#AmericanIndianOrAlaskanNative)</span></p><p><b>value</b>: true</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Asian Indian <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#AsianIndian)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Chinese <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Chinese)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Filipino <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Filipino)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Japanese <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Japanese)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Korean <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Korean)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Vietnamese <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Vietnamese)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Other Asian <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#OtherAsian)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Native Hawaiian <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#NativeHawaiian)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Guamanian Or Chamorro <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#GuamanianOrChamorro)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Samoan <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#Samoan)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Other Pacific Islander <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#OtherPacificIslander)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Other Race <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#OtherRace)</span></p><p><b>value</b>: false</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: First Other Asian Literal <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#FirstOtherAsianLiteral)</span></p><p><b>value</b>: Malaysian</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: First American Indian Or Alaska Native Literal <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#FirstAmericanIndianOrAlaskanNativeLiteral)</span></p><p><b>value</b>: Arikara</p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Hispanic Mexican <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#HispanicMexican)</span></p><p><b>value</b>: Yes <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#Y)</span></p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Hispanic Cuban <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#HispanicCuban)</span></p><p><b>value</b>: Yes <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#Y)</span></p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Hispanic Puerto Rican <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#HispanicPuertoRican)</span></p><p><b>value</b>: Yes <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#Y)</span></p></blockquote><blockquote><p><b>component</b></p><p><b>code</b>: Hispanic Other <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/vr-common-library/2024Jan/CodeSystem-codesystem-vr-component.html\">Local Component Codes</a>#HispanicOther)</span></p><p><b>value</b>: No <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/R4/v2/0136/index.html\">v2 Y/N Indicator</a>#N)</span></p></blockquote></div>"
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-local-observation-codes-vr",
+                    "code": "inputraceandethnicityMother"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/patient-mother-carmen-teresa-lee",
+                "display": "Patient - Mother (Carmen Teresa Lee)"
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "White"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "BlackOrAfricanAmerican"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "AmericanIndianOrAlaskanNative"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "AsianIndian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Chinese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Filipino"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Japanese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Korean"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Vietnamese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "OtherAsian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "NativeHawaiian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "GuamanianOrChamorro"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Samoan"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "OtherPacificIslander"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "OtherRace"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicMexican"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "code": "Y",
+                        "display": "Yes"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicCuban"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "code": "UNK",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicPuertoRican"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "code": "UNK",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicOther"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "code": "UNK",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "fullUrl": "urn:uuid:9b0abc88-167d-460e-9a02-af7524198936",
+            "resource": {
+              "resourceType": "Observation",
+              "id": "observation-input-race-and-ethnicity-bob-ray-lee",
+              "meta": {
+                "profile": [
+                  "http://hl7.org/fhir/us/vr-common-library/StructureDefinition/input-race-and-ethnicity-vr"
+                ]
+              },
+              "status": "final",
+              "code": {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-local-observation-codes-vr",
+                    "code": "inputraceandethnicityFather"
+                  }
+                ]
+              },
+              "subject": {
+                "reference": "Patient/patient-father-bob-ray-lee",
+                "display": "Patient - Father (Bob Ray Lee)"
+              },
+              "component": [
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "White"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "BlackOrAfricanAmerican"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "AmericanIndianOrAlaskanNative"
+                      }
+                    ]
+                  },
+                  "valueBoolean": true
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "AsianIndian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Chinese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Filipino"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Japanese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Korean"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Vietnamese"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "OtherAsian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "NativeHawaiian"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "GuamanianOrChamorro"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "Samoan"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "OtherPacificIslander"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "OtherRace"
+                      }
+                    ]
+                  },
+                  "valueBoolean": false
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicMexican"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v2-0136",
+                        "code": "Y",
+                        "display": "Yes"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicCuban"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "code": "UNK",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicPuertoRican"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "code": "UNK",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "code": {
+                    "coding": [
+                      {
+                        "system": "http://hl7.org/fhir/us/vr-common-library/CodeSystem/codesystem-vr-component",
+                        "code": "HispanicOther"
+                      }
+                    ]
+                  },
+                  "valueCodeableConcept": {
+                    "coding": [
+                      {
+                        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+                        "code": "UNK",
+                        "display": "Unknown"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Add tests to BFDR.Messaging classes such that reported test line coverage is as close to 100% as possible. In most cases, 100% line coverage is reached. Exceptions to this are:

BFDRBaseMessage
33-35: Unreachable. The condition on line 32 can't be met due to an identical condition in the base constructor.
281-284, 287-290: Unreachable. These classes are abstract, so the message type will never match these values.

BFDRAcknowledgementMessage
117-120: Unreachable. Header.Response is guaranteed to be non-null here.

BFDRParentalDemographicsCodingMessage
256-259: Unreachable. Header.Response is guaranteed to be non-null here.

BFDRErrorMessage
135-138: Unreachable. Header.Response is guaranteed to be non-null here.

Addresses Jira issue 763.