### PR TITLE
fix(bfdr): deleted fields return blank strings

### DIFF
--- a/projects/BFDR.CLI/Program.cs
+++ b/projects/BFDR.CLI/Program.cs
@@ -58,7 +58,7 @@ namespace BFDR.CLI
                 Console.WriteLine(commands);
                 return (0);
             }
-            else if (args.Length == 2 && args[0] == "fakerecord" && args[1] == "birth" )
+            else if (args.Length == 2 && args[0] == "fakerecord" && args[1] == "birth")
             {
                 // 0. Set up a BirthRecord object
                 BirthRecord birthRecord = new BirthRecord();
@@ -81,10 +81,10 @@ namespace BFDR.CLI
                 birthRecord.CertifierName = "Janet Seito";
                 birthRecord.CertifierNPI = "223347044";
                 birthRecord.CertifierTitleHelper = "76231001";
-                birthRecord.AttendantName ="Avery Jones";
+                birthRecord.AttendantName = "Avery Jones";
                 birthRecord.AttendantNPI = "762310012345";
                 birthRecord.AttendantTitleHelper = "76231001";
-               
+
 
                 birthRecord.EventLocationJurisdiction = "MA";
                 Dictionary<string, string> birthAddress = new Dictionary<string, string>();
@@ -149,9 +149,9 @@ namespace BFDR.CLI
                 birthRecord.MotherEthnicityLiteral = "Colombian";
                 birthRecord.MotherEthnicity3Helper = VR.ValueSets.YesNoUnknown.Yes;
                 // Mother and Father Race
-                Tuple<string, string>[] motherRace = { Tuple.Create(NvssRace.BlackOrAfricanAmerican, "Y")};
+                Tuple<string, string>[] motherRace = { Tuple.Create(NvssRace.BlackOrAfricanAmerican, "Y") };
                 birthRecord.MotherRace = motherRace;
-                Tuple<string, string>[] fatherRace = { Tuple.Create(NvssRace.White, "Y")};
+                Tuple<string, string>[] fatherRace = { Tuple.Create(NvssRace.White, "Y") };
                 birthRecord.FatherRace = fatherRace;
 
 
@@ -160,7 +160,7 @@ namespace BFDR.CLI
 
                 return 0;
             }
-            else if (args.Length == 2 && args[0] == "fakerecord" && args[1] == "fetaldeath" )
+            else if (args.Length == 2 && args[0] == "fakerecord" && args[1] == "fetaldeath")
             {
                 // 0. Set up a FetalDeathRecord object
                 FetalDeathRecord fetaldeathRecord = new FetalDeathRecord();
@@ -183,10 +183,10 @@ namespace BFDR.CLI
                 fetaldeathRecord.CertifierName = "Janet Seito";
                 fetaldeathRecord.CertifierNPI = "223347044";
                 fetaldeathRecord.CertifierTitleHelper = "76231001";
-                fetaldeathRecord.AttendantName ="Avery Jones";
+                fetaldeathRecord.AttendantName = "Avery Jones";
                 fetaldeathRecord.AttendantNPI = "762310012345";
                 fetaldeathRecord.AttendantTitleHelper = "76231001";
-               
+
 
                 fetaldeathRecord.EventLocationJurisdiction = "MA";
                 Dictionary<string, string> deliveryAddress = new Dictionary<string, string>();
@@ -204,8 +204,6 @@ namespace BFDR.CLI
 
                 fetaldeathRecord.FetalDeathSetOrder = null;
                 fetaldeathRecord.FetalDeathPlurality = null;
-                fetaldeathRecord.CyanoticCongenitalHeartDisease = true;
-                fetaldeathRecord.NoCongenitalAnomaliesOfTheNewborn = true;
                 fetaldeathRecord.EpiduralOrSpinalAnesthesia = true;
                 fetaldeathRecord.AugmentationOfLabor = true;
                 fetaldeathRecord.NoSpecifiedAbnormalConditionsOfNewborn = true;
@@ -252,9 +250,9 @@ namespace BFDR.CLI
                 fetaldeathRecord.MotherEthnicityLiteral = "Colombian";
                 fetaldeathRecord.MotherEthnicity3Helper = VR.ValueSets.YesNoUnknown.Yes;
                 // Mother and Father Race
-                Tuple<string, string>[] motherRace = { Tuple.Create(NvssRace.BlackOrAfricanAmerican, "Y")};
+                Tuple<string, string>[] motherRace = { Tuple.Create(NvssRace.BlackOrAfricanAmerican, "Y") };
                 fetaldeathRecord.MotherRace = motherRace;
-                Tuple<string, string>[] fatherRace = { Tuple.Create(NvssRace.White, "Y")};
+                Tuple<string, string>[] fatherRace = { Tuple.Create(NvssRace.White, "Y") };
                 fetaldeathRecord.FatherRace = fatherRace;
 
 
@@ -339,19 +337,19 @@ namespace BFDR.CLI
             }
             else if (args.Length > 2 && args[0] == "ije2json")
             {
-              // This command will export the files to the same directory they were imported from.
-              for (int i = 1; i < args.Length; i++)
-              {
-                  string ijeFile = args[i];
-                  string ijeRawRecord = File.ReadAllText(ijeFile);
-                  IJEBirth ije = new IJEBirth(ijeRawRecord);
-                  BirthRecord b = ije.ToRecord();
-                  string outputFilename = ijeFile.Replace(".ije", ".json");
-                  StreamWriter sw = new StreamWriter(outputFilename);
-                  sw.WriteLine(b.ToJSON());
-                  sw.Flush();
-              }
-              return 0;
+                // This command will export the files to the same directory they were imported from.
+                for (int i = 1; i < args.Length; i++)
+                {
+                    string ijeFile = args[i];
+                    string ijeRawRecord = File.ReadAllText(ijeFile);
+                    IJEBirth ije = new IJEBirth(ijeRawRecord);
+                    BirthRecord b = ije.ToRecord();
+                    string outputFilename = ijeFile.Replace(".ije", ".json");
+                    StreamWriter sw = new StreamWriter(outputFilename);
+                    sw.WriteLine(b.ToJSON());
+                    sw.Flush();
+                }
+                return 0;
             }
             else if (args.Length == 3 && args[0] == "ije2xml" && args[1] == "birth")
             {
@@ -576,34 +574,34 @@ namespace BFDR.CLI
                 return 0;
             }
 
-          //  else if (args.Length >= 3 && args[0] == "batch")
-          //  {
-          //      string url = args[1];
-          //      List<BFDRBaseMessage> messages = new List<BFDRBaseMessage>();
-          //      for (int i = 2; i < args.Length; i++)
-          //      {
-          //          messages.Add(BFDRBaseMessage.Parse(File.ReadAllText(args[i])));
-          //      }
-          //      string payload = Client.CreateBulkUploadPayload(messages, url, true);
-          //      Console.WriteLine(payload);
-          //      return 0;
-          //  }
-           // else if (args.Length == 3 && args[0] == "filter")
-           // {
-           //     Console.WriteLine($"Filtering file {args[1]}");
+            //  else if (args.Length >= 3 && args[0] == "batch")
+            //  {
+            //      string url = args[1];
+            //      List<BFDRBaseMessage> messages = new List<BFDRBaseMessage>();
+            //      for (int i = 2; i < args.Length; i++)
+            //      {
+            //          messages.Add(BFDRBaseMessage.Parse(File.ReadAllText(args[i])));
+            //      }
+            //      string payload = Client.CreateBulkUploadPayload(messages, url, true);
+            //      Console.WriteLine(payload);
+            //      return 0;
+            //  }
+            // else if (args.Length == 3 && args[0] == "filter")
+            // {
+            //     Console.WriteLine($"Filtering file {args[1]}");
 
-           //     BFDRBaseMessage baseMessage = BFDRBaseMessage.Parse(File.ReadAllText(args[1]));
-                
-           //     FilterService FilterService = new FilterService("./BFDR.Filter/NCHSIJEFilter.json", "./BFDR.Filter/IJEToFHIRMapping.json");
+            //     BFDRBaseMessage baseMessage = BFDRBaseMessage.Parse(File.ReadAllText(args[1]));
 
-           //     var filteredFile = FilterService.filterMessage(baseMessage).ToJson();
-           //     BFDRBaseMessage.Parse(filteredFile);
-           //     Console.WriteLine($"File successfully filtered and saved to {args[2]}");
-                    
-           //     File.WriteAllText(args[2], filteredFile);
-                
-           //     return 0;
-           //  }
+            //     FilterService FilterService = new FilterService("./BFDR.Filter/NCHSIJEFilter.json", "./BFDR.Filter/IJEToFHIRMapping.json");
+
+            //     var filteredFile = FilterService.filterMessage(baseMessage).ToJson();
+            //     BFDRBaseMessage.Parse(filteredFile);
+            //     Console.WriteLine($"File successfully filtered and saved to {args[2]}");
+
+            //     File.WriteAllText(args[2], filteredFile);
+
+            //     return 0;
+            //  }
             else if (args.Length == 3 && args[0] == "ije" && args[1] == "birth")
             {
 
@@ -760,13 +758,13 @@ namespace BFDR.CLI
                 Console.WriteLine(XDocument.Parse(b.ToXML()).ToString());
                 return 0;
             }
-            else if (args.Length == 3 && args[0] == "checkXml" && args[1] == "birth" )
+            else if (args.Length == 3 && args[0] == "checkXml" && args[1] == "birth")
             {
                 BirthRecord b = new BirthRecord(File.ReadAllText(args[2]), true);
                 Console.WriteLine(XDocument.Parse(b.ToXML()).ToString());
                 return 0;
             }
-            else if (args.Length == 3 && args[0] == "checkXml" && args[1] == "fetaldeath" )
+            else if (args.Length == 3 && args[0] == "checkXml" && args[1] == "fetaldeath")
             {
                 FetalDeathRecord b = new FetalDeathRecord(File.ReadAllText(args[2]), true);
                 Console.WriteLine(XDocument.Parse(b.ToXML()).ToString());
@@ -900,7 +898,7 @@ namespace BFDR.CLI
             else if (args.Length == 3 && args[0] == "roundtrip-ije" && args[1] == "fetaldeath")
             {
                 // Console.WriteLine("Converting FHIR to IJE...\n");
-                
+
                 FetalDeathRecord b = new FetalDeathRecord(File.ReadAllText(args[2]));
                 IJEFetalDeath ije1, ije2, ije3;
                 try
@@ -1106,7 +1104,7 @@ namespace BFDR.CLI
                 ijeb.MRACE8E = "";
 
                 ijeb.METHNIC1 = "N";
-                ijeb.METHNIC2 = "N";                
+                ijeb.METHNIC2 = "N";
                 ijeb.METHNIC3 = "N";
                 ijeb.METHNIC4 = "N";
                 ijeb.METHNIC5 = "";

--- a/projects/BFDR.Tests/BirthRecord_Should.cs
+++ b/projects/BFDR.Tests/BirthRecord_Should.cs
@@ -1234,10 +1234,10 @@ namespace BFDR.Tests
     public void TestComplexPartialDates()
     {
       // Tests source: https://github.com/HL7/vr-common-library/blob/fixPartialDateTime/input/pagecontent/usage.md#partial-dates-and-times
-       BirthRecord br = new();
+      BirthRecord br = new();
       // 2023
       br.BirthYear = 2023;
-      Date fhirBirth = ((Patient) br.GetBundle().Entry.Find(entry => entry.Resource.Meta.Profile.Any(profile => profile == VR.ProfileURL.Child)).Resource).BirthDateElement;
+      Date fhirBirth = ((Patient)br.GetBundle().Entry.Find(entry => entry.Resource.Meta.Profile.Any(profile => profile == VR.ProfileURL.Child)).Resource).BirthDateElement;
       Extension pdt = fhirBirth.GetExtension(VR.ExtensionURL.PartialDateTime);
       Assert.Equal(2023, br.BirthYear);
       Assert.Null(br.BirthMonth);
@@ -1255,7 +1255,7 @@ namespace BFDR.Tests
       // 2023-12
       br.BirthYear = 2023;
       br.BirthMonth = 12;
-      fhirBirth = ((Patient) br.GetBundle().Entry.Find(entry => entry.Resource.Meta.Profile.Any(profile => profile == VR.ProfileURL.Child)).Resource).BirthDateElement;
+      fhirBirth = ((Patient)br.GetBundle().Entry.Find(entry => entry.Resource.Meta.Profile.Any(profile => profile == VR.ProfileURL.Child)).Resource).BirthDateElement;
       pdt = fhirBirth.GetExtension(VR.ExtensionURL.PartialDateTime);
       Assert.Equal(2023, br.BirthYear);
       Assert.Equal(12, br.BirthMonth);
@@ -1274,7 +1274,7 @@ namespace BFDR.Tests
       br.BirthYear = 2023;
       br.BirthMonth = 12;
       br.BirthDay = 23;
-      fhirBirth = ((Patient) br.GetBundle().Entry.Find(entry => entry.Resource.Meta.Profile.Any(profile => profile == VR.ProfileURL.Child)).Resource).BirthDateElement;
+      fhirBirth = ((Patient)br.GetBundle().Entry.Find(entry => entry.Resource.Meta.Profile.Any(profile => profile == VR.ProfileURL.Child)).Resource).BirthDateElement;
       pdt = fhirBirth.GetExtension(VR.ExtensionURL.PartialDateTime);
       Assert.Equal(2023, br.BirthYear);
       Assert.Equal(12, br.BirthMonth);
@@ -1294,7 +1294,7 @@ namespace BFDR.Tests
       br.BirthMonth = 12;
       br.BirthDay = 23;
       br.BirthTime = "13:28:17-5:00";
-      fhirBirth = ((Patient) br.GetBundle().Entry.Find(entry => entry.Resource.Meta.Profile.Any(profile => profile == VR.ProfileURL.Child)).Resource).BirthDateElement;
+      fhirBirth = ((Patient)br.GetBundle().Entry.Find(entry => entry.Resource.Meta.Profile.Any(profile => profile == VR.ProfileURL.Child)).Resource).BirthDateElement;
       pdt = fhirBirth.GetExtension(VR.ExtensionURL.PartialDateTime);
       Assert.Equal(2023, br.BirthYear);
       Assert.Equal(12, br.BirthMonth);
@@ -1314,7 +1314,7 @@ namespace BFDR.Tests
       br.BirthMonth = 12;
       br.BirthDay = 23;
       br.BirthTime = "-1";
-      fhirBirth = ((Patient) br.GetBundle().Entry.Find(entry => entry.Resource.Meta.Profile.Any(profile => profile == VR.ProfileURL.Child)).Resource).BirthDateElement; // THIS NEEDS TO BE FIXED
+      fhirBirth = ((Patient)br.GetBundle().Entry.Find(entry => entry.Resource.Meta.Profile.Any(profile => profile == VR.ProfileURL.Child)).Resource).BirthDateElement; // THIS NEEDS TO BE FIXED
       pdt = fhirBirth.GetExtension(VR.ExtensionURL.PartialDateTime);
       Assert.Equal(2023, br.BirthYear);
       Assert.Equal(12, br.BirthMonth);
@@ -1340,7 +1340,7 @@ namespace BFDR.Tests
       br.BirthMonth = 12;
       br.BirthDay = 23;
       br.BirthTime = "18:28";
-      fhirBirth = ((Patient) br.GetBundle().Entry.Find(entry => entry.Resource.Meta.Profile.Any(profile => profile == VR.ProfileURL.Child)).Resource).BirthDateElement;
+      fhirBirth = ((Patient)br.GetBundle().Entry.Find(entry => entry.Resource.Meta.Profile.Any(profile => profile == VR.ProfileURL.Child)).Resource).BirthDateElement;
       pdt = fhirBirth.GetExtension(VR.ExtensionURL.PartialDateTime);
       Assert.Equal(-1, br.BirthYear);
       Assert.Equal(12, br.BirthMonth);
@@ -1364,7 +1364,7 @@ namespace BFDR.Tests
       br.BirthMonth = -1;
       br.BirthDay = 23;
       br.BirthTime = "-1";
-      fhirBirth = ((Patient) br.GetBundle().Entry.Find(entry => entry.Resource.Meta.Profile.Any(profile => profile == VR.ProfileURL.Child)).Resource).BirthDateElement;
+      fhirBirth = ((Patient)br.GetBundle().Entry.Find(entry => entry.Resource.Meta.Profile.Any(profile => profile == VR.ProfileURL.Child)).Resource).BirthDateElement;
       pdt = fhirBirth.GetExtension(VR.ExtensionURL.PartialDateTime);
       Assert.Equal(2023, br.BirthYear);
       Assert.Equal(-1, br.BirthMonth);
@@ -1390,7 +1390,7 @@ namespace BFDR.Tests
       br.BirthMonth = null;
       br.BirthDay = 23;
       br.BirthTime = "-1";
-      fhirBirth = ((Patient) br.GetBundle().Entry.Find(entry => entry.Resource.Meta.Profile.Any(profile => profile == VR.ProfileURL.Child)).Resource).BirthDateElement;
+      fhirBirth = ((Patient)br.GetBundle().Entry.Find(entry => entry.Resource.Meta.Profile.Any(profile => profile == VR.ProfileURL.Child)).Resource).BirthDateElement;
       pdt = fhirBirth.GetExtension(VR.ExtensionURL.PartialDateTime);
       Assert.Equal(2023, br.BirthYear);
       Assert.Null(br.BirthMonth);
@@ -1512,8 +1512,8 @@ namespace BFDR.Tests
       BirthRecord br = new();
       // 2023
       br.DateOfLastLiveBirthYear = 2023;
-      Observation observation = (Observation) br.GetBundle().Entry.Where(e => e.Resource is Observation dObs && VitalRecord.CodeableConceptToDict(dObs.Code)["code"] == "68499-3").FirstOrDefault().Resource;
-      FhirDateTime dateToUse = ((FhirDateTime) observation.Value);
+      Observation observation = (Observation)br.GetBundle().Entry.Where(e => e.Resource is Observation dObs && VitalRecord.CodeableConceptToDict(dObs.Code)["code"] == "68499-3").FirstOrDefault().Resource;
+      FhirDateTime dateToUse = ((FhirDateTime)observation.Value);
       Extension pdt = dateToUse.GetExtension(VR.ExtensionURL.PartialDateTime);
       Assert.Equal(2023, br.DateOfLastLiveBirthYear);
       Assert.Null(br.DateOfLastLiveBirthMonth);
@@ -1528,8 +1528,8 @@ namespace BFDR.Tests
       // 2023-12
       br.DateOfLastLiveBirthYear = 2023;
       br.DateOfLastLiveBirthMonth = 12;
-      observation = (Observation) br.GetBundle().Entry.Where(e => e.Resource is Observation dObs && VitalRecord.CodeableConceptToDict(dObs.Code)["code"] == "68499-3").FirstOrDefault().Resource;
-      dateToUse = ((FhirDateTime) observation.Value);
+      observation = (Observation)br.GetBundle().Entry.Where(e => e.Resource is Observation dObs && VitalRecord.CodeableConceptToDict(dObs.Code)["code"] == "68499-3").FirstOrDefault().Resource;
+      dateToUse = ((FhirDateTime)observation.Value);
       pdt = dateToUse.GetExtension(VR.ExtensionURL.PartialDateTime);
       Assert.Equal(2023, br.DateOfLastLiveBirthYear);
       Assert.Equal(12, br.DateOfLastLiveBirthMonth);
@@ -1545,8 +1545,8 @@ namespace BFDR.Tests
       ije = new(br);
       br.DateOfLastLiveBirthYear = null;
       br.DateOfLastLiveBirthMonth = 12;
-      observation = (Observation) br.GetBundle().Entry.Where(e => e.Resource is Observation dObs && VitalRecord.CodeableConceptToDict(dObs.Code)["code"] == "68499-3").FirstOrDefault().Resource;
-      dateToUse = ((FhirDateTime) observation.Value);
+      observation = (Observation)br.GetBundle().Entry.Where(e => e.Resource is Observation dObs && VitalRecord.CodeableConceptToDict(dObs.Code)["code"] == "68499-3").FirstOrDefault().Resource;
+      dateToUse = ((FhirDateTime)observation.Value);
       pdt = dateToUse.GetExtension(VR.ExtensionURL.PartialDateTime);
       Assert.Null(br.DateOfLastLiveBirthYear);
       Assert.Equal(12, br.DateOfLastLiveBirthMonth);
@@ -1563,8 +1563,8 @@ namespace BFDR.Tests
       // EXPLICIT_UNKOWN-12
       br.DateOfLastLiveBirthYear = -1;
       br.DateOfLastLiveBirthMonth = 12;
-      observation = (Observation) br.GetBundle().Entry.Where(e => e.Resource is Observation dObs && VitalRecord.CodeableConceptToDict(dObs.Code)["code"] == "68499-3").FirstOrDefault().Resource;
-      dateToUse = ((FhirDateTime) observation.Value);
+      observation = (Observation)br.GetBundle().Entry.Where(e => e.Resource is Observation dObs && VitalRecord.CodeableConceptToDict(dObs.Code)["code"] == "68499-3").FirstOrDefault().Resource;
+      dateToUse = ((FhirDateTime)observation.Value);
       pdt = dateToUse.GetExtension(VR.ExtensionURL.PartialDateTime);
       Assert.Equal(-1, br.DateOfLastLiveBirthYear);
       Assert.Equal(12, br.DateOfLastLiveBirthMonth);
@@ -1581,8 +1581,8 @@ namespace BFDR.Tests
       // EXPLICIT_UNKOWN-EXPLICIT_UNKNOWN
       br.DateOfLastLiveBirthYear = -1;
       br.DateOfLastLiveBirthMonth = -1;
-      observation = (Observation) br.GetBundle().Entry.Where(e => e.Resource is Observation dObs && VitalRecord.CodeableConceptToDict(dObs.Code)["code"] == "68499-3").FirstOrDefault().Resource;
-      dateToUse = ((FhirDateTime) observation.Value);
+      observation = (Observation)br.GetBundle().Entry.Where(e => e.Resource is Observation dObs && VitalRecord.CodeableConceptToDict(dObs.Code)["code"] == "68499-3").FirstOrDefault().Resource;
+      dateToUse = ((FhirDateTime)observation.Value);
       pdt = dateToUse.GetExtension(VR.ExtensionURL.PartialDateTime);
       Assert.Equal(-1, br.DateOfLastLiveBirthYear);
       Assert.Equal(-1, br.DateOfLastLiveBirthMonth);
@@ -2015,7 +2015,6 @@ namespace BFDR.Tests
       Assert.False(record.HepatitisB);
       Assert.False(record.HepatitisC);
       Assert.False(record.Syphilis);
-      Assert.False(record.GenitalHerpesSimplex);
       //maternal morbidities
       Assert.False(record.NoMaternalMorbidities);
       Assert.False(record.ICUAdmission);
@@ -2345,12 +2344,12 @@ namespace BFDR.Tests
     public void TestEncounterRole()
     {
       BirthRecord importedRecord = new(File.ReadAllText(TestHelpers.FixturePath("fixtures/json/BirthRecordBabyGQuinn.json")));
-      Encounter encBirth = (Encounter) importedRecord.GetBundle().Entry.Find(e => e.Resource.Meta.Profile.Any(p => p == ProfileURL.EncounterBirth)).Resource;
-      Encounter encMaternity = (Encounter) importedRecord.GetBundle().Entry.Find(e => e.Resource.Meta.Profile.Any(p => p == ProfileURL.EncounterMaternity)).Resource;
+      Encounter encBirth = (Encounter)importedRecord.GetBundle().Entry.Find(e => e.Resource.Meta.Profile.Any(p => p == ProfileURL.EncounterBirth)).Resource;
+      Encounter encMaternity = (Encounter)importedRecord.GetBundle().Entry.Find(e => e.Resource.Meta.Profile.Any(p => p == ProfileURL.EncounterMaternity)).Resource;
       Assert.NotNull(encBirth.Extension.Find(e => e.Url.Equals(BFDR.ExtensionURL.ExtensionRole)));
       Assert.NotNull(encMaternity.Extension.Find(e => e.Url.Equals(BFDR.ExtensionURL.ExtensionRole)));
       BirthRecord emptyRecord = new();
-      encMaternity = (Encounter) emptyRecord.GetBundle().Entry.Find(e => e.Resource.Meta.Profile.Any(p => p == ProfileURL.EncounterMaternity)).Resource;
+      encMaternity = (Encounter)emptyRecord.GetBundle().Entry.Find(e => e.Resource.Meta.Profile.Any(p => p == ProfileURL.EncounterMaternity)).Resource;
       Assert.NotNull(encMaternity.Extension.Find(e => e.Url.Equals(BFDR.ExtensionURL.ExtensionRole)));
     }
 
@@ -3591,7 +3590,6 @@ namespace BFDR.Tests
       Assert.False(birthRecord.HepatitisB);
       Assert.False(birthRecord.HepatitisC);
       Assert.False(birthRecord.Syphilis);
-      Assert.False(birthRecord.GenitalHerpesSimplex);
       Assert.False(birthRecord.NoMaternalMorbidities);
       Assert.False(birthRecord.ICUAdmission);
       Assert.False(birthRecord.MaternalTransfusion);
@@ -3955,7 +3953,8 @@ namespace BFDR.Tests
     }
 
     [Fact]
-    public void TestPatientFetalDeath() {
+    public void TestPatientFetalDeath()
+    {
       Assert.Null(SetterBirthRecord.PatientFetalDeath);
       SetterBirthRecord.PatientFetalDeath = false;
       Assert.Null(SetterBirthRecord.PatientFetalDeath); //Fetal death should only be indicated if Patient is deceased (value=true).
@@ -3975,7 +3974,8 @@ namespace BFDR.Tests
     }
 
     [Fact]
-    public void TestConnectathonRecords() {
+    public void TestConnectathonRecords()
+    {
       string romeroIje = "2024TT0999910            1031F010101911487607784  1101199210130XXMX77000019AZUSY199112190UUU30HNNN                    YNNNNNNNNNNNNNN                                                                                                                                                                                                                                                                                                30HNNN                    YNNNNNNNNNNNNNN                                                                                                                                                                                                                                                                                                1N8888888888888888000501010001270N03000006201588888800000000320190731NNNNNN NN000NN NNNNNNNNYNNNNYNNNNYNN21XNNNNNN0539021001040199999999990YYYNNNNNNNNNNNNNNNNYYN        9999NXX                 20200102                                                 YYTRF                                             XMIDDLEXX                                         CARDENAS ROMERO                                          PIMA                     TUCSON                                            NORTHWEST MEDICAL CENTER                          ALEJANDRA                                                                                           ROMERO LEON                                                                                                                                                  ROMERO LEON                                                                                                                         6666 NORTH ORACLE ROAD100                         85705    PIMA                        TUCSON                      ARIZONA                     UNITED STATES               RAMON                                             FELIPE                                            CARDENAS OTERO                                           8888888888888888882930                                                                                                                ZZMX                                                                                                                                                                                                    BANNER UNIVERSITY MEDICAL CENTER - TUCSON                                                         MEXICO                                                  MEXICO                                                                                                 9999 NORTH PRIEST RD236                           85489                                MESA                        ARIZONA                     UNITED STATES               Y1             HEATHERSTEVENS                                    1932304839                                                                                     1393674        1393655                20200102                                                  1XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        ";
       string zalbanaizIje = "2024TT0099990            1025M010101311568794535  1095199505150XXKU73000013AZUSY199506040YYX40NNNN                    NNNNNNNNNNNNNNY                                                                                                                                                                                    MIDDLE EASTERN                ARABIAN                                                                       60NNNN                    NNNNNNNNNNNNNNY                                                                                                                                                                                    MIDDLE EASTERN                ARABIAN                                                                       1N0604201812272018180503016501990N01000001201988888800000000220180418NNNNNN NN000NN NNNNNNNNNNNNNNYNNYYNN14NNNNNNN2277036009880202999999990NNNNNNNNNNNNNNNNNNNNYY        9999NXX                 20190102                                                 XYUGBNX                                           XMX                                               ZALBANAIZ                                                MARICOPA                 MESA                                              MOUNTAIN VISTA MEDICAL CENTER                     REEM                                              NASSER                                            ALHAMADI                                                                                                                                                     ALHAMADI                                                                                                                            999 N COLLEGE AVE5656                             85281    MARICOPA                    TEMPE                       ARIZONA                     UNITED STATES               OMAR                                              AHMED                                             ALBANAI                                                  8888888888888888882626                                                                                                                ZZKU                                                                                                                                                                                                                                                                                                      KUWAIT                                                  KUWAIT                                                                                                 888 N PRIEST AVE9999                              85429                                GLENDALE                    ARIZONA                     UNITED STATES               Y1             MANISHAAPUROHIT                                   1972721538                                                                                     1201183921     1200527124             20190102                                                  0XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        ";
 

--- a/projects/BFDR/BFDR.xml
+++ b/projects/BFDR/BFDR.xml
@@ -256,6 +256,155 @@
             <para>Console.WriteLine($"Child Date of Birth: {ExampleBirthRecord.DateOfBirth}");</para>
             </example>
         </member>
+        <member name="P:BFDR.BirthRecord.NoCongenitalAnomaliesOfTheNewborn">
+            <summary>No Congenital Anomalies of the Newborn.</summary>
+        </member>
+        <member name="P:BFDR.BirthRecord.Anencephaly">
+            <summary>Congenital Anomalies of the Newborn, Anencephaly.</summary>
+        </member>
+        <member name="P:BFDR.BirthRecord.CleftLipWithOrWithoutCleftPalate">
+            <summary>Congenital Anomalies of the Newborn, Cleft Lip with or without Cleft Palate.</summary>
+        </member>
+        <member name="P:BFDR.BirthRecord.CleftPalateAlone">
+            <summary>Congenital Anomalies of the Newborn, Cleft Palate Alone.</summary>
+        </member>
+        <member name="P:BFDR.BirthRecord.CongenitalDiaphragmaticHernia">
+            <summary>Congenital Anomalies of the Newborn, Congenital Diaphragmatic Hernia.</summary>
+        </member>
+        <member name="P:BFDR.BirthRecord.CyanoticCongenitalHeartDisease">
+            <summary>Congenital Anomalies of the Newborn, Cyanotic Congenital Heart Disease.</summary>
+        </member>
+        <member name="P:BFDR.BirthRecord.DownSyndrome">
+            <summary>Congenital Anomalies of the Newborn, Down Syndrome.</summary>
+        </member>
+        <member name="P:BFDR.BirthRecord.Gastroschisis">
+            <summary>Congenital Anomalies of the Newborn, Gastroschisis.</summary>
+        </member>
+        <member name="P:BFDR.BirthRecord.Hypospadias">
+            <summary>Congenital Anomalies of the Newborn, Hypospadias.</summary>
+        </member>
+        <member name="P:BFDR.BirthRecord.LimbReductionDefect">
+            <summary>Congenital Anomalies of the Newborn, Limb Reduction Defect.</summary>
+        </member>
+        <member name="P:BFDR.BirthRecord.Meningomyelocele">
+            <summary>Congenital Anomalies of the Newborn, Meningomyelocele.</summary>
+        </member>
+        <member name="P:BFDR.BirthRecord.Omphalocele">
+            <summary>Congenital Anomalies of the Newborn, Omphalocele.</summary>
+        </member>
+        <member name="P:BFDR.BirthRecord.SuspectedChromosomalDisorder">
+            <summary>Congenital Anomalies of the Newborn, Suspected Chromosomal Disorder.</summary>
+        </member>
+        <member name="P:BFDR.BirthRecord.Chlamydia">
+            <summary>Infections Present During Pregnancy, Chlamydia.</summary>
+        </member>
+        <member name="P:BFDR.BirthRecord.Gonorrhea">
+            <summary>Infections Present During Pregnancy, Gonorrhea.</summary>
+        </member>
+        <member name="P:BFDR.BirthRecord.Syphilis">
+            <summary>Infections Present During Pregnancy, Syphilis.</summary>
+        </member>
+        <member name="P:BFDR.BirthRecord.PreviousPretermBirth">
+            <summary>Previous Preterm Birth.</summary>
+        </member>
+        <member name="P:BFDR.BirthRecord.DateOfLastOtherPregnancyOutcomeDay">
+            <summary>Date Of Last Other Pregnancy Outcome Day</summary>
+            <value>the date of the last other pregnancy outcome day
+            </value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeDay = 4;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Date of Last Other Pregnancy Outcome: {ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeDay}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.DateOfLastOtherPregnancyOutcomeMonth">
+            <summary>Date Of Last Other Pregnancy Outcome Month</summary>
+            <value>the date of the last other pregnancy outcome month
+            </value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeMonth = 4;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Date of Last Other Pregnancy Outcome: {ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeMonth}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.DateOfLastOtherPregnancyOutcomeYear">
+            <summary>Date Of Last Other Pregnancy Outcome year</summary>
+            <value>the date of the Mother's last other pregnancy outcome
+            </value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeYear = 2022;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Date of Last Other Pregnancy Outcome:: {ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeYear}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.DateOfLastOtherPregnancyOutcome">
+            <summary>Date Of Last Other Pregnancy Outcome.</summary>
+            <value>Date of Last Other Pregnancy Outcome</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.DateOfLastOtherPregnancyOutcome = "2020-02-19";</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Date of Last Other Pregnancy Outcome: {ExampleBirthRecord.DateOfLastOtherPregnancyOutcome}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.NumberOfPrenatalVisits">
+            <summary>NumberOfPrenatalVisits.</summary>
+            <value>NumberOfPrenatalVisits</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.NumberOfPrenatalVisits = 4;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"NumberOfPrenatalVisits: {ExampleBirthRecord.NumberOfPrenatalVisits}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.NumberOfPrenatalVisitsEditFlag">
+            <summary>NumberOfPrenatalVisitsEditFlag.</summary>
+            <value>NumberOfPrenatalVisitsEditFlag</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.NumberOfPrenatalVisitsEditFlag = 4;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"NumberOfPrenatalVisitsEditFlag: {ExampleBirthRecord.NumberOfPrenatalVisitsEditFlag}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.NumberOfPrenatalVisitsEditFlagHelper">
+            <summary>
+            NumberOfPrenatalVisitsEditFlag Helper
+            </summary>
+        </member>
+        <member name="P:BFDR.BirthRecord.NumberOfOtherPregnancyOutcomes">
+            <summary>NumberOfOtherPregnancyOutcomes.</summary>
+            <value>NumberOfOtherPregnancyOutcomes</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.NumberOfOtherPregnancyOutcomes = 1;</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"NumberOfOtherPregnancyOutcomes: {ExampleBirthRecord.NumberOfOtherPregnancyOutcomes}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.MotherTransferred">
+            <summary>Mother Transferred</summary>
+            <value>Mother transferred</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.MotherTransferred = "hosp-trans";</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Mother transferred: {ExampleBirthRecord.MotherTransferred}");</para>
+            </example>
+        </member>
+        <member name="P:BFDR.BirthRecord.MotherTransferredHelper">
+            <summary>Mother Transferred Helper</summary>
+            <value>Mother transferred helper</value>
+            <example>
+            <para>// Setter:</para>
+            <para>ExampleBirthRecord.MotherTransferredHelper = "hosp-trans";</para>
+            <para>// Getter:</para>
+            <para>Console.WriteLine($"Mother transferred: {ExampleBirthRecord.MotherTransferredHelper}");</para>
+            </example>
+        </member>
         <member name="F:BFDR.BirthRecord.EncounterBirth">
             <summary>The encounter of the birth.</summary>
         </member>
@@ -3513,6 +3662,15 @@
         <member name="F:BFDR.NatalityRecord.EMERGING_ISSUES_SECTION">
             <summary>Emerging Issues Section Constant</summary>
         </member>
+        <member name="F:BFDR.NatalityRecord.DATE_OF_LAST_OTHER_PREGNANCY_OUTCOME">
+            <summary>Date of Last Other Pregnancy Outcome Section Constant</summary>
+        </member>
+        <member name="F:BFDR.NatalityRecord.NUMBER_OF_PRENATAL_VISITS">
+            <summary>Number of Prenatal Visits Section Constant</summary>
+        </member>
+        <member name="F:BFDR.NatalityRecord.NUMBER_OF_OTHER_PREGNANCY_OUTCOMES">
+            <summary>Number of Other Pregnancy Outcomes Section Constant</summary>
+        </member>
         <member name="F:BFDR.NatalityRecord.FETUS_SECTION">
             <summary> Fetus Section Constant </summary>
         </member>
@@ -4029,45 +4187,6 @@
             <para>Console.WriteLine($"Patient Fetal Death: {ExampleFetalDeathRecord.PatientFetalDeath}");</para>
             </example>
         </member>
-        <member name="P:BFDR.NatalityRecord.NoCongenitalAnomaliesOfTheNewborn">
-            <summary>No Congenital Anomalies of the Newborn.</summary>
-        </member>
-        <member name="P:BFDR.NatalityRecord.Anencephaly">
-            <summary>Congenital Anomalies of the Newborn, Anencephaly.</summary>
-        </member>
-        <member name="P:BFDR.NatalityRecord.CleftLipWithOrWithoutCleftPalate">
-            <summary>Congenital Anomalies of the Newborn, Cleft Lip with or without Cleft Palate.</summary>
-        </member>
-        <member name="P:BFDR.NatalityRecord.CleftPalateAlone">
-            <summary>Congenital Anomalies of the Newborn, Cleft Palate Alone.</summary>
-        </member>
-        <member name="P:BFDR.NatalityRecord.CongenitalDiaphragmaticHernia">
-            <summary>Congenital Anomalies of the Newborn, Congenital Diaphragmatic Hernia.</summary>
-        </member>
-        <member name="P:BFDR.NatalityRecord.CyanoticCongenitalHeartDisease">
-            <summary>Congenital Anomalies of the Newborn, Cyanotic Congenital Heart Disease.</summary>
-        </member>
-        <member name="P:BFDR.NatalityRecord.DownSyndrome">
-            <summary>Congenital Anomalies of the Newborn, Down Syndrome.</summary>
-        </member>
-        <member name="P:BFDR.NatalityRecord.Gastroschisis">
-            <summary>Congenital Anomalies of the Newborn, Gastroschisis.</summary>
-        </member>
-        <member name="P:BFDR.NatalityRecord.Hypospadias">
-            <summary>Congenital Anomalies of the Newborn, Hypospadias.</summary>
-        </member>
-        <member name="P:BFDR.NatalityRecord.LimbReductionDefect">
-            <summary>Congenital Anomalies of the Newborn, Limb Reduction Defect.</summary>
-        </member>
-        <member name="P:BFDR.NatalityRecord.Meningomyelocele">
-            <summary>Congenital Anomalies of the Newborn, Meningomyelocele.</summary>
-        </member>
-        <member name="P:BFDR.NatalityRecord.Omphalocele">
-            <summary>Congenital Anomalies of the Newborn, Omphalocele.</summary>
-        </member>
-        <member name="P:BFDR.NatalityRecord.SuspectedChromosomalDisorder">
-            <summary>Congenital Anomalies of the Newborn, Suspected Chromosomal Disorder.</summary>
-        </member>
         <member name="P:BFDR.NatalityRecord.NoCharacteristicsOfLaborAndDelivery">
             <summary>No Characteristics of Labor and Delivery.</summary>
         </member>
@@ -4113,23 +4232,11 @@
         <member name="P:BFDR.NatalityRecord.NoInfectionsPresentDuringPregnancy">
             <summary>No Infections Present During Pregnancy.</summary>
         </member>
-        <member name="P:BFDR.NatalityRecord.Chlamydia">
-            <summary>Infections Present During Pregnancy, Chlamydia.</summary>
-        </member>
-        <member name="P:BFDR.NatalityRecord.Gonorrhea">
-            <summary>Infections Present During Pregnancy, Gonorrhea.</summary>
-        </member>
         <member name="P:BFDR.NatalityRecord.HepatitisB">
             <summary>Infections Present During Pregnancy, Hepatitis B.</summary>
         </member>
         <member name="P:BFDR.NatalityRecord.HepatitisC">
             <summary>Infections Present During Pregnancy, Hepatitis C.</summary>
-        </member>
-        <member name="P:BFDR.NatalityRecord.Syphilis">
-            <summary>Infections Present During Pregnancy, Syphilis.</summary>
-        </member>
-        <member name="P:BFDR.NatalityRecord.GenitalHerpesSimplex">
-            <summary>Infections Present During Pregnancy, Genital Herpes Simplex.</summary>
         </member>
         <member name="P:BFDR.NatalityRecord.NoMaternalMorbidities">
             <summary>No Maternal Morbidities.</summary>
@@ -4169,9 +4276,6 @@
         </member>
         <member name="P:BFDR.NatalityRecord.PreviousCesarean">
             <summary>Previous Cesarean.</summary>
-        </member>
-        <member name="P:BFDR.NatalityRecord.PreviousPretermBirth">
-            <summary>Previous Preterm Birth.</summary>
         </member>
         <member name="P:BFDR.NatalityRecord.FertilityEnhancingDrugTherapyArtificialIntrauterineInsemination">
             <summary>Fertility Enhancing Drug Therapy, Artificial or Intrauterine Insemination.</summary>
@@ -5770,74 +5874,6 @@
             <para>Console.WriteLine($"Date of Last Live Birth: {ExampleBirthRecord.DateOfLastLiveBirth}");</para>
             </example>
         </member>
-        <member name="P:BFDR.NatalityRecord.DateOfLastOtherPregnancyOutcomeDay">
-            <summary>Date Of Last Other Pregnancy Outcome Day</summary>
-            <value>the date of the last other pregnancy outcome day
-            </value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeDay = 4;</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Date of Last Other Pregnancy Outcome: {ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeDay}");</para>
-            </example>
-        </member>
-        <member name="P:BFDR.NatalityRecord.DateOfLastOtherPregnancyOutcomeMonth">
-            <summary>Date Of Last Other Pregnancy Outcome Month</summary>
-            <value>the date of the last other pregnancy outcome month
-            </value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeMonth = 4;</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Date of Last Other Pregnancy Outcome: {ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeMonth}");</para>
-            </example>
-        </member>
-        <member name="P:BFDR.NatalityRecord.DateOfLastOtherPregnancyOutcomeYear">
-            <summary>Date Of Last Other Pregnancy Outcome year</summary>
-            <value>the date of the Mother's last other pregnancy outcome
-            </value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeYear = 2022;</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Date of Last Other Pregnancy Outcome:: {ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeYear}");</para>
-            </example>
-        </member>
-        <member name="P:BFDR.NatalityRecord.DateOfLastOtherPregnancyOutcome">
-            <summary>Date Of Last Other Pregnancy Outcome.</summary>
-            <value>Date of Last Other Pregnancy Outcome</value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleBirthRecord.DateOfLastOtherPregnancyOutcome = "2020-02-19";</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Date of Last Other Pregnancy Outcome: {ExampleBirthRecord.DateOfLastOtherPregnancyOutcome}");</para>
-            </example>
-        </member>
-        <member name="P:BFDR.NatalityRecord.NumberOfPrenatalVisits">
-            <summary>NumberOfPrenatalVisits.</summary>
-            <value>NumberOfPrenatalVisits</value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleBirthRecord.NumberOfPrenatalVisits = 4;</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"NumberOfPrenatalVisits: {ExampleBirthRecord.NumberOfPrenatalVisits}");</para>
-            </example>
-        </member>
-        <member name="P:BFDR.NatalityRecord.NumberOfPrenatalVisitsEditFlag">
-            <summary>NumberOfPrenatalVisitsEditFlag.</summary>
-            <value>NumberOfPrenatalVisitsEditFlag</value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleBirthRecord.NumberOfPrenatalVisitsEditFlag = 4;</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"NumberOfPrenatalVisitsEditFlag: {ExampleBirthRecord.NumberOfPrenatalVisitsEditFlag}");</para>
-            </example>
-        </member>
-        <member name="P:BFDR.NatalityRecord.NumberOfPrenatalVisitsEditFlagHelper">
-            <summary>
-            NumberOfPrenatalVisitsEditFlag Helper
-            </summary>
-        </member>
         <member name="P:BFDR.NatalityRecord.GestationalAgeAtDelivery">
             <summary>GestationalAgeAtDelivery.</summary>
             <value>GestationalAgeAtDelivery</value>
@@ -5881,16 +5917,6 @@
             <para>ExampleBirthRecord.NumberOfBirthsNowLiving = 1;</para>
             <para>// Getter:</para>
             <para>Console.WriteLine($"NumberOfBirthsNowLiving: {ExampleBirthRecord.NumberOfBirthsNowLiving}");</para>
-            </example>
-        </member>
-        <member name="P:BFDR.NatalityRecord.NumberOfOtherPregnancyOutcomes">
-            <summary>NumberOfOtherPregnancyOutcomes.</summary>
-            <value>NumberOfOtherPregnancyOutcomes</value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleBirthRecord.NumberOfOtherPregnancyOutcomes = 1;</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"NumberOfOtherPregnancyOutcomes: {ExampleBirthRecord.NumberOfOtherPregnancyOutcomes}");</para>
             </example>
         </member>
         <member name="P:BFDR.NatalityRecord.MotherReceivedWICFood">
@@ -6582,26 +6608,6 @@
             <para>Console.WriteLine($"Paternity acknowledgement signed: {ExampleBirthRecord.PaternityAcknowledgementSignedHelper}");</para>
             </example>
         </member>
-        <member name="P:BFDR.NatalityRecord.MotherTransferred">
-            <summary>Mother Transferred</summary>
-            <value>Mother transferred</value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleBirthRecord.MotherTransferred = "hosp-trans";</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Mother transferred: {ExampleBirthRecord.MotherTransferred}");</para>
-            </example>
-        </member>
-        <member name="P:BFDR.NatalityRecord.MotherTransferredHelper">
-            <summary>Mother Transferred Helper</summary>
-            <value>Mother transferred helper</value>
-            <example>
-            <para>// Setter:</para>
-            <para>ExampleBirthRecord.MotherTransferredHelper = "hosp-trans";</para>
-            <para>// Getter:</para>
-            <para>Console.WriteLine($"Mother transferred: {ExampleBirthRecord.MotherTransferredHelper}");</para>
-            </example>
-        </member>
         <member name="P:BFDR.NatalityRecord.InfantLiving">
             <summary>Infant Living</summary>
             <value>Infant Living</value>
@@ -6631,6 +6637,26 @@
             <para>// Getter:</para>
             <para>Console.WriteLine($"SSN Requested: {ExampleBirthRecord.SSNRequested}");</para>
             </example>
+        </member>
+        <member name="M:BFDR.NatalityRecord.GetIntegerObservationValue(System.String)">
+            <summary>
+            Get an integer value from an Observation contained in this record.
+            </summary>
+            <param name="code">the code to identify the type of Observation</param>
+            <returns>the value of the specified Observation, or null if there is no Observation with the specified code</returns>
+        </member>
+        <member name="M:BFDR.NatalityRecord.SetIntegerObservationValue(System.String,System.String,System.Nullable{System.Int32},System.String,System.String,System.String,System.String)">
+            <summary>
+            Set an integer value on a contained Observation, identified by code. The Observation will be created if it does not already exist.
+            </summary>
+            <param name="code">the code to identify the type of Observation</param>
+            <param name="codeDesc">display text for the identifying code</param>
+            <param name="value">value to set on the Observation</param>
+            <param name="profileURL">profile conformed to by the Observation</param>
+            <param name="section">section to which to add a reference to the Observation</param>
+            <param name="subjectId">identifier for the subject of the Observation. unused</param>
+            <param name="propertyName">unused</param>
+            <returns></returns>
         </member>
         <member name="P:BFDR.NatalityRecord.ApgarScoreFiveMinutes">
             <summary>APGAR score at 5 mins.</summary>

--- a/projects/BFDR/BirthRecord.cs
+++ b/projects/BFDR/BirthRecord.cs
@@ -463,5 +463,530 @@ namespace BFDR
             get => GetDateOfDelivery();
             set => SetDateOfDelivery(value);
         }
+
+        //
+        // Congenital Anomalies of the Newborn Section
+        //
+
+        /// <summary>No Congenital Anomalies of the Newborn.</summary>
+        [Property("No Congenital Anomalies of the Newborn", Property.Types.Bool, "Congenital Anomalies of the Newborn",
+                  "No Congenital Anomalies of the Newborn", true, IGURL.ObservationNoneOfSpecifiedCongenitalAnomoliesOfTheNewborn, false, 219)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Observation, categoryCode: "73780-9", code: VitalRecord.NONE_OF_THE_ABOVE, section: NEWBORN_INFORMATION_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
+        public bool NoCongenitalAnomaliesOfTheNewborn
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Congenital Anomalies of the Newborn, Anencephaly.</summary>
+        [Property("Anencephaly", Property.Types.Bool, "Congenital Anomalies of the Newborn",
+                  "Congenital Anomalies of the Newborn, Anencephaly", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 219)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "89369001", section: NEWBORN_INFORMATION_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
+        public bool Anencephaly
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Congenital Anomalies of the Newborn, Cleft Lip with or without Cleft Palate.</summary>
+        [Property("Cleft Lip with or without Cleft Palate", Property.Types.Bool, "Congenital Anomalies of the Newborn",
+                  "Congenital Anomalies of the Newborn, Cleft Lip with or without Cleft Palate", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 226)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "80281008", section: NEWBORN_INFORMATION_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
+        public bool CleftLipWithOrWithoutCleftPalate
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Congenital Anomalies of the Newborn, Cleft Palate Alone.</summary>
+        [Property("Cleft Palate Alone", Property.Types.Bool, "Congenital Anomalies of the Newborn",
+                  "Congenital Anomalies of the Newborn, Cleft Palate Alone", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 227)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "87979003", section: NEWBORN_INFORMATION_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
+        public bool CleftPalateAlone
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Congenital Anomalies of the Newborn, Congenital Diaphragmatic Hernia.</summary>
+        [Property("Congenital Diaphragmatic Hernia", Property.Types.Bool, "Congenital Anomalies of the Newborn",
+                  "Congenital Anomalies of the Newborn, Congenital Diaphragmatic Hernia", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 222)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "17190001", section: NEWBORN_INFORMATION_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
+        public bool CongenitalDiaphragmaticHernia
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Congenital Anomalies of the Newborn, Cyanotic Congenital Heart Disease.</summary>
+        [Property("Cyanotic Congenital Heart Disease", Property.Types.Bool, "Congenital Anomalies of the Newborn",
+                  "Congenital Anomalies of the Newborn, Cyanotic Congenital Heart Disease", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 221)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "12770006", section: NEWBORN_INFORMATION_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
+        public bool CyanoticCongenitalHeartDisease
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Congenital Anomalies of the Newborn, Down Syndrome.</summary>
+        [Property("Down Syndrome", Property.Types.Bool, "Congenital Anomalies of the Newborn",
+                  "Congenital Anomalies of the Newborn, Down Syndrome", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 228)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "70156005", section: NEWBORN_INFORMATION_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
+        public bool DownSyndrome
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Congenital Anomalies of the Newborn, Gastroschisis.</summary>
+        [Property("Gastroschisis", Property.Types.Bool, "Congenital Anomalies of the Newborn",
+                  "Congenital Anomalies of the Newborn, Gastroschisis", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 224)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "72951007", section: NEWBORN_INFORMATION_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
+        public bool Gastroschisis
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Congenital Anomalies of the Newborn, Hypospadias.</summary>
+        [Property("Hypospadias", Property.Types.Bool, "Congenital Anomalies of the Newborn",
+                  "Congenital Anomalies of the Newborn, Hypospadias", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 230)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "416010008", section: NEWBORN_INFORMATION_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
+        public bool Hypospadias
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Congenital Anomalies of the Newborn, Limb Reduction Defect.</summary>
+        [Property("Limb Reduction Defect", Property.Types.Bool, "Congenital Anomalies of the Newborn",
+                  "Congenital Anomalies of the Newborn, Limb Reduction Defect", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 225)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "67341007", section: NEWBORN_INFORMATION_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
+        public bool LimbReductionDefect
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Congenital Anomalies of the Newborn, Meningomyelocele.</summary>
+        [Property("Meningomyelocele", Property.Types.Bool, "Congenital Anomalies of the Newborn",
+                  "Congenital Anomalies of the Newborn, Meningomyelocele", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 220)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "67531005", section: NEWBORN_INFORMATION_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
+        public bool Meningomyelocele
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Congenital Anomalies of the Newborn, Omphalocele.</summary>
+        [Property("Omphalocele", Property.Types.Bool, "Congenital Anomalies of the Newborn",
+                  "Congenital Anomalies of the Newborn, Omphalocele", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 223)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "18735004", section: NEWBORN_INFORMATION_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
+        public bool Omphalocele
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Congenital Anomalies of the Newborn, Suspected Chromosomal Disorder.</summary>
+        [Property("Suspected Chromosomal Disorder", Property.Types.Bool, "Congenital Anomalies of the Newborn",
+                  "Congenital Anomalies of the Newborn, Suspected Chromosomal Disorder", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 229)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "409709004", section: NEWBORN_INFORMATION_SECTION)]
+        [FHIRSubject(FHIRSubject.Subject.Newborn)]
+        public bool SuspectedChromosomalDisorder
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Infections Present During Pregnancy, Chlamydia.</summary>
+        [Property("Chlamydia", Property.Types.Bool, "Infections Present During Pregnancy",
+                  "Infections Present During Pregnancy, Chlamydia", true, IGURL.ConditionInfectionPresentDuringPregnancy, true, 171)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "72519-2", code: "105629000", section: MEDICAL_INFORMATION_SECTION)]
+        public bool Chlamydia
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Infections Present During Pregnancy, Gonorrhea.</summary>
+        [Property("Gonorrhea", Property.Types.Bool, "Infections Present During Pregnancy",
+                  "Infections Present During Pregnancy, Gonorrhea", true, IGURL.ConditionInfectionPresentDuringPregnancy, true, 168)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "72519-2", code: "15628003", section: MEDICAL_INFORMATION_SECTION)]
+        public bool Gonorrhea
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Infections Present During Pregnancy, Syphilis.</summary>
+        [Property("Syphilis", Property.Types.Bool, "Infections Present During Pregnancy",
+                  "Infections Present During Pregnancy, Syphilis", true, IGURL.ConditionInfectionPresentDuringPregnancy, true, 169)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "72519-2", code: "76272004", section: MEDICAL_INFORMATION_SECTION)]
+        public bool Syphilis
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Previous Preterm Birth.</summary>
+        [Property("Previous Preterm Birth", Property.Types.Bool, "Pregnancy Risk Factors",
+                  "Pregnancy Risk Factors, Previous Preterm Birth", true, IGURL.ObservationPreviousPretermBirth, true, 245)]
+        [FHIRPath(fhirType: FHIRPath.FhirType.Observation, categoryCode: "73775-9", code: "161765003", section: MEDICAL_INFORMATION_SECTION)]
+        public bool PreviousPretermBirth
+        {
+            get => EntryExists();
+            set => UpdateEntry(value);
+        }
+
+        /// <summary>Date Of Last Other Pregnancy Outcome Day</summary>
+        /// <value>the date of the last other pregnancy outcome day
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeDay = 4;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Date of Last Other Pregnancy Outcome: {ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeDay}");</para>
+        /// </example>
+        [Property("DateOfLastOtherPregnancyOutcomeDay", Property.Types.Int32, "Date of Last Other Pregnancy Outcome", "Date of last other pregnancy outcome.", false, IGURL.ObservationDateOfLastOtherPregnancyOutcome, false, 34)]
+        [PropertyParam("DateOfLastOtherPregnancyOutcomeDay", "The day of the last other pregnancy outcome.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='68500-8')", "")]
+        public int? DateOfLastOtherPregnancyOutcomeDay
+        {
+            get
+            {
+
+                Observation obs = GetObservation("68500-8");
+                if (obs != null)
+                {
+                    return GetDateFragmentOrPartialDate(obs.Value, VR.ExtensionURL.PartialDateDayVR);
+                }
+                return null;
+            }
+            set
+            {
+                Observation obs = GetOrCreateObservation("68500-8", CodeSystems.LOINC, "Date of last other pregnancy outcome", BFDR.ProfileURL.ObservationDateOfLastOtherPregnancyOutcome, DATE_OF_LAST_OTHER_PREGNANCY_OUTCOME, Mother.Id);
+                if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
+                {
+                    obs.Value = new FhirDateTime();
+                    obs.Extension.Add(NewBlankPartialDateTimeExtension(false));
+                }
+                FhirDateTime newDate = UpdateFhirDateTimeDateElement(obs.Value as FhirDateTime, value, VR.ExtensionURL.PartialDateDayVR);
+                if (newDate != null)
+                {
+                    obs.Value = newDate;
+                }
+            }
+        }
+
+        /// <summary>Date Of Last Other Pregnancy Outcome Month</summary>
+        /// <value>the date of the last other pregnancy outcome month
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeMonth = 4;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Date of Last Other Pregnancy Outcome: {ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeMonth}");</para>
+        /// </example>
+        [Property("DateOfLastOtherPregnancyOutcomeMonth", Property.Types.Int32, "Date of Last Other Pregnancy Outcome", "Date of last other pregnancy outcome.", false, IGURL.ObservationDateOfLastOtherPregnancyOutcome, false, 34)]
+        [PropertyParam("dateOfLastOtherPregnancyOutcomeMonth", "The month of the last other pregnancy outcome.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='68500-8')", "")]
+        public int? DateOfLastOtherPregnancyOutcomeMonth
+        {
+            get
+            {
+                Observation obs = GetObservation("68500-8");
+                if (obs != null)
+                {
+                    return GetDateFragmentOrPartialDate(obs.Value, VR.ExtensionURL.PartialDateMonthVR);
+                }
+                return null;
+            }
+            set
+            {
+                Observation obs = GetOrCreateObservation("68500-8", CodeSystems.LOINC, "Date of last other pregnancy outcome", BFDR.ProfileURL.ObservationDateOfLastOtherPregnancyOutcome, DATE_OF_LAST_OTHER_PREGNANCY_OUTCOME, Mother.Id);
+                if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
+                {
+                    obs.Value = new FhirDateTime();
+                    obs.Value.Extension.Add(NewBlankPartialDateTimeExtension(false));
+                }
+                FhirDateTime newDate = UpdateFhirDateTimeDateElement(obs.Value as FhirDateTime, value, VR.ExtensionURL.PartialDateMonthVR);
+                if (newDate != null)
+                {
+                    obs.Value = newDate;
+                }
+            }
+        }
+
+        /// <summary>Date Of Last Other Pregnancy Outcome year</summary>
+        /// <value>the date of the Mother's last other pregnancy outcome
+        /// </value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeYear = 2022;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Date of Last Other Pregnancy Outcome:: {ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeYear}");</para>
+        /// </example>
+        [Property("DateOfLastOtherPregnancyOutcomeYear", Property.Types.Int32, "Date of Last Other Pregnancy Outcome", "Date of last other pregnancy outcome.", false, IGURL.ObservationDateOfLastOtherPregnancyOutcome, false, 34)]
+        [PropertyParam("dateOfLastOtherPregnancyOutcomeYear", "The year of the last other pregnancy outcome.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='68500-8')", "")]
+        public int? DateOfLastOtherPregnancyOutcomeYear
+        {
+            get
+            {
+                Observation obs = GetObservation("68500-8");
+                if (obs != null)
+                {
+                    return GetDateFragmentOrPartialDate(obs.Value, VR.ExtensionURL.PartialDateYearVR);
+                }
+                return null;
+            }
+            set
+            {
+                Observation obs = GetOrCreateObservation("68500-8", CodeSystems.LOINC, "Date of last other pregnancy outcome", BFDR.ProfileURL.ObservationDateOfLastOtherPregnancyOutcome, DATE_OF_LAST_OTHER_PREGNANCY_OUTCOME, Mother.Id);
+                if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
+                {
+                    obs.Value = new FhirDateTime();
+                    obs.Value.Extension.Add(NewBlankPartialDateTimeExtension(false));
+                }
+                FhirDateTime newDate = UpdateFhirDateTimeDateElement(obs.Value as FhirDateTime, value, VR.ExtensionURL.PartialDateYearVR);
+                if (newDate != null)
+                {
+                    obs.Value = newDate;
+                }
+            }
+        }
+
+        /// <summary>Date Of Last Other Pregnancy Outcome.</summary>
+        /// <value>Date of Last Other Pregnancy Outcome</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.DateOfLastOtherPregnancyOutcome = "2020-02-19";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Date of Last Other Pregnancy Outcome: {ExampleBirthRecord.DateOfLastOtherPregnancyOutcome}");</para>
+        /// </example>
+        [Property("Date Of Last Other Pregnancy Outcome", Property.Types.String, "Date of Last Other Pregnancy Outcome", "Date of mother's last live birth.", true, IGURL.ObservationDateOfLastOtherPregnancyOutcome, true, 14)]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='68500-8')", "")]
+        public string DateOfLastOtherPregnancyOutcome
+        {
+            get
+            {
+                Observation obs = GetObservation("68500-8");
+                if (obs != null)
+                {
+                    return (obs.Value as Hl7.Fhir.Model.FhirDateTime)?.Value;
+                }
+                return null;
+            }
+            set
+            {
+                Observation obs = GetOrCreateObservation("68500-8", CodeSystems.LOINC, "Date of last other pregnancy outcome", BFDR.ProfileURL.ObservationDateOfLastOtherPregnancyOutcome, DATE_OF_LAST_OTHER_PREGNANCY_OUTCOME, Mother.Id);
+                obs.Value = ConvertToDateTime(value);
+            }
+        }
+
+        /// <summary>NumberOfPrenatalVisits.</summary>
+        /// <value>NumberOfPrenatalVisits</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.NumberOfPrenatalVisits = 4;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"NumberOfPrenatalVisits: {ExampleBirthRecord.NumberOfPrenatalVisits}");</para>
+        /// </example>
+        [Property("Number Of Prenatal Visits", Property.Types.Int32, "Number of Prenatal Visits", "Number of Prenatal Visits.", true, IGURL.ObservationNumberPrenatalVisits, true, 14)]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='68493-6')", "")]
+        public int? NumberOfPrenatalVisits
+        {
+            get => GetIntegerObservationValue("68493-6");
+            set => SetIntegerObservationValue("68493-6", CodeSystems.LOINC, value, BFDR.ProfileURL.ObservationNumberPrenatalVisits, NUMBER_OF_PRENATAL_VISITS, Mother.Id);
+        }
+
+        /// <summary>NumberOfPrenatalVisitsEditFlag.</summary>
+        /// <value>NumberOfPrenatalVisitsEditFlag</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.NumberOfPrenatalVisitsEditFlag = 4;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"NumberOfPrenatalVisitsEditFlag: {ExampleBirthRecord.NumberOfPrenatalVisitsEditFlag}");</para>
+        /// </example>
+        [Property("Number Of Prenatal Visits Edit Flag", Property.Types.Dictionary, "Number of Prenatal Visits", "Number of Prenatal Visits Edit Flag.", true, IGURL.ObservationNumberPrenatalVisits, true, 14)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='68493-6')", "")]
+        public Dictionary<string, string> NumberOfPrenatalVisitsEditFlag
+        {
+            get
+            {
+                Observation obs = GetObservation("68493-6");
+                Extension editFlag = obs?.Value?.Extension.FirstOrDefault(ext => ext.Url == VR.ExtensionURL.BypassEditFlag);
+                if (editFlag != null && editFlag.Value != null && editFlag.Value.GetType() == typeof(CodeableConcept))
+                {
+                    return CodeableConceptToDict((CodeableConcept)editFlag.Value);
+                }
+                return EmptyCodeableDict();
+            }
+            set
+            {
+                if (IsDictEmptyOrDefault(value))
+                {
+                    return;
+                }
+                Observation obs = GetObservation("68493-6");
+                if (obs == null)
+                {
+                    obs = GetOrCreateObservation("68493-6", CodeSystems.LOINC, "Number of prenatal visits", BFDR.ProfileURL.ObservationNumberPrenatalVisits, NUMBER_OF_PRENATAL_VISITS, Mother.Id);
+                    obs.Value = new UnsignedInt();
+                }
+                obs.Value?.Extension.RemoveAll(ext => ext.Url == VR.ExtensionURL.BypassEditFlag);
+                Extension editFlag = new Extension(VR.ExtensionURL.BypassEditFlag, DictToCodeableConcept(value));
+                obs.Value.Extension.Add(editFlag);
+            }
+        }
+
+        /// <summary>
+        /// NumberOfPrenatalVisitsEditFlag Helper
+        /// </summary>
+        [Property("NumberOfPrenatalVisitsEditFlagHelper", Property.Types.String, "Number of Prenatal Visits", "NumberOfPrenatalVisitsEditFlag.", false, IGURL.ObservationNumberPrenatalVisits, true, 2)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='68493-6')", "")]
+        public String NumberOfPrenatalVisitsEditFlagHelper
+        {
+            get
+            {
+                return NumberOfPrenatalVisitsEditFlag.ContainsKey("code") && !String.IsNullOrWhiteSpace(NumberOfPrenatalVisitsEditFlag["code"]) ? NumberOfPrenatalVisitsEditFlag["code"] : null;
+            }
+            set
+            {
+                if (!String.IsNullOrWhiteSpace(value))
+                {
+                    SetCodeValue("NumberOfPrenatalVisitsEditFlag", value, BFDR.ValueSets.PregnancyReportEditFlags.Codes);
+                }
+            }
+        }
+
+        /// <summary>NumberOfOtherPregnancyOutcomes.</summary>
+        /// <value>NumberOfOtherPregnancyOutcomes</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.NumberOfOtherPregnancyOutcomes = 1;</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"NumberOfOtherPregnancyOutcomes: {ExampleBirthRecord.NumberOfOtherPregnancyOutcomes}");</para>
+        /// </example>
+        [Property("NumberOfOtherPregnancyOutcomes", Property.Types.Int32, "Number Of Other Pregnancy Outcomes", "Number Of Other Pregnancy Outcomes", true, IGURL.ObservationNumberOtherPregnancyOutcomes, true, 14)]
+        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='69043-8')", "")]
+        public int? NumberOfOtherPregnancyOutcomes
+        {
+            get => GetIntegerObservationValue("69043-8");
+            set => SetIntegerObservationValue("69043-8", CodeSystems.LOINC, value, BFDR.ProfileURL.ObservationNumberOtherPregnancyOutcomes, NUMBER_OF_OTHER_PREGNANCY_OUTCOMES, Mother.Id);
+        }
+
+        /// <summary>Mother Transferred</summary>
+        /// <value>Mother transferred</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.MotherTransferred = "hosp-trans";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Mother transferred: {ExampleBirthRecord.MotherTransferred}");</para>
+        /// </example>
+        [Property("MotherTransferred", Property.Types.Dictionary, "MotherTransferred", "MotherTransferred", false, VR.IGURL.Mother, true, 288)]
+        [PropertyParam("code", "The code used to describe this concept.")]
+        [PropertyParam("system", "The relevant code system.")]
+        [PropertyParam("display", "The human readable version of this code.")]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "hospitalization")]
+        public Dictionary<string, string> MotherTransferred
+        {
+            get
+            {
+                Dictionary<string, string> admitSource = CodeableConceptToDict(EncounterMaternity?.Hospitalization?.AdmitSource);
+                return admitSource;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    return;
+                }
+                // TODO define CC
+                CodeableConcept admitSource = DictToCodeableConcept(value);
+                HospitalizationComponent hosp = new HospitalizationComponent();
+                hosp.AdmitSource = admitSource;
+                EncounterMaternity.Hospitalization = hosp;
+            }
+        }
+
+        /// <summary>Mother Transferred Helper</summary>
+        /// <value>Mother transferred helper</value>
+        /// <example>
+        /// <para>// Setter:</para>
+        /// <para>ExampleBirthRecord.MotherTransferredHelper = "hosp-trans";</para>
+        /// <para>// Getter:</para>
+        /// <para>Console.WriteLine($"Mother transferred: {ExampleBirthRecord.MotherTransferredHelper}");</para>
+        /// </example>
+        [Property("MotherTransferred", Property.Types.String, "MotherTransferred", "MotherTransferred", false, VR.IGURL.Mother, true, 288)]
+        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "hospitalization")]
+        public string MotherTransferredHelper
+        {
+            get
+            {
+                // TODO there should be a mapping for this
+                if (MotherTransferred.ContainsKey("code"))
+                {
+                    string code = MotherTransferred["code"];
+                    if (code == "hosp-trans")
+                    {
+                        // TODO add check for Transferred From name == "UNKNOWN" and return U
+                        if (FacilityMotherTransferredFrom == "UNKNOWN")
+                        {
+                            return "U";
+                        }
+                        return "Y";
+                    }
+                    if (code == "other")
+                    {
+                        return "N";
+                    }
+                }
+                return "";
+            }
+            set
+            {
+                if (String.IsNullOrEmpty(value))
+                {
+                    return;
+                }
+                // IJE values are Y, N, U, set to "hosp-trans" if value is Y
+                // https://build.fhir.org/ig/HL7/fhir-bfdr/usage.html#mother-or-infant-transferred
+                if (value == "Y")
+                {
+                    MotherTransferred = CodeableConceptToDict(new CodeableConcept(CodeSystems.AdmitSource, "hosp-trans", "Transferred from other hospital", "The Patient has been transferred from another hospital for this encounter."));
+                }
+                else if (value == "U")
+                {
+                    // If the value is unknown, set the code to hosp-trans, and the hospitalization.origin.name should be set to “UNKNOWN” 
+                    // https://build.fhir.org/ig/HL7/fhir-bfdr/usage.html#mother-or-infant-transferred
+                    MotherTransferred = CodeableConceptToDict(new CodeableConcept(CodeSystems.AdmitSource, "hosp-trans", "Transferred from other hospital", "The Patient has been transferred from another hospital for this encounter."));
+                    FacilityMotherTransferredFrom = "UNKNOWN";
+                }
+                else
+                {
+                    // all other codes should be interpretted as N with "other" as the code to express mother did not transfer
+                    MotherTransferred = CodeableConceptToDict(new CodeableConcept(CodeSystems.AdmitSource, "other", "Other", "Did not transfer"));
+                }
+            }
+        }
     }
+
 }

--- a/projects/BFDR/IJEBirth.cs
+++ b/projects/BFDR/IJEBirth.cs
@@ -183,7 +183,7 @@ namespace BFDR
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
-                   TimeAllowingUnknown_Set("TB", "BirthTime", value);
+                    TimeAllowingUnknown_Set("TB", "BirthTime", value);
                 }
             }
         }
@@ -513,15 +513,8 @@ namespace BFDR
         [IJEField(29, 90, 1, "Mother Married?--Ever (NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "MARE", 1)]
         public string MARE
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Mother Married?-- At Conception, at Birth or any Time in Between</summary>
@@ -1582,7 +1575,7 @@ namespace BFDR
         [IJEField(98, 461, 1, "Father's Race--Other Pacific Islander", "FRACE14", 1)]
         public string FRACE14
         {
-             get
+            get
             {
                 return Get_FatherRace(NvssRace.OtherPacificIslander);
             }
@@ -1965,45 +1958,25 @@ namespace BFDR
         [IJEField(129, 761, 2, "Date of Last Prenatal Care Visit--Month(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "DOLP_MO", 1)]
         public string DOLP_MO
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => "  ";
+            set { }
+
         }
 
         /// <summary>Date of Last Prenatal Care Visit--Day(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(130, 763, 2, "Date of Last Prenatal Care Visit--Day(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "DOLP_DY", 1)]
         public string DOLP_DY
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => "  ";
+            set { }
         }
 
         /// <summary>Date of Last Prenatal Care Visit--Year(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(131, 765, 4, "Date of Last Prenatal Care Visit--Year(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "DOLP_YR", 1)]
         public string DOLP_YR
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => "    ";
+            set { }
         }
 
         /// <summary>Total Number of Prenatal Care Visits</summary>
@@ -2050,16 +2023,22 @@ namespace BFDR
             }
             set
             {
-              if (value != "9" && !string.IsNullOrWhiteSpace(value)){
-                if (!string.IsNullOrWhiteSpace(HIN) && HIN != "-1"){
-                    record.MotherHeight = int.Parse(value)*12+int.Parse(HIN);
-                } else {
-                  record.MotherHeight = int.Parse(value);
+                if (value != "9" && !string.IsNullOrWhiteSpace(value))
+                {
+                    if (!string.IsNullOrWhiteSpace(HIN) && HIN != "-1")
+                    {
+                        record.MotherHeight = int.Parse(value) * 12 + int.Parse(HIN);
+                    }
+                    else
+                    {
+                        record.MotherHeight = int.Parse(value);
+                    }
+                    record.MotherHeight = int.Parse(value) * 12;
                 }
-                record.MotherHeight = int.Parse(value)*12;
-              } else {
-                record.MotherHeight = -1;
-              }
+                else
+                {
+                    record.MotherHeight = -1;
+                }
             }
         }
 
@@ -2079,15 +2058,21 @@ namespace BFDR
             }
             set
             {
-              if (value != "99" && !string.IsNullOrWhiteSpace(value)){
-                if (!string.IsNullOrWhiteSpace(HFT) && HFT != "-1"){
-                    record.MotherHeight = int.Parse(value)+(int.Parse(HFT)*12);
-                  } else {
-                    record.MotherHeight = int.Parse(value);
-                  }
-              } else {
-                record.MotherHeight = -1;
-              }
+                if (value != "99" && !string.IsNullOrWhiteSpace(value))
+                {
+                    if (!string.IsNullOrWhiteSpace(HFT) && HFT != "-1")
+                    {
+                        record.MotherHeight = int.Parse(value) + (int.Parse(HFT) * 12);
+                    }
+                    else
+                    {
+                        record.MotherHeight = int.Parse(value);
+                    }
+                }
+                else
+                {
+                    record.MotherHeight = -1;
+                }
             }
         }
 
@@ -2101,7 +2086,7 @@ namespace BFDR
             }
             set
             {
-                Set_MappingIJEToFHIR(BFDR.Mappings.PregnancyReportEditFlags.IJEToFHIR, "HGT_BYPASS", "MotherHeightEditFlag",  value);
+                Set_MappingIJEToFHIR(BFDR.Mappings.PregnancyReportEditFlags.IJEToFHIR, "HGT_BYPASS", "MotherHeightEditFlag", value);
             }
         }
 
@@ -2427,16 +2412,16 @@ namespace BFDR
         [IJEField(162, 825, 1, "Risk Factors--Poor Pregnancy Outcomes(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "PPO", 1)]
         public string PPO
         {
-            get => "U"; // Not present in FHIR
-            set {}
+            get => " "; // Not present in FHIR
+            set { }
         }
 
         /// <summary><html>Risk Factors--Vaginal Bleeding  <b>(NCHS DELETED THIS ITEM EFFECTIVE 2011)</b></html></summary>
         [IJEField(163, 826, 1, "<html>Risk Factors--Vaginal Bleeding  <b>(NCHS DELETED THIS ITEM EFFECTIVE 2011)</b></html>", "VB", 1)]
         public string VB
         {
-            get => "U"; // Not present in FHIR
-            set {}
+            get => " "; // Not present in FHIR
+            set { }
         }
 
         /// <summary>Risk Factors--Infertility Treatment  (SEE ADDITIONAL SUBCATEGORIES IN LOCATIONS 925-926)</summary>
@@ -2503,8 +2488,8 @@ namespace BFDR
         [IJEField(170, 834, 1, "<html>Infections Present--Herpes Simplex (HSV) <b> (NCHS DELETED THIS ITEM EFFECTIVE 2011)</b></html>", "HSV", 1)]
         public string HSV
         {
-            get => PresenceToIJE(record.GenitalHerpesSimplex, record.NoInfectionsPresentDuringPregnancy);
-            set => IJEToPresence(value, (v) => record.GenitalHerpesSimplex = v, (v) => record.NoInfectionsPresentDuringPregnancy = v);
+            get => " ";
+            set { }
         }
 
         /// <summary>Infections Present--Chlamydia</summary>
@@ -2535,30 +2520,16 @@ namespace BFDR
         [IJEField(174, 838, 1, "Obstetric Procedures--Cervical Cerclage(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "CERV", 1)]
         public string CERV
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Obstetric Procedures--Tocolysis(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(175, 839, 1, "Obstetric Procedures--Tocolysis(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "TOC", 1)]
         public string TOC
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Obstetric Procedures--Successful External Cephalic Version</summary>
@@ -2581,45 +2552,24 @@ namespace BFDR
         [IJEField(178, 842, 1, "Onset of Labor--Premature Rupture of Membranes(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "PROM", 1)]
         public string PROM
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Onset of Labor--Precipitous Labor(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(179, 843, 1, "Onset of Labor--Precipitous Labor(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "PRIC", 1)]
         public string PRIC
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Onset of Labor--Prolonged Labor(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(180, 844, 1, "Onset of Labor--Prolonged Labor(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "PROL", 1)]
         public string PROL
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Characteristics of Labor &amp; Delivery--Induction of Labor</summary>
@@ -2642,8 +2592,8 @@ namespace BFDR
         [IJEField(183, 847, 1, "<html>Characteristics of Labor & Delivery--Non-vertex Presentation <b>(NCHS DELETED THIS ITEM EFFECTIVE 2011)</b></html>", "NVPR", 1)]
         public string NVPR
         {
-            get => "U"; // Not present in FHIR
-            set {}
+            get => " "; // Not present in FHIR
+            set { }
         }
 
         /// <summary>Characteristics of Labor &amp; Delivery--Steroids</summary>
@@ -2674,16 +2624,16 @@ namespace BFDR
         [IJEField(187, 851, 1, "Characteristics of Labor & Delivery--Meconium Staining(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "MECS", 1)]
         public string MECS
         {
-            get => "U"; // Not present in FHIR
-            set {}
+            get => " "; // Not present in FHIR
+            set { }
         }
 
         /// <summary>Characteristics of Labor &amp; Delivery--Fetal Intolerance(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(188, 852, 1, "Characteristics of Labor & Delivery--Fetal Intolerance(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "FINT", 1)]
         public string FINT
         {
-            get => "U"; // Not present in FHIR
-            set {}
+            get => " "; // Not present in FHIR
+            set { }
         }
 
         /// <summary>Characteristics of Labor &amp; Delivery--Anesthesia</summary>
@@ -2698,30 +2648,16 @@ namespace BFDR
         [IJEField(190, 854, 1, "<html>Method of Delivery--Attempted Forceps <b>(NCHS DELETED THIS ITEM EFFECTIVE 2011)</b></html>", "ATTF", 1)]
         public string ATTF
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary><html>Method of Delivery--Attempted Vacuum <b>(NCHS DELETED THIS ITEM EFFECTIVE 2011)</b></html></summary>
         [IJEField(191, 855, 1, "<html>Method of Delivery--Attempted Vacuum <b>(NCHS DELETED THIS ITEM EFFECTIVE 2011)</b></html>", "ATTV", 1)]
         public string ATTV
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Method of Delivery--Fetal Presentation</summary>
@@ -2843,8 +2779,8 @@ namespace BFDR
         [IJEField(200, 864, 1, "Maternal Morbidity--Unplanned Operation(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "UOPR", 1)]
         public string UOPR
         {
-            get => "U"; // Not present in FHIR
-            set {}
+            get => " ";
+            set { }
         }
 
         /// <summary>Birthweight in grams</summary>
@@ -2895,7 +2831,7 @@ namespace BFDR
                     }
                     else if (record.GestationalAgeAtDelivery["code"] == "d")
                     {
-                        int days = (int)(Convert.ToDecimal(record.GestationalAgeAtDelivery["value"])/7);
+                        int days = (int)(Convert.ToDecimal(record.GestationalAgeAtDelivery["value"]) / 7);
                         return Truncate(days.ToString(), info.Length).PadLeft(info.Length, '0');
                     }
 
@@ -3066,8 +3002,8 @@ namespace BFDR
         [IJEField(218, 896, 1, "Abnormal Conditions of the Newborn--Birth Injury(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "BINJ", 1)]
         public string BINJ
         {
-            get => "U"; // Not present in FHIR
-            set {}
+            get => " ";
+            set { }
         }
 
         /// <summary>Congenital Anomalies of the Newborn--Anencephaly</summary>
@@ -3502,7 +3438,8 @@ namespace BFDR
         {
             get
             {
-                return LeftJustified_Get("MOMLNAME", "MotherFamilyName");            }
+                return LeftJustified_Get("MOMLNAME", "MotherFamilyName");
+            }
             set
             {
                 LeftJustified_Set("MOMLNAME", "MotherFamilyName", value);
@@ -3796,7 +3733,8 @@ namespace BFDR
         {
             get
             {
-                return LeftJustified_Get("DADLNAME", "FatherFamilyName");            }
+                return LeftJustified_Get("DADLNAME", "FatherFamilyName");
+            }
             set
             {
                 LeftJustified_Set("DADLNAME", "FatherFamilyName", value);
@@ -4230,7 +4168,7 @@ namespace BFDR
         {
             get
             {
-                string stateName =  IJEData.Instance.StateCodeToStateName(BPLACEC_ST_TER);
+                string stateName = IJEData.Instance.StateCodeToStateName(BPLACEC_ST_TER);
                 if (!String.IsNullOrWhiteSpace(stateName))
                 {
                     return Truncate(stateName, 28).PadRight(28, ' ');
@@ -4249,7 +4187,7 @@ namespace BFDR
         {
             get
             {
-                string countryName =  IJEData.Instance.CountryCodeToCountryName(BPLACEC_CNT);
+                string countryName = IJEData.Instance.CountryCodeToCountryName(BPLACEC_CNT);
                 if (!String.IsNullOrWhiteSpace(countryName))
                 {
                     return Truncate(countryName, 28).PadRight(28, ' ');
@@ -4268,7 +4206,7 @@ namespace BFDR
         {
             get
             {
-                string stateName =  IJEData.Instance.StateCodeToStateName(FBPLACD_ST_TER_C);
+                string stateName = IJEData.Instance.StateCodeToStateName(FBPLACD_ST_TER_C);
                 if (!String.IsNullOrWhiteSpace(stateName))
                 {
                     return Truncate(stateName, 28).PadRight(28, ' ');
@@ -4287,7 +4225,7 @@ namespace BFDR
         {
             get
             {
-                string countryName =  IJEData.Instance.CountryCodeToCountryName(FBPLACE_CNT_C);
+                string countryName = IJEData.Instance.CountryCodeToCountryName(FBPLACE_CNT_C);
                 if (!String.IsNullOrWhiteSpace(countryName))
                 {
                     return Truncate(countryName, 28).PadRight(28, ' ');
@@ -4733,11 +4671,11 @@ namespace BFDR
         {
             get
             {
-                 return NumericAllowingUnknown_Get("CERTIFIED_YR", "CertifiedYear");
+                return NumericAllowingUnknown_Get("CERTIFIED_YR", "CertifiedYear");
             }
             set
             {
-                 NumericAllowingUnknown_Set("CERTIFIED_YR", "CertifiedYear", value);
+                NumericAllowingUnknown_Set("CERTIFIED_YR", "CertifiedYear", value);
             }
         }
 

--- a/projects/BFDR/IJEFetalDeath.cs
+++ b/projects/BFDR/IJEFetalDeath.cs
@@ -115,7 +115,7 @@ namespace BFDR
             }
         }
 
-       /// <summary>NCHS ICD10 to actual ICD10 </summary>
+        /// <summary>NCHS ICD10 to actual ICD10 </summary>
         private string NCHSICD10toActualICD10(string nchsicd10code)
         {
             string code = "";
@@ -256,7 +256,7 @@ namespace BFDR
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
-                   TimeAllowingUnknown_Set("TD", "DeliveryTime", value);
+                    TimeAllowingUnknown_Set("TD", "DeliveryTime", value);
                 }
             }
         }
@@ -586,30 +586,16 @@ namespace BFDR
         [IJEField(29, 90, 1, "Mother Married?--Ever(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "MARE", 1)]
         public string MARE
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Mother Married?-- At Conception, at Delivery or any Time in Between(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(30, 91, 1, "Mother Married?-- At Conception, at Delivery or any Time in Between(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "MARN", 1)]
         public string MARN
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         // <summary>FILLER</summary>
@@ -1308,15 +1294,8 @@ namespace BFDR
         [IJEField(79, 423, 1, "Mother Transferred?(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "TRAN", 1)]
         public string TRAN
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Date of First Prenatal Care Visit--Month</summary>
@@ -1365,75 +1344,40 @@ namespace BFDR
         [IJEField(83, 432, 2, "Date of Last Prenatal Care Visit--Month(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "DOLP_MO", 1)]
         public string DOLP_MO
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => "  ";
+            set { }
         }
 
         /// <summary>Date of Last Prenatal Care Visit--Day(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(84, 434, 2, "Date of Last Prenatal Care Visit--Day(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "DOLP_DY", 1)]
         public string DOLP_DY
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => "  ";
+            set { }
         }
 
         /// <summary>Date of Last Prenatal Care Visit--Year(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(85, 436, 4, "Date of Last Prenatal Care Visit--Year(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "DOLP_YR", 1)]
         public string DOLP_YR
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => "    ";
+            set { }
         }
 
         /// <summary>Total Number of Prenatal Care Visits(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(86, 440, 2, "Total Number of Prenatal Care Visits(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "NPREV", 1)]
         public string NPREV
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => "  ";
+            set { }
         }
 
         /// <summary>Total Number of Prenatal Care Visits--Edit Flag(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(87, 442, 1, "Total Number of Prenatal Care Visits--Edit Flag(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "NPREV_BYPASS", 1)]
         public string NPREV_BYPASS
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Mother's Height--Feet</summary>
@@ -1452,16 +1396,22 @@ namespace BFDR
             }
             set
             {
-              if (value != "9" && !string.IsNullOrWhiteSpace(value)){
-                if (!string.IsNullOrWhiteSpace(HIN) && HIN != "-1"){
-                    record.MotherHeight = int.Parse(value)*12+int.Parse(HIN);
-                } else {
-                  record.MotherHeight = int.Parse(value);
+                if (value != "9" && !string.IsNullOrWhiteSpace(value))
+                {
+                    if (!string.IsNullOrWhiteSpace(HIN) && HIN != "-1")
+                    {
+                        record.MotherHeight = int.Parse(value) * 12 + int.Parse(HIN);
+                    }
+                    else
+                    {
+                        record.MotherHeight = int.Parse(value);
+                    }
+                    record.MotherHeight = int.Parse(value) * 12;
                 }
-                record.MotherHeight = int.Parse(value)*12;
-              } else {
-                record.MotherHeight = -1;
-              }
+                else
+                {
+                    record.MotherHeight = -1;
+                }
             }
         }
 
@@ -1481,15 +1431,21 @@ namespace BFDR
             }
             set
             {
-              if (value != "99" && !string.IsNullOrWhiteSpace(value)){
-                if (!string.IsNullOrWhiteSpace(HFT) && HFT != "-1"){
-                    record.MotherHeight = int.Parse(value)+(int.Parse(HFT)*12);
-                  } else {
-                    record.MotherHeight = int.Parse(value);
-                  }
-              } else {
-                record.MotherHeight = -1;
-              }
+                if (value != "99" && !string.IsNullOrWhiteSpace(value))
+                {
+                    if (!string.IsNullOrWhiteSpace(HFT) && HFT != "-1")
+                    {
+                        record.MotherHeight = int.Parse(value) + (int.Parse(HFT) * 12);
+                    }
+                    else
+                    {
+                        record.MotherHeight = int.Parse(value);
+                    }
+                }
+                else
+                {
+                    record.MotherHeight = -1;
+                }
             }
         }
 
@@ -1503,7 +1459,7 @@ namespace BFDR
             }
             set
             {
-                Set_MappingIJEToFHIR(BFDR.Mappings.PregnancyReportEditFlags.IJEToFHIR, "HGT_BYPASS", "MotherHeightEditFlag",  value);
+                Set_MappingIJEToFHIR(BFDR.Mappings.PregnancyReportEditFlags.IJEToFHIR, "HGT_BYPASS", "MotherHeightEditFlag", value);
             }
         }
 
@@ -1539,7 +1495,7 @@ namespace BFDR
         [IJEField(95, 455, 1, "Did Mother get WIC Food for Herself?", "WIC", 1)]
         public string WIC
         {
-             get
+            get
             {
                 return Get_MappingFHIRToIJE(VR.Mappings.YesNoUnknown.FHIRToIJE, "MotherReceivedWICFood", "WIC");
             }
@@ -1584,15 +1540,8 @@ namespace BFDR
         [IJEField(98, 460, 2, "Previous Other Pregnancy Outcomes(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "POPO", 1)]
         public string POPO
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => "  ";
+            set { }
         }
 
         /// <summary>Date of Last Live Birth--Month</summary>
@@ -1627,30 +1576,16 @@ namespace BFDR
         [IJEField(101, 468, 2, "Date of Last Other Pregnancy Outcome--Month(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "MOPO", 1)]
         public string MOPO
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => "  ";
+            set { }
         }
 
         /// <summary>Date of Last Other Pregnancy Outcome--Year(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(102, 470, 4, "Date of Last Other Pregnancy Outcome--Year(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "YOPO", 1)]
         public string YOPO
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => "    ";
+            set { }
         }
 
         /// <summary>Number of Cigarettes Smoked in 3 months prior to Pregnancy</summary>
@@ -1787,45 +1722,24 @@ namespace BFDR
         [IJEField(114, 494, 1, "Risk Factors--Previous Preterm Births(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "PPB", 1)]
         public string PPB
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => "";
+            set { }
         }
 
         /// <summary>Risk Factors--Poor Pregnancy Outcomes(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(115, 495, 1, "Risk Factors--Poor Pregnancy Outcomes(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "PPO", 1)]
         public string PPO
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary><html>Risk Factors--Vaginal Bleeding <b><i> (NCHS DELETED THIS ITEM EFFECTIVE 2011)</i></b></html></summary>
         [IJEField(116, 496, 1, "<html>Risk Factors--Vaginal Bleeding <b><i> (NCHS DELETED THIS ITEM EFFECTIVE 2011)</i></b></html>", "VB", 1)]
         public string VB
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary><html>Risk Factors--Infertility Treatment  <b>(SEE ADDITIONAL SUBCATEGORIES IN LOCATIONS 574-575)</b></html></summary>
@@ -1876,180 +1790,96 @@ namespace BFDR
         [IJEField(121, 502, 1, "Infections Present--Gonorrhea(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "GON", 1)]
         public string GON
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Infections Present--Syphilis(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(122, 503, 1, "Infections Present--Syphilis(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "SYPH", 1)]
         public string SYPH
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary><html>Infections Present--Herpes Simplex (HSV) <b><i>(NCHS DELETED THIS ITEM EFFECTIVE 2011)</i></b></html></summary>
         [IJEField(123, 504, 1, "<html>Infections Present--Herpes Simplex (HSV) <b><i>(NCHS DELETED THIS ITEM EFFECTIVE 2011)</i></b></html>", "HSV", 1)]
         public string HSV
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Infections Present--Chlamydia(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(124, 505, 1, "Infections Present--Chlamydia(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "CHAM", 1)]
         public string CHAM
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Infections Present--Listeria(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(125, 506, 1, "Infections Present--Listeria(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "LM", 1)]
         public string LM
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Infections Present--Group B streptococcus(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(126, 507, 1, "Infections Present--Group B streptococcus(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "GBS", 1)]
         public string GBS
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Infections Present--Cytomeglovirus(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(127, 508, 1, "Infections Present--Cytomeglovirus(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "CMV", 1)]
         public string CMV
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Infections Present--Parvo virus(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(128, 509, 1, "Infections Present--Parvo virus(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "B19", 1)]
         public string B19
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Infections Present--Toxoplasmosis(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(129, 510, 1, "Infections Present--Toxoplasmosis(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "TOXO", 1)]
         public string TOXO
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Infections Present--Other(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(130, 511, 1, "Infections Present--Other(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "OTHERI", 1)]
         public string OTHERI
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary><html>Method of Delivery--Attempted Forceps<b><i> (NCHS DELETED THIS ITEM EFFECTIVE 2011)</i></b></html></summary>
         [IJEField(131, 512, 1, "<html>Method of Delivery--Attempted Forceps<b><i> (NCHS DELETED THIS ITEM EFFECTIVE 2011)</i></b></html>", "ATTF", 1)]
         public string ATTF
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary><html>Method of Delivery--Attempted Vacuum <b><i>(NCHS DELETED THIS ITEM EFFECTIVE 2011)</i></b></html></summary>
         [IJEField(132, 513, 1, "<html>Method of Delivery--Attempted Vacuum <b><i>(NCHS DELETED THIS ITEM EFFECTIVE 2011)</i></b></html>", "ATTV", 1)]
         public string ATTV
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Method of Delivery--Fetal Presentation</summary>
@@ -2133,45 +1963,24 @@ namespace BFDR
         [IJEField(136, 517, 1, "Method of Delivery--Hysterotomy/Hysterectomy(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "HYST", 1)]
         public string HYST
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Maternal Morbidity--Maternal Transfusion(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(137, 518, 1, "Maternal Morbidity--Maternal Transfusion(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "MTR", 1)]
         public string MTR
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Maternal Morbidity--Perineal Laceration(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(138, 519, 1, "Maternal Morbidity--Perineal Laceration(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "PLAC", 1)]
         public string PLAC
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Maternal Morbidity--Ruptured Uterus</summary>
@@ -2186,15 +1995,8 @@ namespace BFDR
         [IJEField(140, 521, 1, "Maternal Morbidity--Unplanned Hysterectomy(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "UHYS", 1)]
         public string UHYS
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Maternal Morbidity--Admit to Intensive Care</summary>
@@ -2209,15 +2011,8 @@ namespace BFDR
         [IJEField(142, 523, 1, "Maternal Morbidity--Unplanned Operation(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "UOPR", 1)]
         public string UOPR
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Weight of Fetus</summary>
@@ -2268,7 +2063,7 @@ namespace BFDR
                     }
                     else if (record.GestationalAgeAtDelivery["code"] == "d")
                     {
-                        int days = (int)(Convert.ToDecimal(record.GestationalAgeAtDelivery["value"])/7);
+                        int days = (int)(Convert.ToDecimal(record.GestationalAgeAtDelivery["value"]) / 7);
                         return Truncate(days.ToString(), info.Length).PadLeft(info.Length, '0');
                     }
 
@@ -2440,180 +2235,96 @@ namespace BFDR
         [IJEField(156, 549, 1, "Congenital Anomalies of the Fetus--Anencephaly(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "ANEN", 1)]
         public string ANEN
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Congenital Anomalies of the Fetus--Meningomyelocele/Spina Bifida(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(157, 550, 1, "Congenital Anomalies of the Fetus--Meningomyelocele/Spina Bifida(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "MNSB", 1)]
         public string MNSB
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Congenital Anomalies of the Fetus--Cyanotic congenital heart disease(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(158, 551, 1, "Congenital Anomalies of the Fetus--Cyanotic congenital heart disease(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "CCHD", 1)]
         public string CCHD
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Congenital Anomalies of the Fetus--Congenital diaphragmatic hernia(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(159, 552, 1, "Congenital Anomalies of the Fetus--Congenital diaphragmatic hernia(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "CDH", 1)]
         public string CDH
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Congenital Anomalies of the Fetus--Omphalocele(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(160, 553, 1, "Congenital Anomalies of the Fetus--Omphalocele(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "OMPH", 1)]
         public string OMPH
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Congenital Anomalies of the Fetus--Gastroschisis(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(161, 554, 1, "Congenital Anomalies of the Fetus--Gastroschisis(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "GAST", 1)]
         public string GAST
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Congenital Anomalies of the Fetus--Limb Reduction Defect(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(162, 555, 1, "Congenital Anomalies of the Fetus--Limb Reduction Defect(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "LIMB", 1)]
         public string LIMB
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Congenital Anomalies of the Fetus--Cleft Lip with or without Cleft Palate(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(163, 556, 1, "Congenital Anomalies of the Fetus--Cleft Lip with or without Cleft Palate(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "CL", 1)]
         public string CL
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Congenital Anomalies of the Fetus--Cleft Palate Alone(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(164, 557, 1, "Congenital Anomalies of the Fetus--Cleft Palate Alone(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "CP", 1)]
         public string CP
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Congenital Anomalies of the Fetus--Down Syndrome(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(165, 558, 1, "Congenital Anomalies of the Fetus--Down Syndrome(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "DOWT", 1)]
         public string DOWT
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Congenital Anomalies of the Fetus--Suspected Chromosomal disorder(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(166, 559, 1, "Congenital Anomalies of the Fetus--Suspected Chromosomal disorder(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "CDIT", 1)]
         public string CDIT
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>Congenital Anomalies of the Fetus--Hypospadias(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)</summary>
         [IJEField(167, 560, 1, "Congenital Anomalies of the Fetus--Hypospadias(NCHS DELETED THIS ITEM EFFECTIVE 2014/2015)", "HYPO", 1)]
         public string HYPO
         {
-            get
-            {
-                // TODO: Implement mapping from FHIR record location:
-                return "";
-            }
-            set
-            {
-                // TODO: Implement mapping to FHIR record location:
-            }
+            get => " ";
+            set { }
         }
 
         /// <summary>NCHS USE ONLY: Receipt date -- Year</summary>
@@ -3483,7 +3194,8 @@ namespace BFDR
         {
             get
             {
-                return LeftJustified_Get("MOMLNAME", "MotherFamilyName");            }
+                return LeftJustified_Get("MOMLNAME", "MotherFamilyName");
+            }
             set
             {
                 LeftJustified_Set("MOMLNAME", "MotherFamilyName", value);
@@ -3833,7 +3545,8 @@ namespace BFDR
         {
             get
             {
-                return LeftJustified_Get("DADLNAME", "FatherFamilyName");            }
+                return LeftJustified_Get("DADLNAME", "FatherFamilyName");
+            }
             set
             {
                 LeftJustified_Set("DADLNAME", "FatherFamilyName", value);
@@ -4076,7 +3789,7 @@ namespace BFDR
         {
             get
             {
-                string stateName =  IJEData.Instance.StateCodeToStateName(BPLACEC_ST_TER);
+                string stateName = IJEData.Instance.StateCodeToStateName(BPLACEC_ST_TER);
                 if (!String.IsNullOrWhiteSpace(stateName))
                 {
                     return Truncate(stateName, 28).PadRight(28, ' ');
@@ -4095,7 +3808,7 @@ namespace BFDR
         {
             get
             {
-                string countryName =  IJEData.Instance.CountryCodeToCountryName(BPLACEC_CNT);
+                string countryName = IJEData.Instance.CountryCodeToCountryName(BPLACEC_CNT);
                 if (!String.IsNullOrWhiteSpace(countryName))
                 {
                     return Truncate(countryName, 28).PadRight(28, ' ');
@@ -4114,7 +3827,7 @@ namespace BFDR
         {
             get
             {
-                string stateName =  IJEData.Instance.StateCodeToStateName(FBPLACD_ST_TER_C);
+                string stateName = IJEData.Instance.StateCodeToStateName(FBPLACD_ST_TER_C);
                 if (!String.IsNullOrWhiteSpace(stateName))
                 {
                     return Truncate(stateName, 28).PadRight(28, ' ');
@@ -4133,7 +3846,7 @@ namespace BFDR
         {
             get
             {
-                string countryName =  IJEData.Instance.CountryCodeToCountryName(FBPLACE_CNT_C);
+                string countryName = IJEData.Instance.CountryCodeToCountryName(FBPLACE_CNT_C);
                 if (!String.IsNullOrWhiteSpace(countryName))
                 {
                     return Truncate(countryName, 28).PadRight(28, ' ');
@@ -4511,7 +4224,7 @@ namespace BFDR
         [IJEField(303, 4328, 1, "Father's Race--Other Pacific Islander", "FRACE14", 1)]
         public string FRACE14
         {
-             get
+            get
             {
                 return Get_FatherRace(NvssRace.OtherPacificIslander);
             }
@@ -5046,11 +4759,11 @@ namespace BFDR
         {
             get
             {
-                 return NumericAllowingUnknown_Get("CERTIFIED_YR", "CertifiedYear");
+                return NumericAllowingUnknown_Get("CERTIFIED_YR", "CertifiedYear");
             }
             set
             {
-                 NumericAllowingUnknown_Set("CERTIFIED_YR", "CertifiedYear", value);
+                NumericAllowingUnknown_Set("CERTIFIED_YR", "CertifiedYear", value);
             }
         }
 
@@ -5060,11 +4773,11 @@ namespace BFDR
         {
             get
             {
-                 return NumericAllowingUnknown_Get("CERTIFIED_MO", "CertifiedMonth");
+                return NumericAllowingUnknown_Get("CERTIFIED_MO", "CertifiedMonth");
             }
             set
             {
-                 NumericAllowingUnknown_Set("CERTIFIED_MO", "CertifiedMonth", value);
+                NumericAllowingUnknown_Set("CERTIFIED_MO", "CertifiedMonth", value);
             }
         }
 

--- a/projects/BFDR/NatalityRecord_fieldsAndCreateMethods.cs
+++ b/projects/BFDR/NatalityRecord_fieldsAndCreateMethods.cs
@@ -47,7 +47,7 @@ namespace BFDR
         private const string COMPOSITION_PROVIDER_FETAL_DEATH_REPORT = "69045-3";
         private const string COMPOSITION_PROVIDER_LIVE_BIRTH_REPORT = "68998-4";
         private const string COMPOSITION_JURISDICTION_FETAL_DEATH_REPORT = "92010-8";
-        private const string COMPOSITION_JURISDICTION_LIVE_BIRTH_REPORT  ="92011-6";
+        private const string COMPOSITION_JURISDICTION_LIVE_BIRTH_REPORT = "92011-6";
         /// <summary>Composition code coded cause of fetal death</summary>
         protected const string COMPOSITION_CODED_CAUSE_OF_FETAL_DEATH = "86804-2";
         private const string COMPOSITION_CODED_RACE_AND_ETHNICITY = "86805-9";
@@ -69,12 +69,15 @@ namespace BFDR
         private const string SUCCESSFUL_OUTCOME = "385669000";
         private const string UNSUCCESSFUL_OUTCOME = "385671000";
         private const string DATE_OF_LAST_LIVE_BIRTH = "68499-3";
-        private const string DATE_OF_LAST_OTHER_PREGNANCY_OUTCOME = "68500-8";
-        private const string NUMBER_OF_PRENATAL_VISITS = "68493-6";
+        /// <summary>Date of Last Other Pregnancy Outcome Section Constant</summary>
+        protected const string DATE_OF_LAST_OTHER_PREGNANCY_OUTCOME = "68500-8";
+        /// <summary>Number of Prenatal Visits Section Constant</summary>
+        protected const string NUMBER_OF_PRENATAL_VISITS = "68493-6";
         private const string GESTATIONAL_AGE = "11884-4";
-        private const string NUMBER_OF_BIRTHS_NOW_DEAD = "68496-9"; 
+        private const string NUMBER_OF_BIRTHS_NOW_DEAD = "68496-9";
         private const string NUMBER_OF_BIRTHS_NOW_LIVING = "11638-4";
-        private const string NUMBER_OF_OTHER_PREGNANCY_OUTCOMES = "69043-8";
+        /// <summary>Number of Other Pregnancy Outcomes Section Constant</summary>
+        protected const string NUMBER_OF_OTHER_PREGNANCY_OUTCOMES = "69043-8";
         private const string MOTHER_RECEIVED_WIC_FOOD = "87303-4";
         private const string INFANT_BREASTFED_AT_DISCHARGE = "73756-9";
 
@@ -95,17 +98,17 @@ namespace BFDR
             {
                 return new string[] {
                     MOTHER_PRENATAL_SECTION, MEDICAL_INFORMATION_SECTION, NEWBORN_INFORMATION_SECTION, MOTHER_INFORMATION_SECTION,
-                    FATHER_INFORMATION_SECTION, PATIENT_QUESTIONAIRRE_RESPONSE_SECTION, EMERGING_ISSUES_SECTION, RACE_ETHNICITY_MOTHER, 
+                    FATHER_INFORMATION_SECTION, PATIENT_QUESTIONAIRRE_RESPONSE_SECTION, EMERGING_ISSUES_SECTION, RACE_ETHNICITY_MOTHER,
                     RACE_ETHNICITY_FATHER, DATE_OF_LAST_LIVE_BIRTH, DATE_OF_LAST_OTHER_PREGNANCY_OUTCOME, NUMBER_OF_PRENATAL_VISITS,
-                    GESTATIONAL_AGE, NUMBER_OF_BIRTHS_NOW_DEAD, NUMBER_OF_BIRTHS_NOW_LIVING, NUMBER_OF_OTHER_PREGNANCY_OUTCOMES, MOTHER_RECEIVED_WIC_FOOD, 
+                    GESTATIONAL_AGE, NUMBER_OF_BIRTHS_NOW_DEAD, NUMBER_OF_BIRTHS_NOW_LIVING, NUMBER_OF_OTHER_PREGNANCY_OUTCOMES, MOTHER_RECEIVED_WIC_FOOD,
                     INFANT_BREASTFED_AT_DISCHARGE
                 };
-            } 
+            }
         }
 
         /// <summary>Birth record composition sections use LOINC codes</summary>
         protected override string CompositionSectionCodeSystem { get => VR.CodeSystems.LOINC; }
-        
+
         /// <summary>Use annotation on the property to determine whether the subject is
         /// the mother or newborn, then extract the corresponding resource id.</summary>
         /// <param name="propertyName">name of the NatalityRecord property</param>
@@ -132,15 +135,15 @@ namespace BFDR
             Attendant.Extension.Add(roleExt);
             // Not linked to Composition or inserted in bundle, since this is run before the composition exists.
         }
-    
-            /// <summary>Create Certifier/Practitioner.</summary>
+
+        /// <summary>Create Certifier/Practitioner.</summary>
         protected void CreateCertifier()
         {
             Certifier = new Practitioner();
-            Certifier .Id = Guid.NewGuid().ToString();
-            Certifier .Meta = new Meta();
+            Certifier.Id = Guid.NewGuid().ToString();
+            Certifier.Meta = new Meta();
             string[] certifier_profile = { BFDR.ExtensionURL.PractitionerBirthCertifier };
-            Certifier .Meta.Profile = certifier_profile;
+            Certifier.Meta.Profile = certifier_profile;
             Extension roleExt = new Extension(BFDR.ExtensionURL.ExtensionRole, new Code("certifier"));
             Certifier.Extension.Add(roleExt);
             // Not linked to Composition or inserted in bundle, since this is run before the composition exists.
@@ -167,7 +170,7 @@ namespace BFDR
             Bundle.AddResourceEntry(locationBirth, "urn:uuid:" + locationBirth.Id);
             return locationBirth;
         }
-        
+
 
         /// <summary>Create Maternity Encounter.</summary>
         protected Encounter CreateMaternityEncounter()

--- a/projects/BFDR/NatalityRecord_submissionProperties.cs
+++ b/projects/BFDR/NatalityRecord_submissionProperties.cs
@@ -225,7 +225,8 @@ namespace BFDR
             {
                 FhirDateTime dateTime = (FhirDateTime)Subject.BirthDateElement.GetExtension(VR.ExtensionURL.PatientBirthTime).Value;
                 string time = GetTimeFragment(dateTime);
-                if (time != null) {
+                if (time != null)
+                {
                     return time;
                 }
             }
@@ -664,7 +665,7 @@ namespace BFDR
                     // TODO - determine how YC/Jurisdictional checks should be handled and update. For now, this just sets the state of the PlaceOfBirth.
                     if (value == "YC")
                     {
-                         currentAddress["addressState"] = "NY";
+                        currentAddress["addressState"] = "NY";
                     }
                     else
                     {
@@ -714,7 +715,7 @@ namespace BFDR
                     Console.WriteLine($"Failed to set PlaceOfBirth: {ex}");
                 }
 
-                
+
             }
         }
 
@@ -744,7 +745,7 @@ namespace BFDR
         public Dictionary<string, string> MotherPlaceOfBirth
         {
             get => GetPlaceOfBirth(Mother);
-            set 
+            set
             {
                 try
                 {
@@ -864,7 +865,7 @@ namespace BFDR
                 // before clearing, save the city limits value and billing
                 Address billing = Mother.Address.Find(addr => addr.Use == Address.AddressUse.Billing);
                 Dictionary<string, string> cityLimits = MotherResidenceWithinCityLimits;
-                
+
                 Mother.Address.Clear();
                 Address residence = DictToAddress(value);
                 residence.Use = Address.AddressUse.Home;
@@ -1399,152 +1400,7 @@ namespace BFDR
             }
         }
 
-        //
-        // Congenital Anomalies of the Newborn Section
-        //
 
-        /// <summary>No Congenital Anomalies of the Newborn.</summary>
-        [Property("No Congenital Anomalies of the Newborn", Property.Types.Bool, "Congenital Anomalies of the Newborn",
-                  "No Congenital Anomalies of the Newborn", true, IGURL.ObservationNoneOfSpecifiedCongenitalAnomoliesOfTheNewborn, false, 219)]
-        [FHIRPath(fhirType: FHIRPath.FhirType.Observation, categoryCode: "73780-9", code: VitalRecord.NONE_OF_THE_ABOVE, section: NEWBORN_INFORMATION_SECTION)]
-        [FHIRSubject(FHIRSubject.Subject.Newborn)]
-        public bool NoCongenitalAnomaliesOfTheNewborn
-        {
-            get => EntryExists();
-            set => UpdateEntry(value);
-        }
-
-        /// <summary>Congenital Anomalies of the Newborn, Anencephaly.</summary>
-        [Property("Anencephaly", Property.Types.Bool, "Congenital Anomalies of the Newborn",
-                  "Congenital Anomalies of the Newborn, Anencephaly", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 219)]
-        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "89369001", section: NEWBORN_INFORMATION_SECTION)]
-        [FHIRSubject(FHIRSubject.Subject.Newborn)]
-        public bool Anencephaly
-        {
-            get => EntryExists();
-            set => UpdateEntry(value);
-        }
-
-        /// <summary>Congenital Anomalies of the Newborn, Cleft Lip with or without Cleft Palate.</summary>
-        [Property("Cleft Lip with or without Cleft Palate", Property.Types.Bool, "Congenital Anomalies of the Newborn",
-                  "Congenital Anomalies of the Newborn, Cleft Lip with or without Cleft Palate", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 226)]
-        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "80281008", section: NEWBORN_INFORMATION_SECTION)]
-        [FHIRSubject(FHIRSubject.Subject.Newborn)]
-        public bool CleftLipWithOrWithoutCleftPalate
-        {
-            get => EntryExists();
-            set => UpdateEntry(value);
-        }
-
-        /// <summary>Congenital Anomalies of the Newborn, Cleft Palate Alone.</summary>
-        [Property("Cleft Palate Alone", Property.Types.Bool, "Congenital Anomalies of the Newborn",
-                  "Congenital Anomalies of the Newborn, Cleft Palate Alone", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 227)]
-        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "87979003", section: NEWBORN_INFORMATION_SECTION)]
-        [FHIRSubject(FHIRSubject.Subject.Newborn)]
-        public bool CleftPalateAlone
-        {
-            get => EntryExists();
-            set => UpdateEntry(value);
-        }
-
-        /// <summary>Congenital Anomalies of the Newborn, Congenital Diaphragmatic Hernia.</summary>
-        [Property("Congenital Diaphragmatic Hernia", Property.Types.Bool, "Congenital Anomalies of the Newborn",
-                  "Congenital Anomalies of the Newborn, Congenital Diaphragmatic Hernia", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 222)]
-        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "17190001", section: NEWBORN_INFORMATION_SECTION)]
-        [FHIRSubject(FHIRSubject.Subject.Newborn)]
-        public bool CongenitalDiaphragmaticHernia
-        {
-            get => EntryExists();
-            set => UpdateEntry(value);
-        }
-
-        /// <summary>Congenital Anomalies of the Newborn, Cyanotic Congenital Heart Disease.</summary>
-        [Property("Cyanotic Congenital Heart Disease", Property.Types.Bool, "Congenital Anomalies of the Newborn",
-                  "Congenital Anomalies of the Newborn, Cyanotic Congenital Heart Disease", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 221)]
-        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "12770006", section: NEWBORN_INFORMATION_SECTION)]
-        [FHIRSubject(FHIRSubject.Subject.Newborn)]
-        public bool CyanoticCongenitalHeartDisease
-        {
-            get => EntryExists();
-            set => UpdateEntry(value);
-        }
-
-        /// <summary>Congenital Anomalies of the Newborn, Down Syndrome.</summary>
-        [Property("Down Syndrome", Property.Types.Bool, "Congenital Anomalies of the Newborn",
-                  "Congenital Anomalies of the Newborn, Down Syndrome", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 228)]
-        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "70156005", section: NEWBORN_INFORMATION_SECTION)]
-        [FHIRSubject(FHIRSubject.Subject.Newborn)]
-        public bool DownSyndrome
-        {
-            get => EntryExists();
-            set => UpdateEntry(value);
-        }
-
-        /// <summary>Congenital Anomalies of the Newborn, Gastroschisis.</summary>
-        [Property("Gastroschisis", Property.Types.Bool, "Congenital Anomalies of the Newborn",
-                  "Congenital Anomalies of the Newborn, Gastroschisis", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 224)]
-        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "72951007", section: NEWBORN_INFORMATION_SECTION)]
-        [FHIRSubject(FHIRSubject.Subject.Newborn)]
-        public bool Gastroschisis
-        {
-            get => EntryExists();
-            set => UpdateEntry(value);
-        }
-
-        /// <summary>Congenital Anomalies of the Newborn, Hypospadias.</summary>
-        [Property("Hypospadias", Property.Types.Bool, "Congenital Anomalies of the Newborn",
-                  "Congenital Anomalies of the Newborn, Hypospadias", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 230)]
-        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "416010008", section: NEWBORN_INFORMATION_SECTION)]
-        [FHIRSubject(FHIRSubject.Subject.Newborn)]
-        public bool Hypospadias
-        {
-            get => EntryExists();
-            set => UpdateEntry(value);
-        }
-
-        /// <summary>Congenital Anomalies of the Newborn, Limb Reduction Defect.</summary>
-        [Property("Limb Reduction Defect", Property.Types.Bool, "Congenital Anomalies of the Newborn",
-                  "Congenital Anomalies of the Newborn, Limb Reduction Defect", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 225)]
-        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "67341007", section: NEWBORN_INFORMATION_SECTION)]
-        [FHIRSubject(FHIRSubject.Subject.Newborn)]
-        public bool LimbReductionDefect
-        {
-            get => EntryExists();
-            set => UpdateEntry(value);
-        }
-
-        /// <summary>Congenital Anomalies of the Newborn, Meningomyelocele.</summary>
-        [Property("Meningomyelocele", Property.Types.Bool, "Congenital Anomalies of the Newborn",
-                  "Congenital Anomalies of the Newborn, Meningomyelocele", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 220)]
-        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "67531005", section: NEWBORN_INFORMATION_SECTION)]
-        [FHIRSubject(FHIRSubject.Subject.Newborn)]
-        public bool Meningomyelocele
-        {
-            get => EntryExists();
-            set => UpdateEntry(value);
-        }
-
-        /// <summary>Congenital Anomalies of the Newborn, Omphalocele.</summary>
-        [Property("Omphalocele", Property.Types.Bool, "Congenital Anomalies of the Newborn",
-                  "Congenital Anomalies of the Newborn, Omphalocele", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 223)]
-        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "18735004", section: NEWBORN_INFORMATION_SECTION)]
-        [FHIRSubject(FHIRSubject.Subject.Newborn)]
-        public bool Omphalocele
-        {
-            get => EntryExists();
-            set => UpdateEntry(value);
-        }
-
-        /// <summary>Congenital Anomalies of the Newborn, Suspected Chromosomal Disorder.</summary>
-        [Property("Suspected Chromosomal Disorder", Property.Types.Bool, "Congenital Anomalies of the Newborn",
-                  "Congenital Anomalies of the Newborn, Suspected Chromosomal Disorder", true, IGURL.ConditionCongenitalAnomalyOfNewborn, true, 229)]
-        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "73780-9", code: "409709004", section: NEWBORN_INFORMATION_SECTION)]
-        [FHIRSubject(FHIRSubject.Subject.Newborn)]
-        public bool SuspectedChromosomalDisorder
-        {
-            get => EntryExists();
-            set => UpdateEntry(value);
-        }
 
         //
         // Characteristics of Labor and Delivery Section
@@ -1717,25 +1573,7 @@ namespace BFDR
             set => UpdateEntry(value);
         }
 
-        /// <summary>Infections Present During Pregnancy, Chlamydia.</summary>
-        [Property("Chlamydia", Property.Types.Bool, "Infections Present During Pregnancy",
-                  "Infections Present During Pregnancy, Chlamydia", true, IGURL.ConditionInfectionPresentDuringPregnancy, true, 171)]
-        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "72519-2", code: "105629000", section: MEDICAL_INFORMATION_SECTION)]
-        public bool Chlamydia
-        {
-            get => EntryExists();
-            set => UpdateEntry(value);
-        }
 
-        /// <summary>Infections Present During Pregnancy, Gonorrhea.</summary>
-        [Property("Gonorrhea", Property.Types.Bool, "Infections Present During Pregnancy",
-                  "Infections Present During Pregnancy, Gonorrhea", true, IGURL.ConditionInfectionPresentDuringPregnancy, true, 168)]
-        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "72519-2", code: "15628003", section: MEDICAL_INFORMATION_SECTION)]
-        public bool Gonorrhea
-        {
-            get => EntryExists();
-            set => UpdateEntry(value);
-        }
 
         /// <summary>Infections Present During Pregnancy, Hepatitis B.</summary>
         [Property("Hepatitis B", Property.Types.Bool, "Infections Present During Pregnancy",
@@ -1752,26 +1590,6 @@ namespace BFDR
                   "Infections Present During Pregnancy, Hepatitis C", true, IGURL.ConditionInfectionPresentDuringPregnancy, true, 173)]
         [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "72519-2", code: "50711007", section: MEDICAL_INFORMATION_SECTION)]
         public bool HepatitisC
-        {
-            get => EntryExists();
-            set => UpdateEntry(value);
-        }
-
-        /// <summary>Infections Present During Pregnancy, Syphilis.</summary>
-        [Property("Syphilis", Property.Types.Bool, "Infections Present During Pregnancy",
-                  "Infections Present During Pregnancy, Syphilis", true, IGURL.ConditionInfectionPresentDuringPregnancy, true, 169)]
-        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "72519-2", code: "76272004", section: MEDICAL_INFORMATION_SECTION)]
-        public bool Syphilis
-        {
-            get => EntryExists();
-            set => UpdateEntry(value);
-        }
-
-        /// <summary>Infections Present During Pregnancy, Genital Herpes Simplex.</summary>
-        [Property("Genital Herpes Simplex", Property.Types.Bool, "Infections Present During Pregnancy",
-                  "Infections Present During Pregnancy, Genital Herpes Simplex", true, IGURL.ConditionInfectionPresentDuringPregnancy, false, 173)]
-        [FHIRPath(fhirType: FHIRPath.FhirType.Condition, categoryCode: "72519-2", code: "33839006", section: MEDICAL_INFORMATION_SECTION)]
-        public bool GenitalHerpesSimplex
         {
             get => EntryExists();
             set => UpdateEntry(value);
@@ -1910,16 +1728,6 @@ namespace BFDR
                   "Pregnancy Risk Factors, Previous Cesarean", true, IGURL.ObservationPreviousCesarean, true, 249)]
         [FHIRPath(fhirType: FHIRPath.FhirType.Observation, categoryCode: "73775-9", code: "200144004", section: MEDICAL_INFORMATION_SECTION)]
         public bool PreviousCesarean
-        {
-            get => EntryExists();
-            set => UpdateEntry(value);
-        }
-
-        /// <summary>Previous Preterm Birth.</summary>
-        [Property("Previous Preterm Birth", Property.Types.Bool, "Pregnancy Risk Factors",
-                  "Pregnancy Risk Factors, Previous Preterm Birth", true, IGURL.ObservationPreviousPretermBirth, true, 245)]
-        [FHIRPath(fhirType: FHIRPath.FhirType.Observation, categoryCode: "73775-9", code: "161765003", section: MEDICAL_INFORMATION_SECTION)]
-        public bool PreviousPretermBirth
         {
             get => EntryExists();
             set => UpdateEntry(value);
@@ -6112,231 +5920,9 @@ namespace BFDR
             }
         }
 
-        /// <summary>Date Of Last Other Pregnancy Outcome Day</summary>
-        /// <value>the date of the last other pregnancy outcome day
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeDay = 4;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Date of Last Other Pregnancy Outcome: {ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeDay}");</para>
-        /// </example>
-        [Property("DateOfLastOtherPregnancyOutcomeDay", Property.Types.Int32, "Date of Last Other Pregnancy Outcome", "Date of last other pregnancy outcome.", false, IGURL.ObservationDateOfLastOtherPregnancyOutcome, false, 34)]
-        [PropertyParam("DateOfLastOtherPregnancyOutcomeDay", "The month of the last other pregnancy outcome.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='68500-8')", "")]
-        public int? DateOfLastOtherPregnancyOutcomeDay
-        {
-            get
-            {
 
-                Observation obs = GetObservation("68500-8");
-                if (obs != null)
-                {
-                    return GetDateFragmentOrPartialDate(obs.Value, VR.ExtensionURL.PartialDateDayVR);
-                }
-                return null;
-            }
-            set
-            {
-                Observation obs = GetOrCreateObservation("68500-8", CodeSystems.LOINC, "Date of last other pregnancy outcome", BFDR.ProfileURL.ObservationDateOfLastOtherPregnancyOutcome, DATE_OF_LAST_OTHER_PREGNANCY_OUTCOME, Mother.Id);
-                if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
-                {
-                    obs.Value = new FhirDateTime();
-                    obs.Extension.Add(NewBlankPartialDateTimeExtension(false));
-                }
-                FhirDateTime newDate = UpdateFhirDateTimeDateElement(obs.Value as FhirDateTime, value, VR.ExtensionURL.PartialDateDayVR);
-                if (newDate != null)
-                {
-                    obs.Value = newDate;
-                }
-            }
-        }
 
-        /// <summary>Date Of Last Other Pregnancy Outcome Month</summary>
-        /// <value>the date of the last other pregnancy outcome month
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeMonth = 4;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Date of Last Other Pregnancy Outcome: {ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeMonth}");</para>
-        /// </example>
-        [Property("DateOfLastOtherPregnancyOutcomeMonth", Property.Types.Int32, "Date of Last Other Pregnancy Outcome", "Date of last other pregnancy outcome.", false, IGURL.ObservationDateOfLastOtherPregnancyOutcome, false, 34)]
-        [PropertyParam("dateOfLastOtherPregnancyOutcomeMonth", "The month of the last other pregnancy outcome.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='68500-8')", "")]
-        public int? DateOfLastOtherPregnancyOutcomeMonth
-        {
-            get
-            {
-                Observation obs = GetObservation("68500-8");
-                if (obs != null)
-                {
-                    return GetDateFragmentOrPartialDate(obs.Value, VR.ExtensionURL.PartialDateMonthVR);
-                }
-                return null;
-            }
-            set
-            {
-                Observation obs = GetOrCreateObservation("68500-8", CodeSystems.LOINC, "Date of last other pregnancy outcome", BFDR.ProfileURL.ObservationDateOfLastOtherPregnancyOutcome, DATE_OF_LAST_OTHER_PREGNANCY_OUTCOME, Mother.Id);
-                if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
-                {
-                    obs.Value = new FhirDateTime();
-                    obs.Value.Extension.Add(NewBlankPartialDateTimeExtension(false));
-                }
-                FhirDateTime newDate = UpdateFhirDateTimeDateElement(obs.Value as FhirDateTime, value, VR.ExtensionURL.PartialDateMonthVR);
-                if (newDate != null)
-                {
-                    obs.Value = newDate;
-                }
-            }
-        }
 
-        /// <summary>Date Of Last Other Pregnancy Outcome year</summary>
-        /// <value>the date of the Mother's last other pregnancy outcome
-        /// </value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeYear = 2022;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Date of Last Other Pregnancy Outcome:: {ExampleBirthRecord.DateOfLastOtherPregnancyOutcomeYear}");</para>
-        /// </example>
-        [Property("DateOfLastOtherPregnancyOutcomeYear", Property.Types.Int32, "Date of Last Other Pregnancy Outcome", "Date of last other pregnancy outcome.", false, IGURL.ObservationDateOfLastOtherPregnancyOutcome, false, 34)]
-        [PropertyParam("dateOfLastOtherPregnancyOutcomeYear", "The year of the last other pregnancy outcome.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='68500-8')", "")]
-        public int? DateOfLastOtherPregnancyOutcomeYear
-        {
-            get
-            {
-                Observation obs = GetObservation("68500-8");
-                if (obs != null)
-                {
-                    return GetDateFragmentOrPartialDate(obs.Value, VR.ExtensionURL.PartialDateYearVR);
-                }
-                return null;
-            }
-            set
-            {
-                Observation obs = GetOrCreateObservation("68500-8", CodeSystems.LOINC, "Date of last other pregnancy outcome", BFDR.ProfileURL.ObservationDateOfLastOtherPregnancyOutcome, DATE_OF_LAST_OTHER_PREGNANCY_OUTCOME, Mother.Id);
-                if (obs.Value as Hl7.Fhir.Model.FhirDateTime == null)
-                {
-                    obs.Value = new FhirDateTime();
-                    obs.Value.Extension.Add(NewBlankPartialDateTimeExtension(false));
-                }
-                FhirDateTime newDate = UpdateFhirDateTimeDateElement(obs.Value as FhirDateTime, value, VR.ExtensionURL.PartialDateYearVR);
-                if (newDate != null)
-                {
-                    obs.Value = newDate;
-                }
-            }
-        }
-
-        /// <summary>Date Of Last Other Pregnancy Outcome.</summary>
-        /// <value>Date of Last Other Pregnancy Outcome</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.DateOfLastOtherPregnancyOutcome = "2020-02-19";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Date of Last Other Pregnancy Outcome: {ExampleBirthRecord.DateOfLastOtherPregnancyOutcome}");</para>
-        /// </example>
-        [Property("Date Of Last Other Pregnancy Outcome", Property.Types.String, "Date of Last Other Pregnancy Outcome", "Date of mother's last live birth.", true, IGURL.ObservationDateOfLastOtherPregnancyOutcome, true, 14)]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='68500-8')", "")]
-        public string DateOfLastOtherPregnancyOutcome
-        {
-            get
-            {
-                Observation obs = GetObservation("68500-8");
-                if (obs != null)
-                {
-                    return (obs.Value as Hl7.Fhir.Model.FhirDateTime)?.Value;
-                }
-                return null;
-            }
-            set
-            {
-                Observation obs = GetOrCreateObservation("68500-8", CodeSystems.LOINC, "Date of last other pregnancy outcome", BFDR.ProfileURL.ObservationDateOfLastOtherPregnancyOutcome, DATE_OF_LAST_OTHER_PREGNANCY_OUTCOME, Mother.Id);
-                obs.Value = ConvertToDateTime(value);
-            }
-        }
-
-        /// <summary>NumberOfPrenatalVisits.</summary>
-        /// <value>NumberOfPrenatalVisits</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.NumberOfPrenatalVisits = 4;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"NumberOfPrenatalVisits: {ExampleBirthRecord.NumberOfPrenatalVisits}");</para>
-        /// </example>
-        [Property("Number Of Prenatal Visits", Property.Types.Int32, "Number of Prenatal Visits", "Number of Prenatal Visits.", true, IGURL.ObservationNumberPrenatalVisits, true, 14)]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='68493-6')", "")]
-        public int? NumberOfPrenatalVisits
-        {
-            get => GetIntegerObservationValue("68493-6");
-            set => SetIntegerObservationValue("68493-6", CodeSystems.LOINC, value, BFDR.ProfileURL.ObservationNumberPrenatalVisits, NUMBER_OF_PRENATAL_VISITS, Mother.Id);
-        }
-
-        /// <summary>NumberOfPrenatalVisitsEditFlag.</summary>
-        /// <value>NumberOfPrenatalVisitsEditFlag</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.NumberOfPrenatalVisitsEditFlag = 4;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"NumberOfPrenatalVisitsEditFlag: {ExampleBirthRecord.NumberOfPrenatalVisitsEditFlag}");</para>
-        /// </example>
-        [Property("Number Of Prenatal Visits Edit Flag", Property.Types.Dictionary, "Number of Prenatal Visits", "Number of Prenatal Visits Edit Flag.", true, IGURL.ObservationNumberPrenatalVisits, true, 14)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='68493-6')", "")]
-        public Dictionary<string, string> NumberOfPrenatalVisitsEditFlag
-        {
-            get
-            {
-                Observation obs = GetObservation("68493-6");
-                Extension editFlag = obs?.Value?.Extension.FirstOrDefault(ext => ext.Url == VR.ExtensionURL.BypassEditFlag);
-                if (editFlag != null && editFlag.Value != null && editFlag.Value.GetType() == typeof(CodeableConcept))
-                {
-                    return CodeableConceptToDict((CodeableConcept)editFlag.Value);
-                }
-                return EmptyCodeableDict();
-            }
-            set
-            {
-                if (IsDictEmptyOrDefault(value))
-                {
-                    return;
-                }
-                Observation obs = GetObservation("68493-6");
-                if (obs == null)
-                {
-                    obs = GetOrCreateObservation("68493-6", CodeSystems.LOINC, "Number of prenatal visits", BFDR.ProfileURL.ObservationNumberPrenatalVisits, NUMBER_OF_PRENATAL_VISITS, Mother.Id);
-                    obs.Value = new UnsignedInt();
-                }
-                obs.Value?.Extension.RemoveAll(ext => ext.Url == VR.ExtensionURL.BypassEditFlag);
-                Extension editFlag = new Extension(VR.ExtensionURL.BypassEditFlag, DictToCodeableConcept(value));
-                obs.Value.Extension.Add(editFlag);
-            }
-        }
-
-        /// <summary>
-        /// NumberOfPrenatalVisitsEditFlag Helper
-        /// </summary>
-        [Property("NumberOfPrenatalVisitsEditFlagHelper", Property.Types.String, "Number of Prenatal Visits", "NumberOfPrenatalVisitsEditFlag.", false, IGURL.ObservationNumberPrenatalVisits, true, 2)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='68493-6')", "")]
-        public String NumberOfPrenatalVisitsEditFlagHelper
-        {
-            get
-            {
-                return NumberOfPrenatalVisitsEditFlag.ContainsKey("code") && !String.IsNullOrWhiteSpace(NumberOfPrenatalVisitsEditFlag["code"]) ? NumberOfPrenatalVisitsEditFlag["code"] : null;
-            }
-            set
-            {
-                if (!String.IsNullOrWhiteSpace(value))
-                {
-                    SetCodeValue("NumberOfPrenatalVisitsEditFlag", value, BFDR.ValueSets.PregnancyReportEditFlags.Codes);
-                }
-            }
-        }
 
         /// <summary>GestationalAgeAtDelivery.</summary>
         /// <value>GestationalAgeAtDelivery</value>
@@ -6531,22 +6117,6 @@ namespace BFDR
             }
         }
 
-        /// <summary>NumberOfOtherPregnancyOutcomes.</summary>
-        /// <value>NumberOfOtherPregnancyOutcomes</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.NumberOfOtherPregnancyOutcomes = 1;</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"NumberOfOtherPregnancyOutcomes: {ExampleBirthRecord.NumberOfOtherPregnancyOutcomes}");</para>
-        /// </example>
-        [Property("NumberOfOtherPregnancyOutcomes", Property.Types.Int32, "Number Of Other Pregnancy Outcomes", "Number Of Other Pregnancy Outcomes", true, IGURL.ObservationNumberOtherPregnancyOutcomes, true, 14)]
-        [FHIRPath("Bundle.entry.resource.where($this is Observation).where(code.coding.code='69043-8')", "")]
-        public int? NumberOfOtherPregnancyOutcomes
-        {
-            get => GetIntegerObservationValue("69043-8");
-            set => SetIntegerObservationValue("69043-8", CodeSystems.LOINC, value, BFDR.ProfileURL.ObservationNumberOtherPregnancyOutcomes, NUMBER_OF_OTHER_PREGNANCY_OUTCOMES, Mother.Id);
-        }
-
         /// <summary>MotherReceivedWICFood.</summary>
         /// <value>MotherReceivedWICFood</value>
         /// <example>
@@ -6682,7 +6252,7 @@ namespace BFDR
                     Code = new CodeableConcept(VR.CodeSystems.LOINC, code),
                     Subject = new ResourceReference($"urn:uuid:{subjectId}")
                 };
-                obs.Category.Add(new CodeableConcept(CodeSystems.ObservationCategory, "vital-signs"));  
+                obs.Category.Add(new CodeableConcept(CodeSystems.ObservationCategory, "vital-signs"));
                 AddReferenceToComposition(obs.Id, section);
                 Bundle.AddResourceEntry(obs, "urn:uuid:" + obs.Id);
             }
@@ -8309,7 +7879,7 @@ namespace BFDR
                     this.Composition.DateElement = new FhirDateTime();
                     this.Composition.DateElement.Extension.Add(NewBlankPartialDateTimeExtension(false));
                 }
-                FhirDateTime newDate = UpdateFhirDateTimeDateElement(this.Composition.DateElement, value,  VR.ExtensionURL.PartialDateMonthVR);
+                FhirDateTime newDate = UpdateFhirDateTimeDateElement(this.Composition.DateElement, value, VR.ExtensionURL.PartialDateMonthVR);
                 if (newDate != null)
                 {
                     this.Composition.DateElement = newDate;
@@ -8446,7 +8016,7 @@ namespace BFDR
                 {
                     // unknown
 
-                    Console.WriteLine("Warning: given 'principal source of payment for this delivery' *" + value + "* code not found in value set. Setting code value to 'Unavailable / Unknown'.");                    PayorTypeFinancialClass = CodeableConceptToDict(new CodeableConcept(CodeSystems.NAHDO, "9999", "Unavailable / Unknown", value));
+                    Console.WriteLine("Warning: given 'principal source of payment for this delivery' *" + value + "* code not found in value set. Setting code value to 'Unavailable / Unknown'."); PayorTypeFinancialClass = CodeableConceptToDict(new CodeableConcept(CodeSystems.NAHDO, "9999", "Unavailable / Unknown", value));
                 }
                 else
                 {
@@ -8504,101 +8074,6 @@ namespace BFDR
         {
             get => GetObservationValueHelper();
             set => SetObservationValueHelper(value, VR.ValueSets.YesNoUnknownNotApplicable.Codes);
-        }
-
-        /// <summary>Mother Transferred</summary>
-        /// <value>Mother transferred</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.MotherTransferred = "hosp-trans";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Mother transferred: {ExampleBirthRecord.MotherTransferred}");</para>
-        /// </example>
-        [Property("MotherTransferred", Property.Types.Dictionary, "MotherTransferred", "MotherTransferred", false, VR.IGURL.Mother, true, 288)]
-        [PropertyParam("code", "The code used to describe this concept.")]
-        [PropertyParam("system", "The relevant code system.")]
-        [PropertyParam("display", "The human readable version of this code.")]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "hospitalization")]
-        public Dictionary<string, string> MotherTransferred
-        {
-            get
-            {
-                Dictionary<string, string> admitSource = CodeableConceptToDict(EncounterMaternity?.Hospitalization?.AdmitSource);
-                return admitSource;
-            }
-            set
-            {
-                if (value == null)
-                {
-                    return;
-                }
-                // TODO define CC
-                CodeableConcept admitSource = DictToCodeableConcept(value);
-                HospitalizationComponent hosp = new HospitalizationComponent();
-                hosp.AdmitSource = admitSource;
-                EncounterMaternity.Hospitalization = hosp;
-            }
-        }
-
-        /// <summary>Mother Transferred Helper</summary>
-        /// <value>Mother transferred helper</value>
-        /// <example>
-        /// <para>// Setter:</para>
-        /// <para>ExampleBirthRecord.MotherTransferredHelper = "hosp-trans";</para>
-        /// <para>// Getter:</para>
-        /// <para>Console.WriteLine($"Mother transferred: {ExampleBirthRecord.MotherTransferredHelper}");</para>
-        /// </example>
-        [Property("MotherTransferred", Property.Types.String, "MotherTransferred", "MotherTransferred", false, VR.IGURL.Mother, true, 288)]
-        [FHIRPath("Bundle.entry.resource.where($this is Patient)", "hospitalization")]
-        public string MotherTransferredHelper
-        {
-            get
-            {
-                // TODO there should be a mapping for this
-                if (MotherTransferred.ContainsKey("code"))
-                {
-                    string code = MotherTransferred["code"];
-                    if (code == "hosp-trans")
-                    {
-                        // TODO add check for Transferred From name == "UNKNOWN" and return U
-                        if (FacilityMotherTransferredFrom == "UNKNOWN")
-                        {
-                            return "U";
-                        }
-                        return "Y";
-                    }
-                    if (code == "other")
-                    {
-                        return "N";
-                    }
-                }
-                return "";
-            }
-            set
-            {
-                if (String.IsNullOrEmpty(value))
-                {
-                    return;
-                }
-                // IJE values are Y, N, U, set to "hosp-trans" if value is Y
-                // https://build.fhir.org/ig/HL7/fhir-bfdr/usage.html#mother-or-infant-transferred
-                if (value == "Y")
-                {
-                    MotherTransferred = CodeableConceptToDict(new CodeableConcept(CodeSystems.AdmitSource, "hosp-trans", "Transferred from other hospital", "The Patient has been transferred from another hospital for this encounter."));
-                }
-                else if (value == "U")
-                {
-                    // If the value is unknown, set the code to hosp-trans, and the hospitalization.origin.name should be set to “UNKNOWN” 
-                    // https://build.fhir.org/ig/HL7/fhir-bfdr/usage.html#mother-or-infant-transferred
-                    MotherTransferred = CodeableConceptToDict(new CodeableConcept(CodeSystems.AdmitSource, "hosp-trans", "Transferred from other hospital", "The Patient has been transferred from another hospital for this encounter."));
-                    FacilityMotherTransferredFrom = "UNKNOWN";
-                }
-                else
-                {
-                    // all other codes should be interpretted as N with "other" as the code to express mother did not transfer
-                    MotherTransferred = CodeableConceptToDict(new CodeableConcept(CodeSystems.AdmitSource, "other", "Other", "Did not transfer"));
-                }
-            }
         }
 
         /// <summary>Infant Living</summary>
@@ -8702,7 +8177,12 @@ namespace BFDR
             }
         }
 
-        private int? GetIntegerObservationValue(string code)
+        /// <summary>
+        /// Get an integer value from an Observation contained in this record.
+        /// </summary>
+        /// <param name="code">the code to identify the type of Observation</param>
+        /// <returns>the value of the specified Observation, or null if there is no Observation with the specified code</returns>
+        protected int? GetIntegerObservationValue(string code)
         {
             Observation observation = GetObservation(code);
             if (observation != null)
@@ -8712,7 +8192,18 @@ namespace BFDR
             return null;
         }
 
-        private Observation SetIntegerObservationValue(string code, string codeDesc, int? value, string profileURL, string section, string subjectId, [CallerMemberName] string propertyName = null)
+        /// <summary>
+        /// Set an integer value on a contained Observation, identified by code. The Observation will be created if it does not already exist.
+        /// </summary>
+        /// <param name="code">the code to identify the type of Observation</param>
+        /// <param name="codeDesc">display text for the identifying code</param>
+        /// <param name="value">value to set on the Observation</param>
+        /// <param name="profileURL">profile conformed to by the Observation</param>
+        /// <param name="section">section to which to add a reference to the Observation</param>
+        /// <param name="subjectId">identifier for the subject of the Observation. unused</param>
+        /// <param name="propertyName">unused</param>
+        /// <returns></returns>
+        protected Observation SetIntegerObservationValue(string code, string codeDesc, int? value, string profileURL, string section, string subjectId, [CallerMemberName] string propertyName = null)
         {
             Observation obs = GetOrCreateObservation(code, CodeSystems.LOINC, codeDesc, profileURL, section, null, propertyName);
             if (obs.Category.FirstOrDefault(cat => cat.Coding.Any(catCode => catCode.Code == "vital-signs")) == null)
@@ -9303,7 +8794,8 @@ namespace BFDR
             }
             if (certifier != null && certifier.Period.StartElement != null && ParseDateElements(certifier.Period.Start, out int? year, out int? month, out int? day))
             {
-                switch(dateUrl) {
+                switch (dateUrl)
+                {
                     case VR.ExtensionURL.PartialDateDayVR:
                         return day;
                     case VR.ExtensionURL.PartialDateMonthVR:
@@ -9358,7 +8850,7 @@ namespace BFDR
 
             // switch(dateUrl) {
             //     case VR.ExtensionURL.PartialDateTimeDayVR:
-                    
+
             //         newDate = SetDay(value, stateComp.Period.StartElement);
             //         break;
             //     case VR.ExtensionURL.PartialDateTimeMonthVR:

--- a/projects/Canary/Models/BFDRRecordFaker.cs
+++ b/projects/Canary/Models/BFDRRecordFaker.cs
@@ -5,119 +5,120 @@ using BFDR;
 
 namespace canary.Models
 {
-    /// <summary>Class <c>BirthRecordFaker</c> can be used to generate synthetic <c>BirthRecord</c>s. Various
-    /// options are available to tailoring the records generated to specific use case by the class.
-    /// </summary>
-    public class BirthRecordFaker : RecordFaker<BirthRecord> 
+  /// <summary>Class <c>BirthRecordFaker</c> can be used to generate synthetic <c>BirthRecord</c>s. Various
+  /// options are available to tailoring the records generated to specific use case by the class.
+  /// </summary>
+  public class BirthRecordFaker : RecordFaker<BirthRecord>
+  {
+    public BirthRecordFaker(string state = "XX", string sex = "Male") : base(state, sex) { }
+
+    /// <summary>Return a new record populated with fake data.</summary>
+    public override BirthRecord Generate(bool simple = false)
     {
-        public BirthRecordFaker(string state = "XX", string sex = "Male") : base(state, sex) {}
-
-        /// <summary>Return a new record populated with fake data.</summary>
-        public override BirthRecord Generate(bool simple = false)
-        {
-            BirthRecord record = new();
-            Bogus.Faker faker = new("en");
-            BFDRRecordFaker.GenerateBFDRAttributes(record, state, simple, faker);
-            Bogus.DataSets.Name.Gender gender = sex == "Male" ? Bogus.DataSets.Name.Gender.Male : Bogus.DataSets.Name.Gender.Female;
-            record.ChildGivenNames = new string[] { faker.Name.FirstName(gender), faker.Name.FirstName(gender) };
-            record.ChildFamilyName = faker.Name.LastName(gender);
-            record.ChildSuffix = faker.Name.Suffix();
-            record.BirthSex = gender.ToString().Substring(0, 1);
-            if (faker.Random.Bool()) {
-              record.MotherPrepregnancyWeight = faker.Random.Number(100, 200);
-              record.MotherWeightAtDelivery = record.MotherPrepregnancyWeight + faker.Random.Number(7, 12);
-            }
-            // set more demographic and record keeping info
-            DateTime birth = faker.Date.Recent();
-            DateTimeOffset birthUtc = new DateTimeOffset(birth.Year, birth.Month, birth.Day, 0, 0, 0, TimeSpan.Zero);
-            record.DateOfBirth = birthUtc.ToString("yyyy-MM-dd");
-            birth = faker.Date.Past(123, DateTime.Today.AddYears(-18));
-            birthUtc = new DateTimeOffset(birth.Year, birth.Month, birth.Day, 0, 0, 0, TimeSpan.Zero);
-            record.FatherDateOfBirth = birthUtc.ToString("yyyy-MM-dd");
-            birth = faker.Date.Past(123, DateTime.Today.AddYears(-18));
-            birthUtc = new DateTimeOffset(birth.Year, birth.Month, birth.Day, 0, 0, 0, TimeSpan.Zero);
-            record.FatherDateOfBirth = birthUtc.ToString("yyyy-MM-dd");
-
-            return record;
-        }
-    }
-
-    /// <summary>Class <c>FetalDeathFaker</c> can be used to generate synthetic <c>BirthRecord</c>s. Various
-    /// options are available to tailoring the records generated to specific use case by the class.
-    /// </summary>
-    public class FetalDeathFaker : RecordFaker<FetalDeathRecord> 
-    {
-        public FetalDeathFaker(string state = "XX", string sex = "Male") : base(state, sex) {}
-
-        /// <summary>Return a new record populated with fake data.</summary>
-        public override FetalDeathRecord Generate(bool simple = false)
-        {
-            FetalDeathRecord record = new();
-            Bogus.Faker faker = new("en");
-            BFDRRecordFaker.GenerateBFDRAttributes(record, state, simple, faker);
-            // Grab Gender enum value
-            Bogus.DataSets.Name.Gender gender = sex == "Male" ? Bogus.DataSets.Name.Gender.Male : Bogus.DataSets.Name.Gender.Female;
-            record.FetusGivenNames = new string[] { faker.Name.FirstName(gender), faker.Name.FirstName(gender) };
-            record.FetusFamilyName = faker.Name.LastName(gender);
-            record.FetusSuffix = faker.Name.Suffix();
-            record.FetalDeathSex = gender.ToString().Substring(0, 1);
-            DateTime birth = faker.Date.Recent();
-            DateTimeOffset birthUtc = new DateTimeOffset(birth.Year, birth.Month, birth.Day, 0, 0, 0, TimeSpan.Zero);
-            record.DateOfDelivery = birthUtc.ToString("yyyy-MM-dd");
-            birth = faker.Date.Past(123, DateTime.Today.AddYears(-18));
-            birthUtc = new DateTimeOffset(birth.Year, birth.Month, birth.Day, 0, 0, 0, TimeSpan.Zero);
-            record.FatherDateOfBirth = birthUtc.ToString("yyyy-MM-dd");
-            birth = faker.Date.Past(123, DateTime.Today.AddYears(-18));
-            birthUtc = new DateTimeOffset(birth.Year, birth.Month, birth.Day, 0, 0, 0, TimeSpan.Zero);
-            record.FatherDateOfBirth = birthUtc.ToString("yyyy-MM-dd");
-            int initiatingCause = faker.Random.Number(0, 7);
-            Console.WriteLine(initiatingCause);
-            switch(initiatingCause)
-            {
-              case 0:
-                record.PrematureRuptureOfMembranes = true;
-                break;
-              case 1:
-                record.AbruptioPlacenta = true;
-                break;
-              case 3:
-                record.PlacentalInsufficiency = true;
-                break;
-              case 4:
-                record.ProlapsedCord = true;
-                break;
-              case 5:
-                record.ChorioamnionitisCOD = true;
-                break;
-              case 6:
-                record.OtherComplicationsOfPlacentaCordOrMembranes = true;
-                break;
-              case 7:
-                record.InitiatingCauseOrConditionUnknown = true;
-                break;
-            }
-            return record;
-        }
-    }
-
-    static class BFDRRecordFaker
-    {
-      public static void GenerateBFDRAttributes(NatalityRecord record, string state, bool simple, Bogus.Faker faker)
+      BirthRecord record = new();
+      Bogus.Faker faker = new("en");
+      BFDRRecordFaker.GenerateBFDRAttributes(record, state, simple, faker);
+      Bogus.DataSets.Name.Gender gender = sex == "Male" ? Bogus.DataSets.Name.Gender.Male : Bogus.DataSets.Name.Gender.Female;
+      record.ChildGivenNames = new string[] { faker.Name.FirstName(gender), faker.Name.FirstName(gender) };
+      record.ChildFamilyName = faker.Name.LastName(gender);
+      record.ChildSuffix = faker.Name.Suffix();
+      record.BirthSex = gender.ToString().Substring(0, 1);
+      if (faker.Random.Bool())
       {
-          record.EventLocationJurisdiction = state;
-          record.CertificateNumber = Convert.ToString(faker.Random.Number(100000, 999999));
-          record.InfantMedicalRecordNumber = Convert.ToString(faker.Random.Number(10000, 99999));
-          record.MotherMedicalRecordNumber = Convert.ToString(faker.Random.Number(10000, 99999));
-          record.MotherSocialSecurityNumber = faker.Person.Ssn();
-          record.FatherSocialSecurityNumber = faker.Person.Ssn();
-          record.MotherPrepregnancyWeightEditFlagHelper = "1";
-          record.MotherWeightAtDeliveryEditFlagHelper = "0";
-          record.BirthWeightEditFlagHelper = "2";
-          record.MotherIndustry = "mother";
-          record.FatherIndustry = "father";
-          record.MotherOccupation = "CEO";
-          record.FatherOccupation = "COO";
-          record.PlaceOfBirth = new Dictionary<string, string>
+        record.MotherPrepregnancyWeight = faker.Random.Number(100, 200);
+        record.MotherWeightAtDelivery = record.MotherPrepregnancyWeight + faker.Random.Number(7, 12);
+      }
+      // set more demographic and record keeping info
+      DateTime birth = faker.Date.Recent();
+      DateTimeOffset birthUtc = new DateTimeOffset(birth.Year, birth.Month, birth.Day, 0, 0, 0, TimeSpan.Zero);
+      record.DateOfBirth = birthUtc.ToString("yyyy-MM-dd");
+      birth = faker.Date.Past(123, DateTime.Today.AddYears(-18));
+      birthUtc = new DateTimeOffset(birth.Year, birth.Month, birth.Day, 0, 0, 0, TimeSpan.Zero);
+      record.FatherDateOfBirth = birthUtc.ToString("yyyy-MM-dd");
+      birth = faker.Date.Past(123, DateTime.Today.AddYears(-18));
+      birthUtc = new DateTimeOffset(birth.Year, birth.Month, birth.Day, 0, 0, 0, TimeSpan.Zero);
+      record.FatherDateOfBirth = birthUtc.ToString("yyyy-MM-dd");
+
+      return record;
+    }
+  }
+
+  /// <summary>Class <c>FetalDeathFaker</c> can be used to generate synthetic <c>BirthRecord</c>s. Various
+  /// options are available to tailoring the records generated to specific use case by the class.
+  /// </summary>
+  public class FetalDeathFaker : RecordFaker<FetalDeathRecord>
+  {
+    public FetalDeathFaker(string state = "XX", string sex = "Male") : base(state, sex) { }
+
+    /// <summary>Return a new record populated with fake data.</summary>
+    public override FetalDeathRecord Generate(bool simple = false)
+    {
+      FetalDeathRecord record = new();
+      Bogus.Faker faker = new("en");
+      BFDRRecordFaker.GenerateBFDRAttributes(record, state, simple, faker);
+      // Grab Gender enum value
+      Bogus.DataSets.Name.Gender gender = sex == "Male" ? Bogus.DataSets.Name.Gender.Male : Bogus.DataSets.Name.Gender.Female;
+      record.FetusGivenNames = new string[] { faker.Name.FirstName(gender), faker.Name.FirstName(gender) };
+      record.FetusFamilyName = faker.Name.LastName(gender);
+      record.FetusSuffix = faker.Name.Suffix();
+      record.FetalDeathSex = gender.ToString().Substring(0, 1);
+      DateTime birth = faker.Date.Recent();
+      DateTimeOffset birthUtc = new DateTimeOffset(birth.Year, birth.Month, birth.Day, 0, 0, 0, TimeSpan.Zero);
+      record.DateOfDelivery = birthUtc.ToString("yyyy-MM-dd");
+      birth = faker.Date.Past(123, DateTime.Today.AddYears(-18));
+      birthUtc = new DateTimeOffset(birth.Year, birth.Month, birth.Day, 0, 0, 0, TimeSpan.Zero);
+      record.FatherDateOfBirth = birthUtc.ToString("yyyy-MM-dd");
+      birth = faker.Date.Past(123, DateTime.Today.AddYears(-18));
+      birthUtc = new DateTimeOffset(birth.Year, birth.Month, birth.Day, 0, 0, 0, TimeSpan.Zero);
+      record.FatherDateOfBirth = birthUtc.ToString("yyyy-MM-dd");
+      int initiatingCause = faker.Random.Number(0, 7);
+      Console.WriteLine(initiatingCause);
+      switch (initiatingCause)
+      {
+        case 0:
+          record.PrematureRuptureOfMembranes = true;
+          break;
+        case 1:
+          record.AbruptioPlacenta = true;
+          break;
+        case 3:
+          record.PlacentalInsufficiency = true;
+          break;
+        case 4:
+          record.ProlapsedCord = true;
+          break;
+        case 5:
+          record.ChorioamnionitisCOD = true;
+          break;
+        case 6:
+          record.OtherComplicationsOfPlacentaCordOrMembranes = true;
+          break;
+        case 7:
+          record.InitiatingCauseOrConditionUnknown = true;
+          break;
+      }
+      return record;
+    }
+  }
+
+  static class BFDRRecordFaker
+  {
+    public static void GenerateBFDRAttributes(NatalityRecord record, string state, bool simple, Bogus.Faker faker)
+    {
+      record.EventLocationJurisdiction = state;
+      record.CertificateNumber = Convert.ToString(faker.Random.Number(100000, 999999));
+      record.InfantMedicalRecordNumber = Convert.ToString(faker.Random.Number(10000, 99999));
+      record.MotherMedicalRecordNumber = Convert.ToString(faker.Random.Number(10000, 99999));
+      record.MotherSocialSecurityNumber = faker.Person.Ssn();
+      record.FatherSocialSecurityNumber = faker.Person.Ssn();
+      record.MotherPrepregnancyWeightEditFlagHelper = "1";
+      record.MotherWeightAtDeliveryEditFlagHelper = "0";
+      record.BirthWeightEditFlagHelper = "2";
+      record.MotherIndustry = "mother";
+      record.FatherIndustry = "father";
+      record.MotherOccupation = "CEO";
+      record.FatherOccupation = "COO";
+      record.PlaceOfBirth = new Dictionary<string, string>
           {
             { "addressLine1", $"{faker.Random.Number(999) + 1} Main Street" },
             { "addressCity", "Springfield" },
@@ -126,77 +127,109 @@ namespace canary.Models
             // birthAddress.Add("addressZip", "01101");
             { "addressCountry", "US" }
           };
-          // set some boolean fields
-          if (faker.Random.Bool()) {
-            record.NoSpecifiedAbnormalConditionsOfNewborn = faker.Random.Bool();
-            if (!record.NoSpecifiedAbnormalConditionsOfNewborn) {
-              record.Seizure = faker.Random.Bool(); 
-            }
-          }
-          if (faker.Random.Bool()) {
-            record.NoCharacteristicsOfLaborAndDelivery= faker.Random.Bool();
-            if (!record.NoCharacteristicsOfLaborAndDelivery) {
-              record.Chorioamnionitis = faker.Random.Bool();
-              record.EpiduralOrSpinalAnesthesia = faker.Random.Bool();
-            }
-          }
-          if (faker.Random.Bool()) {
-            record.NoMaternalMorbidities= faker.Random.Bool();
-            if (!record.NoMaternalMorbidities) {
-              record.MaternalTransfusion = faker.Random.Bool();
-              record.PerinealLaceration = faker.Random.Bool();
-            }
-          }
-          if (faker.Random.Bool()) {
-            record.NoInfectionsPresentDuringPregnancy = faker.Random.Bool();
-            if (!record.NoInfectionsPresentDuringPregnancy) {
-              record.Gonorrhea= faker.Random.Bool();
-              record.Syphilis = faker.Random.Bool();
-            }
-          }
-          if (faker.Random.Bool()) {
-            record.NoCongenitalAnomaliesOfTheNewborn= faker.Random.Bool();
-            if (!record.NoCongenitalAnomaliesOfTheNewborn) {
-              record.CleftLipWithOrWithoutCleftPalate = faker.Random.Bool();
-              record.Omphalocele = faker.Random.Bool();
-            }
-          }
-          if (faker.Random.Bool()) {
-            record.NoPregnancyRiskFactors = faker.Random.Bool();
-            if (!record.NoPregnancyRiskFactors) {
-              record.GestationalDiabetes = faker.Random.Bool();
-              record.PreviousCesarean = faker.Random.Bool();
-            }
-          }
-          // set some numerical fields
-          if (faker.Random.Bool()) {
-            record.ApgarScoreFiveMinutes = faker.Random.Number(0, 10);
-            if (record.ApgarScoreFiveMinutes < 6) {
-              record.ApgarScoreTenMinutes = faker.Random.Number(0, 10);
-            }
-          }
-          if (faker.Random.Bool()) {
-            record.BirthWeight = faker.Random.Number(2000, 4000);
-          }
-          if (faker.Random.Bool()) {
-            record.MotherHeight = faker.Random.Number(60,72);
-          }
-          if (faker.Random.Bool()) {
-            record.CigarettesPerDayInThreeMonthsPriorToPregancy = faker.Random.Number(0,5);
-            record.CigarettesPerDayInFirstTrimester = faker.Random.Number(0,3);
-            record.CigarettesPerDayInSecondTrimester = faker.Random.Number(0,2);
-            record.CigarettesPerDayInLastTrimester = faker.Random.Number(0,1);
-          }
-          if (faker.Random.Bool()) {
-            if (faker.Random.Bool()){
-              record.MotherReceivedWICFoodHelper = "Y";
-            } else {
-              record.MotherReceivedWICFoodHelper = "N";
-            }
-          }
-          // Occupation / Industry
-          Tuple<string, string>[] occupationIndustries =
+      // set some boolean fields
+      if (faker.Random.Bool())
+      {
+        record.NoSpecifiedAbnormalConditionsOfNewborn = faker.Random.Bool();
+        if (!record.NoSpecifiedAbnormalConditionsOfNewborn)
+        {
+          record.Seizure = faker.Random.Bool();
+        }
+      }
+      if (faker.Random.Bool())
+      {
+        record.NoCharacteristicsOfLaborAndDelivery = faker.Random.Bool();
+        if (!record.NoCharacteristicsOfLaborAndDelivery)
+        {
+          record.Chorioamnionitis = faker.Random.Bool();
+          record.EpiduralOrSpinalAnesthesia = faker.Random.Bool();
+        }
+      }
+      if (faker.Random.Bool())
+      {
+        record.NoMaternalMorbidities = faker.Random.Bool();
+        if (!record.NoMaternalMorbidities)
+        {
+          record.MaternalTransfusion = faker.Random.Bool();
+          record.PerinealLaceration = faker.Random.Bool();
+        }
+      }
+      if (faker.Random.Bool())
+      {
+        record.NoInfectionsPresentDuringPregnancy = faker.Random.Bool();
+        if (!record.NoInfectionsPresentDuringPregnancy)
+        {
+          if (record is BirthRecord birthRecord)
           {
+            birthRecord.Gonorrhea = faker.Random.Bool();
+            birthRecord.Syphilis = faker.Random.Bool();
+          }
+          else if (record is FetalDeathRecord fetalDeathRecord)
+          {
+            fetalDeathRecord.HepatitisB = faker.Random.Bool();
+          }
+        }
+      }
+      if (faker.Random.Bool())
+      {
+        if (record is BirthRecord birthRecord)
+        {
+          birthRecord.NoCongenitalAnomaliesOfTheNewborn = faker.Random.Bool();
+          if (!birthRecord.NoCongenitalAnomaliesOfTheNewborn)
+          {
+            birthRecord.CleftLipWithOrWithoutCleftPalate = faker.Random.Bool();
+            birthRecord.Omphalocele = faker.Random.Bool();
+          }
+        }
+
+      }
+      if (faker.Random.Bool())
+      {
+        record.NoPregnancyRiskFactors = faker.Random.Bool();
+        if (!record.NoPregnancyRiskFactors)
+        {
+          record.GestationalDiabetes = faker.Random.Bool();
+          record.PreviousCesarean = faker.Random.Bool();
+        }
+      }
+      // set some numerical fields
+      if (faker.Random.Bool())
+      {
+        record.ApgarScoreFiveMinutes = faker.Random.Number(0, 10);
+        if (record.ApgarScoreFiveMinutes < 6)
+        {
+          record.ApgarScoreTenMinutes = faker.Random.Number(0, 10);
+        }
+      }
+      if (faker.Random.Bool())
+      {
+        record.BirthWeight = faker.Random.Number(2000, 4000);
+      }
+      if (faker.Random.Bool())
+      {
+        record.MotherHeight = faker.Random.Number(60, 72);
+      }
+      if (faker.Random.Bool())
+      {
+        record.CigarettesPerDayInThreeMonthsPriorToPregancy = faker.Random.Number(0, 5);
+        record.CigarettesPerDayInFirstTrimester = faker.Random.Number(0, 3);
+        record.CigarettesPerDayInSecondTrimester = faker.Random.Number(0, 2);
+        record.CigarettesPerDayInLastTrimester = faker.Random.Number(0, 1);
+      }
+      if (faker.Random.Bool())
+      {
+        if (faker.Random.Bool())
+        {
+          record.MotherReceivedWICFoodHelper = "Y";
+        }
+        else
+        {
+          record.MotherReceivedWICFoodHelper = "N";
+        }
+      }
+      // Occupation / Industry
+      Tuple<string, string>[] occupationIndustries =
+      {
               Tuple.Create("Secretary", "State agency"),
               Tuple.Create("Carpenter", "Construction"),
               Tuple.Create("Programmer", "Health Insurance"),
@@ -207,92 +240,92 @@ namespace canary.Models
               Tuple.Create("Barber", "Personal Care and Service"),
               Tuple.Create("Firefighter", "Protective Service"),
           };
-          Tuple<string, string> occIndFather = faker.Random.ArrayElement<Tuple<string, string>>(occupationIndustries);
-          Tuple<string, string> occIndMother = faker.Random.ArrayElement<Tuple<string, string>>(occupationIndustries);
-          record.MotherIndustry = occIndMother.Item2;
-          record.FatherIndustry = occIndFather.Item2;
-          record.MotherOccupation = occIndMother.Item1;
-          record.FatherOccupation = occIndFather.Item1;
-          record.MotherEducationLevelHelper = VR.ValueSets.EducationLevel.Codes[faker.Random.Number(VR.ValueSets.EducationLevel.Codes.GetLength(0) - 1), 0];
-          record.FatherEducationLevelHelper = VR.ValueSets.EducationLevel.Codes[faker.Random.Number(VR.ValueSets.EducationLevel.Codes.GetLength(0) - 1), 0];
+      Tuple<string, string> occIndFather = faker.Random.ArrayElement<Tuple<string, string>>(occupationIndustries);
+      Tuple<string, string> occIndMother = faker.Random.ArrayElement<Tuple<string, string>>(occupationIndustries);
+      record.MotherIndustry = occIndMother.Item2;
+      record.FatherIndustry = occIndFather.Item2;
+      record.MotherOccupation = occIndMother.Item1;
+      record.FatherOccupation = occIndFather.Item1;
+      record.MotherEducationLevelHelper = VR.ValueSets.EducationLevel.Codes[faker.Random.Number(VR.ValueSets.EducationLevel.Codes.GetLength(0) - 1), 0];
+      record.FatherEducationLevelHelper = VR.ValueSets.EducationLevel.Codes[faker.Random.Number(VR.ValueSets.EducationLevel.Codes.GetLength(0) - 1), 0];
 
-          // Ethnicity
-          if (faker.Random.Bool() && !simple)
-          {
-              record.MotherEthnicity1Helper = VR.ValueSets.YesNoUnknown.No;
-              record.MotherEthnicity2Helper = VR.ValueSets.YesNoUnknown.No;
-              record.MotherEthnicity3Helper = VR.ValueSets.YesNoUnknown.Yes;
-              record.MotherEthnicity4Helper = VR.ValueSets.YesNoUnknown.No;
-              record.FatherEthnicity1Helper = VR.ValueSets.YesNoUnknown.No;
-              record.FatherEthnicity2Helper = VR.ValueSets.YesNoUnknown.Yes;
-              record.FatherEthnicity3Helper = VR.ValueSets.YesNoUnknown.No;
-              record.FatherEthnicity4Helper = VR.ValueSets.YesNoUnknown.No;
-              record.MotherEthnicityLiteral = "";
-              record.FatherEthnicityLiteral = "";
-          }
-          else
-          {
-              record.MotherEthnicity1Helper = VR.ValueSets.YesNoUnknown.No;
-              record.MotherEthnicity2Helper = VR.ValueSets.YesNoUnknown.No;
-              record.FatherEthnicity1Helper = VR.ValueSets.YesNoUnknown.No;
-              record.FatherEthnicity2Helper = VR.ValueSets.YesNoUnknown.No;
-          }
-          // Race
-          Tuple<string, string>[] nvssRaces =
-          {
-              Tuple.Create(VR.NvssRace.AmericanIndianOrAlaskanNative, "Y"),
-              Tuple.Create(VR.NvssRace.AsianIndian, "Y"),
-              Tuple.Create(VR.NvssRace.BlackOrAfricanAmerican, "Y"),
-              Tuple.Create(VR.NvssRace.Chinese, "Y"),
-              Tuple.Create(VR.NvssRace.Filipino, "Y"),
-              Tuple.Create(VR.NvssRace.GuamanianOrChamorro, "Y"),
-              Tuple.Create(VR.NvssRace.Japanese, "Y"),
-              Tuple.Create(VR.NvssRace.Korean, "Y"),
-              Tuple.Create(VR.NvssRace.NativeHawaiian, "Y"),
-              Tuple.Create(VR.NvssRace.OtherAsian, "Y"),
-              Tuple.Create(VR.NvssRace.OtherPacificIslander, "Y"),
-              Tuple.Create(VR.NvssRace.OtherRace, "Y"),
-              Tuple.Create(VR.NvssRace.Samoan, "Y"),
-              Tuple.Create(VR.NvssRace.Vietnamese, "Y"),
-              Tuple.Create(VR.NvssRace.White, "Y"),
-          };
-          if (!simple)
-          {
-              Tuple<string, string> race1 = faker.Random.ArrayElement<Tuple<string, string>>(nvssRaces);
-              Tuple<string, string> race2 = faker.Random.ArrayElement<Tuple<string, string>>(nvssRaces);
-              Tuple<string, string> race3 = faker.Random.ArrayElement<Tuple<string, string>>(nvssRaces);
-              Tuple<string, string> race4 = faker.Random.ArrayElement<Tuple<string, string>>(nvssRaces);
-              Tuple<string, string>[] FatherRaces = { race1, race2 };
-              Tuple<string, string>[] MotherRaces = { race3, race4 };
-              record.FatherRace = FatherRaces;
-              record.MotherRace = MotherRaces;
-          }
-          else
-          {
-              Tuple<string, string> race1 = faker.Random.ArrayElement<Tuple<string, string>>(nvssRaces);
-              Tuple<string, string> race2 = faker.Random.ArrayElement<Tuple<string, string>>(nvssRaces);
-              record.FatherRace = new Tuple<string, string>[] { race1 };
-              record.MotherRace = new Tuple<string, string>[] { race2 };
-          }
-
-          Tuple<string, string>[] risks_anomalies_characteristics =
-          {
-              Tuple.Create(VR.NvssRace.AmericanIndianOrAlaskanNative, "Y"),
-              Tuple.Create(VR.NvssRace.AsianIndian, "Y"),
-              Tuple.Create(VR.NvssRace.BlackOrAfricanAmerican, "Y"),
-              Tuple.Create(VR.NvssRace.Chinese, "Y"),
-              Tuple.Create(VR.NvssRace.Filipino, "Y"),
-              Tuple.Create(VR.NvssRace.GuamanianOrChamorro, "Y"),
-              Tuple.Create(VR.NvssRace.Japanese, "Y"),
-              Tuple.Create(VR.NvssRace.Korean, "Y"),
-              Tuple.Create(VR.NvssRace.NativeHawaiian, "Y"),
-              Tuple.Create(VR.NvssRace.OtherAsian, "Y"),
-              Tuple.Create(VR.NvssRace.OtherPacificIslander, "Y"),
-              Tuple.Create(VR.NvssRace.OtherRace, "Y"),
-              Tuple.Create(VR.NvssRace.Samoan, "Y"),
-              Tuple.Create(VR.NvssRace.Vietnamese, "Y"),
-              Tuple.Create(VR.NvssRace.White, "Y"),
-          };
+      // Ethnicity
+      if (faker.Random.Bool() && !simple)
+      {
+        record.MotherEthnicity1Helper = VR.ValueSets.YesNoUnknown.No;
+        record.MotherEthnicity2Helper = VR.ValueSets.YesNoUnknown.No;
+        record.MotherEthnicity3Helper = VR.ValueSets.YesNoUnknown.Yes;
+        record.MotherEthnicity4Helper = VR.ValueSets.YesNoUnknown.No;
+        record.FatherEthnicity1Helper = VR.ValueSets.YesNoUnknown.No;
+        record.FatherEthnicity2Helper = VR.ValueSets.YesNoUnknown.Yes;
+        record.FatherEthnicity3Helper = VR.ValueSets.YesNoUnknown.No;
+        record.FatherEthnicity4Helper = VR.ValueSets.YesNoUnknown.No;
+        record.MotherEthnicityLiteral = "";
+        record.FatherEthnicityLiteral = "";
       }
+      else
+      {
+        record.MotherEthnicity1Helper = VR.ValueSets.YesNoUnknown.No;
+        record.MotherEthnicity2Helper = VR.ValueSets.YesNoUnknown.No;
+        record.FatherEthnicity1Helper = VR.ValueSets.YesNoUnknown.No;
+        record.FatherEthnicity2Helper = VR.ValueSets.YesNoUnknown.No;
+      }
+      // Race
+      Tuple<string, string>[] nvssRaces =
+      {
+              Tuple.Create(VR.NvssRace.AmericanIndianOrAlaskanNative, "Y"),
+              Tuple.Create(VR.NvssRace.AsianIndian, "Y"),
+              Tuple.Create(VR.NvssRace.BlackOrAfricanAmerican, "Y"),
+              Tuple.Create(VR.NvssRace.Chinese, "Y"),
+              Tuple.Create(VR.NvssRace.Filipino, "Y"),
+              Tuple.Create(VR.NvssRace.GuamanianOrChamorro, "Y"),
+              Tuple.Create(VR.NvssRace.Japanese, "Y"),
+              Tuple.Create(VR.NvssRace.Korean, "Y"),
+              Tuple.Create(VR.NvssRace.NativeHawaiian, "Y"),
+              Tuple.Create(VR.NvssRace.OtherAsian, "Y"),
+              Tuple.Create(VR.NvssRace.OtherPacificIslander, "Y"),
+              Tuple.Create(VR.NvssRace.OtherRace, "Y"),
+              Tuple.Create(VR.NvssRace.Samoan, "Y"),
+              Tuple.Create(VR.NvssRace.Vietnamese, "Y"),
+              Tuple.Create(VR.NvssRace.White, "Y"),
+          };
+      if (!simple)
+      {
+        Tuple<string, string> race1 = faker.Random.ArrayElement<Tuple<string, string>>(nvssRaces);
+        Tuple<string, string> race2 = faker.Random.ArrayElement<Tuple<string, string>>(nvssRaces);
+        Tuple<string, string> race3 = faker.Random.ArrayElement<Tuple<string, string>>(nvssRaces);
+        Tuple<string, string> race4 = faker.Random.ArrayElement<Tuple<string, string>>(nvssRaces);
+        Tuple<string, string>[] FatherRaces = { race1, race2 };
+        Tuple<string, string>[] MotherRaces = { race3, race4 };
+        record.FatherRace = FatherRaces;
+        record.MotherRace = MotherRaces;
+      }
+      else
+      {
+        Tuple<string, string> race1 = faker.Random.ArrayElement<Tuple<string, string>>(nvssRaces);
+        Tuple<string, string> race2 = faker.Random.ArrayElement<Tuple<string, string>>(nvssRaces);
+        record.FatherRace = new Tuple<string, string>[] { race1 };
+        record.MotherRace = new Tuple<string, string>[] { race2 };
+      }
+
+      Tuple<string, string>[] risks_anomalies_characteristics =
+      {
+              Tuple.Create(VR.NvssRace.AmericanIndianOrAlaskanNative, "Y"),
+              Tuple.Create(VR.NvssRace.AsianIndian, "Y"),
+              Tuple.Create(VR.NvssRace.BlackOrAfricanAmerican, "Y"),
+              Tuple.Create(VR.NvssRace.Chinese, "Y"),
+              Tuple.Create(VR.NvssRace.Filipino, "Y"),
+              Tuple.Create(VR.NvssRace.GuamanianOrChamorro, "Y"),
+              Tuple.Create(VR.NvssRace.Japanese, "Y"),
+              Tuple.Create(VR.NvssRace.Korean, "Y"),
+              Tuple.Create(VR.NvssRace.NativeHawaiian, "Y"),
+              Tuple.Create(VR.NvssRace.OtherAsian, "Y"),
+              Tuple.Create(VR.NvssRace.OtherPacificIslander, "Y"),
+              Tuple.Create(VR.NvssRace.OtherRace, "Y"),
+              Tuple.Create(VR.NvssRace.Samoan, "Y"),
+              Tuple.Create(VR.NvssRace.Vietnamese, "Y"),
+              Tuple.Create(VR.NvssRace.White, "Y"),
+          };
     }
+  }
 }


### PR DESCRIPTION
Fields in IJE types that are marked as deleted by NCHS return blank strings of the normal field length when accessed. Remove the corresponding fields from the FHIR birth and fetal death record types. Fields that are now exclusive to birth records are owned by the FHIR birth record type.

Addresses Jira issue 782.