### PR TITLE
fix(bfdr): ensure IJE fields return strings of the correct length

### DIFF
--- a/projects/BFDR.Tests/NatalityData_Should.cs
+++ b/projects/BFDR.Tests/NatalityData_Should.cs
@@ -513,32 +513,32 @@ namespace BFDR.Tests
     public void TestSetEthnicityLiteral()
     {
       IJEBirth ije = new();
-      Assert.Equal("", ije.METHNIC5);
-      Assert.Equal("", ije.FETHNIC5);
+      Assert.Equal("", ije.METHNIC5.Trim());
+      Assert.Equal("", ije.FETHNIC5.Trim());
       ije.METHNIC5 = "Bolivian";
       ije.FETHNIC5 = "Columbian";
-      Assert.Equal("Bolivian", ije.METHNIC5);
-      Assert.Equal("Columbian", ije.FETHNIC5);
-      Assert.Equal("Bolivian", ije.ToRecord().MotherEthnicityLiteral);
-      Assert.Equal("Columbian", ije.ToRecord().FatherEthnicityLiteral);
+      Assert.Equal("Bolivian", ije.METHNIC5.Trim());
+      Assert.Equal("Columbian", ije.FETHNIC5.Trim());
+      Assert.Equal("Bolivian", ije.ToRecord().MotherEthnicityLiteral.Trim());
+      Assert.Equal("Columbian", ije.ToRecord().FatherEthnicityLiteral.Trim());
     }
 
     [Fact]
     public void TestImportEthnicityLiteral()
     {
       IJEBirth ije = new(File.ReadAllText(TestHelpers.FixturePath("fixtures/ije/BasicBirthRecord.ije")), true);
-      Assert.Equal("Chilean", ije.METHNIC5);
-      Assert.Equal("Panamanian", ije.FETHNIC5);
-      Assert.Equal("Chilean", ije.ToRecord().MotherEthnicityLiteral);
-      Assert.Equal("Panamanian", ije.ToRecord().FatherEthnicityLiteral);
+      Assert.Equal("Chilean", ije.METHNIC5.Trim());
+      Assert.Equal("Panamanian", ije.FETHNIC5.Trim());
+      Assert.Equal("Chilean", ije.ToRecord().MotherEthnicityLiteral.Trim());
+      Assert.Equal("Panamanian", ije.ToRecord().FatherEthnicityLiteral.Trim());
     }
 
     [Fact]
     public void TestSetCodedEthnicityLiteral()
     {
       IJEBirth ije = new();
-      Assert.Equal("", ije.METHNIC5C);
-      Assert.Equal("", ije.FETHNIC5C);
+      Assert.Equal("", ije.METHNIC5C.Trim());
+      Assert.Equal("", ije.FETHNIC5C.Trim());
       ije.METHNIC5C = VR.ValueSets.HispanicOrigin.Bolivian;
       ije.FETHNIC5C = VR.ValueSets.HispanicOrigin.Chicano;
       Assert.Equal("232", ije.METHNIC5C);
@@ -551,10 +551,10 @@ namespace BFDR.Tests
     public void TestSetCodedEthnicity()
     {
       IJEBirth ije = new();
-      Assert.Equal("", ije.METHNICE);
-      Assert.Equal("", ije.FETHNICE);
-      Assert.Equal("", ije.METHNIC5C);
-      Assert.Equal("", ije.FETHNIC5C);
+      Assert.Equal("", ije.METHNICE.Trim());
+      Assert.Equal("", ije.FETHNICE.Trim());
+      Assert.Equal("", ije.METHNIC5C.Trim());
+      Assert.Equal("", ije.FETHNIC5C.Trim());
       ije.FETHNICE = VR.ValueSets.HispanicOrigin.Chicano;
       ije.METHNICE = VR.ValueSets.HispanicOrigin.Bolivian;
       ije.FETHNIC5C = VR.ValueSets.HispanicOrigin.Dominican;
@@ -1191,8 +1191,8 @@ namespace BFDR.Tests
       Assert.Equal("N", ije.ECVS);
       Assert.Equal("N", ije.ECVF);
       Assert.Equal("N", ije.ANEN);
-      Assert.Equal("7134703", ije.INF_MED_REC_NUM);
-      Assert.Equal("2286144", ije.MOM_MED_REC_NUM);
+      Assert.Equal("7134703", ije.INF_MED_REC_NUM.Trim());
+      Assert.Equal("2286144", ije.MOM_MED_REC_NUM.Trim());
       IJEBirth ije2 = new IJEBirth(ije.ToString());
       Assert.Equal("U", ije2.GDIAB);
       Assert.Equal("Y", ije2.GHYPE);
@@ -1201,8 +1201,8 @@ namespace BFDR.Tests
       Assert.Equal("N", ije2.ECVS);
       Assert.Equal("N", ije2.ECVF);
       Assert.Equal("N", ije2.ANEN);
-      Assert.Equal("7134703", ije2.INF_MED_REC_NUM);
-      Assert.Equal("2286144", ije2.MOM_MED_REC_NUM);
+      Assert.Equal("7134703", ije2.INF_MED_REC_NUM.Trim());
+      Assert.Equal("2286144", ije2.MOM_MED_REC_NUM.Trim());
       IJEBirth ije3 = new IJEBirth(new BirthRecord(ije2.ToRecord().ToXML()));
       Assert.Equal("U", ije3.GDIAB);
       Assert.Equal("Y", ije3.GHYPE);
@@ -1211,8 +1211,8 @@ namespace BFDR.Tests
       Assert.Equal("N", ije3.ECVS);
       Assert.Equal("N", ije3.ECVF);
       Assert.Equal("N", ije3.ANEN);
-      Assert.Equal("7134703", ije3.INF_MED_REC_NUM);
-      Assert.Equal("2286144", ije3.MOM_MED_REC_NUM);
+      Assert.Equal("7134703", ije3.INF_MED_REC_NUM.Trim());
+      Assert.Equal("2286144", ije3.MOM_MED_REC_NUM.Trim());
     }
 
     [Fact]

--- a/projects/BFDR/IJEBirth.cs
+++ b/projects/BFDR/IJEBirth.cs
@@ -135,16 +135,7 @@ namespace BFDR
         {
             get
             {
-                if (String.IsNullOrWhiteSpace(record?.CertificateNumber))
-                {
-                    return "".PadLeft(6, '0');
-                }
-                string id_str = record.CertificateNumber;
-                if (id_str.Length > 6)
-                {
-                    id_str = id_str.Substring(id_str.Length - 6);
-                }
-                return id_str.PadLeft(6, '0');
+                return RightJustifiedZeroed_Get("FILENO", "CertificateNumber");
             }
             set
             {
@@ -169,10 +160,6 @@ namespace BFDR
         {
             get
             {
-                if (record.StateLocalIdentifier1 == null)
-                {
-                    return (new String(' ', 12));
-                }
                 return LeftJustified_Get("AUXNO", "StateLocalIdentifier1");
             }
             set
@@ -699,21 +686,13 @@ namespace BFDR
         {
             get
             {
-                var ethnicityLiteral = record.MotherEthnicityLiteral;
-                if (!String.IsNullOrWhiteSpace(ethnicityLiteral))
-                {
-                    return Truncate(ethnicityLiteral, 20).Trim();
-                }
-                else
-                {
-                    return "";
-                }
+                return LeftJustified_Get("METHNIC5", "MotherEthnicityLiteral");
             }
             set
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
-                    record.MotherEthnicityLiteral = value;
+                    LeftJustified_Set("METHNIC5", "MotherEthnicityLiteral", value);
                 }
             }
         }
@@ -1366,21 +1345,13 @@ namespace BFDR
         {
             get
             {
-                var ethnicityLiteral = record.FatherEthnicityLiteral;
-                if (!String.IsNullOrWhiteSpace(ethnicityLiteral))
-                {
-                    return Truncate(ethnicityLiteral, 20).Trim();
-                }
-                else
-                {
-                    return "";
-                }
+                return LeftJustified_Get("FETHNIC5", "FatherEthnicityLiteral");
             }
             set
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
-                    record.FatherEthnicityLiteral = value;
+                    LeftJustified_Set("FETHNIC5", "FatherEthnicityLiteral", value);
                 }
             }
         }
@@ -1940,12 +1911,10 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location:
                 return record.MotherTransferredHelper;
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location:
                 record.MotherTransferredHelper = value.Trim();
             }
         }
@@ -2761,12 +2730,10 @@ namespace BFDR
         {
             get
             {
-                // TODO: Implement mapping from FHIR record location:
                 return Get_MappingFHIRToIJE(Mappings.FetalPresentation.FHIRToIJE, "FetalPresentation", "PRES");
             }
             set
             {
-                // TODO: Implement mapping to FHIR record location:
                 Set_MappingIJEToFHIR(Mappings.FetalPresentation.IJEToFHIR, "PRES", "FetalPresentation", value.Trim());
             }
         }
@@ -3431,15 +3398,7 @@ namespace BFDR
         [IJEField(247, 1001, 50, "Child's First Name", "KIDFNAME", 1)]
         public string KIDFNAME
         {
-            get
-            {
-                string[] names = record.ChildGivenNames;
-                if (names.Length > 0)
-                {
-                    return Truncate(names[0], 50).PadRight(50, ' ');
-                }
-                return new string(' ', 50);
-            }
+            get => LeftJustifiedValue("KIDFNAME", record.ChildGivenNames);
             set => record.ChildGivenNames = Update_FirstName(value, record.ChildGivenNames);
         }
 
@@ -3447,15 +3406,7 @@ namespace BFDR
         [IJEField(248, 1051, 50, "Child's Middle Name", "KIDMNAME", 1)]
         public string KIDMNAME
         {
-            get
-            {
-                string[] names = record.ChildGivenNames;
-                if (names.Length > 1)
-                {
-                    return Truncate(names[1], 50).PadRight(50, ' ');
-                }
-                return " ";
-            }
+            get => LeftJustifiedValue("KIDMNAME", record.ChildGivenNames, 1);
             set => record.ChildGivenNames = Update_MiddleName(value, record.ChildGivenNames, KIDFNAME);
         }
 
@@ -3533,15 +3484,7 @@ namespace BFDR
         [IJEField(254, 1283, 50, "Mother's First Name", "MOMFNAME", 1)]
         public string MOMFNAME
         {
-            get
-            {
-                string[] names = record.MotherGivenNames;
-                if (names.Length > 0)
-                {
-                    return Truncate(names[0], 50).PadRight(50, ' ');
-                }
-                return new string(' ', 50);
-            }
+            get => LeftJustifiedValue("MOMFNAME", record.MotherGivenNames);
             set => record.MotherGivenNames = Update_FirstName(value, record.MotherGivenNames);
         }
 
@@ -3549,15 +3492,7 @@ namespace BFDR
         [IJEField(255, 1333, 50, "Mother's Middle Name", "MOMMIDDL", 1)]
         public string MOMMIDDL
         {
-            get
-            {
-                string[] names = record.MotherGivenNames;
-                if (names.Length > 1)
-                {
-                    return Truncate(names[1], 50).PadRight(50, ' ');
-                }
-                return " ";
-            }
+            get => LeftJustifiedValue("MOMMIDDL", record.MotherGivenNames, 1);
             set => record.MotherGivenNames = Update_MiddleName(value, record.MotherGivenNames, MOMFNAME);
         }
 
@@ -3594,12 +3529,7 @@ namespace BFDR
         {
             get
             {
-                string[] names = record.MotherMaidenGivenNames;
-                if (names.Length > 0)
-                {
-                    return Truncate(names[0], 50).PadRight(50, ' ');
-                }
-                return new string(' ', 50);
+                return LeftJustifiedValue("MOMFMNME", record.MotherMaidenGivenNames);
             }
             set
             {
@@ -3614,15 +3544,7 @@ namespace BFDR
         [IJEField(259, 1490, 50, "Mother's Middle Maiden Name", "MOMMMID", 1)]
         public string MOMMMID
         {
-            get
-            {
-                string[] names = record.MotherMaidenGivenNames;
-                if (names.Length > 1)
-                {
-                    return Truncate(names[1], 50).PadRight(50, ' ');
-                }
-                return " ";
-            }
+            get => LeftJustifiedValue("MOMMMID", record.MotherMaidenGivenNames, 1);
             set => record.MotherMaidenGivenNames = Update_MiddleName(value, record.MotherMaidenGivenNames, MOMFMNME);
         }
 
@@ -3856,15 +3778,7 @@ namespace BFDR
         [IJEField(274, 1843, 50, "Father's First Name", "DADFNAME", 1)]
         public string DADFNAME
         {
-            get
-            {
-                string[] names = record.FatherGivenNames;
-                if (names.Length > 0)
-                {
-                    return Truncate(names[0], 50).PadRight(50, ' ');
-                }
-                return new string(' ', 50);
-            }
+            get => LeftJustifiedValue("DADFNAME", record.FatherGivenNames);
             set => record.FatherGivenNames = Update_FirstName(value, record.FatherGivenNames);
         }
 
@@ -3872,15 +3786,7 @@ namespace BFDR
         [IJEField(275, 1893, 50, "Father's Middle Name", "DADMNAME", 1)]
         public string DADMNAME
         {
-            get
-            {
-                string[] names = record.FatherGivenNames;
-                if (names.Length > 1)
-                {
-                    return Truncate(names[1], 50).PadRight(50, ' ');
-                }
-                return " ";
-            }
+            get => LeftJustifiedValue("DADMNAME", record.FatherGivenNames, 1);
             set => record.FatherGivenNames = Update_MiddleName(value, record.FatherGivenNames, DADFNAME);
         }
 
@@ -4133,21 +4039,13 @@ namespace BFDR
         {
             get
             {
-                var ethnicityCodeLiteral = record.MotherEthnicityCodeForLiteralHelper;
-                if (!String.IsNullOrWhiteSpace(ethnicityCodeLiteral))
-                {
-                    return Truncate(ethnicityCodeLiteral, 3).Trim();
-                }
-                else
-                {
-                    return "";
-                }
+                return LeftJustified_Get("METHNIC5C", "MotherEthnicityCodeForLiteralHelper");
             }
             set
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
-                    record.MotherEthnicityCodeForLiteralHelper = value;
+                    LeftJustified_Set("METHNIC5C", "MotherEthnicityCodeForLiteralHelper", value);
                 }
             }
         }
@@ -4158,21 +4056,13 @@ namespace BFDR
         {
             get
             {
-                var ethnicityCode = record.MotherEthnicityEditedCodeHelper;
-                if (!String.IsNullOrWhiteSpace(ethnicityCode))
-                {
-                    return Truncate(ethnicityCode, 3).Trim();
-                }
-                else
-                {
-                    return "";
-                }
+                return LeftJustified_Get("METHNICE", "MotherEthnicityEditedCodeHelper");
             }
             set
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
-                    record.MotherEthnicityEditedCodeHelper = value;
+                    LeftJustified_Set("METHNICE", "MotherEthnicityEditedCodeHelper", value);
                 }
             }
         }
@@ -4198,21 +4088,13 @@ namespace BFDR
         {
             get
             {
-                var ethnicityCodeLiteral = record.FatherEthnicityCodeForLiteralHelper;
-                if (!String.IsNullOrWhiteSpace(ethnicityCodeLiteral))
-                {
-                    return Truncate(ethnicityCodeLiteral, 3).Trim();
-                }
-                else
-                {
-                    return "";
-                }
+                return LeftJustified_Get("FETHNIC5C", "FatherEthnicityCodeForLiteralHelper");
             }
             set
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
-                    record.FatherEthnicityCodeForLiteralHelper = value;
+                    LeftJustified_Set("FETHNIC5C", "FatherEthnicityCodeForLiteralHelper", value);
                 }
             }
         }
@@ -4223,21 +4105,13 @@ namespace BFDR
         {
             get
             {
-                var ethnicityCodeLiteral = record.FatherEthnicityEditedCodeHelper;
-                if (!String.IsNullOrWhiteSpace(ethnicityCodeLiteral))
-                {
-                    return Truncate(ethnicityCodeLiteral, 3).Trim();
-                }
-                else
-                {
-                    return "";
-                }
+                return LeftJustified_Get("FETHNICE", "FatherEthnicityEditedCodeHelper");
             }
             set
             {
                 if (!String.IsNullOrWhiteSpace(value))
                 {
-                    record.FatherEthnicityEditedCodeHelper = value;
+                    LeftJustified_Set("FETHNICE", "FatherEthnicityEditedCodeHelper", value);
                 }
             }
         }
@@ -4339,11 +4213,7 @@ namespace BFDR
         {
             get
             {
-                if (record.AttendantOtherHelper != null)
-                {
-                    return LeftJustified_Get("ATTEND_OTH_TXT", "AttendantOtherHelper");
-                }
-                return "";
+                return LeftJustified_Get("ATTEND_OTH_TXT", "AttendantOtherHelper");
             }
             set
             {
@@ -4818,11 +4688,7 @@ namespace BFDR
         {
             get
             {
-                if (record.CertifierOtherHelper != null)
-                {
-                    return LeftJustified_Get("CERTIF_OTH_TXT", "CertifierOtherHelper");
-                }
-                return "";
+                return LeftJustified_Get("CERTIF_OTH_TXT", "CertifierOtherHelper");
             }
             set
             {
@@ -4839,11 +4705,11 @@ namespace BFDR
         {
             get
             {
-                return record.InfantMedicalRecordNumber;
+                return LeftJustified_Get("INF_MED_REC_NUM", "InfantMedicalRecordNumber");
             }
             set
             {
-                record.InfantMedicalRecordNumber = value.Trim();
+                LeftJustified_Set("INF_MED_REC_NUM", "InfantMedicalRecordNumber", value);
             }
         }
 
@@ -4853,11 +4719,11 @@ namespace BFDR
         {
             get
             {
-                return record.MotherMedicalRecordNumber;
+                return LeftJustified_Get("MOM_MED_REC_NUM", "MotherMedicalRecordNumber");
             }
             set
             {
-                record.MotherMedicalRecordNumber = value.Trim();
+                LeftJustified_Set("MOM_MED_REC_NUM", "MotherMedicalRecordNumber", value);
             }
         }
 

--- a/projects/BFDR/IJEFetalDeath.cs
+++ b/projects/BFDR/IJEFetalDeath.cs
@@ -208,16 +208,7 @@ namespace BFDR
         {
             get
             {
-                if (String.IsNullOrWhiteSpace(record?.CertificateNumber))
-                {
-                    return "".PadLeft(6, '0');
-                }
-                string id_str = record.CertificateNumber;
-                if (id_str.Length > 6)
-                {
-                    id_str = id_str.Substring(id_str.Length - 6);
-                }
-                return id_str.PadLeft(6, '0');
+                return RightJustifiedZeroed_Get("FILENO", "CertificateNumber");
             }
             set
             {
@@ -242,10 +233,6 @@ namespace BFDR
         {
             get
             {
-                if (record.StateLocalIdentifier1 == null)
-                {
-                    return (new String(' ', 12));
-                }
                 return LeftJustified_Get("AUXNO", "StateLocalIdentifier1");
             }
             set
@@ -757,15 +744,7 @@ namespace BFDR
         {
             get
             {
-                var ethnicityLiteral = record.MotherEthnicityLiteral;
-                if (!String.IsNullOrWhiteSpace(ethnicityLiteral))
-                {
-                    return Truncate(ethnicityLiteral, 20).Trim();
-                }
-                else
-                {
-                    return "";
-                }
+                return LeftJustified_Get("METHNIC5", "MotherEthnicityLiteral");
             }
             set
             {
@@ -3167,12 +3146,7 @@ namespace BFDR
         {
             get
             {
-                string[] names = record.FetusGivenNames;
-                if (names.Length > 0)
-                {
-                    return Truncate(names[0], 50).PadRight(50, ' ');
-                }
-                return new string(' ', 50);
+                return LeftJustifiedValue("FETFNAME", record.FetusGivenNames);
             }
             set
             {
@@ -3189,12 +3163,7 @@ namespace BFDR
         {
             get
             {
-                string[] names = record.FetusGivenNames;
-                if (names.Length > 1)
-                {
-                    return Truncate(names[1], 50).PadRight(50, ' ');
-                }
-                return " ";
+                return LeftJustifiedValue("FETMNAME", record.FetusGivenNames, 1);
             }
             set => record.FetusGivenNames = Update_MiddleName(value, record.FetusGivenNames, FETFNAME);
         }
@@ -3496,15 +3465,7 @@ namespace BFDR
         [IJEField(239, 3257, 50, "Mother's Legal First Name", "MOMFNAME", 1)]
         public string MOMFNAME
         {
-            get
-            {
-                string[] names = record.MotherGivenNames;
-                if (names.Length > 0)
-                {
-                    return Truncate(names[0], 50).PadRight(50, ' ');
-                }
-                return new string(' ', 50);
-            }
+            get => LeftJustifiedValue("MOMFNAME", record.MotherGivenNames);
             set => record.MotherGivenNames = Update_FirstName(value, record.MotherGivenNames);
         }
 
@@ -3512,15 +3473,7 @@ namespace BFDR
         [IJEField(240, 3307, 50, "Mother's Legal Middle Name", "MOMMNAME", 1)]
         public string MOMMNAME
         {
-            get
-            {
-                string[] names = record.MotherGivenNames;
-                if (names.Length > 1)
-                {
-                    return Truncate(names[1], 50).PadRight(50, ' ');
-                }
-                return " ";
-            }
+            get => LeftJustifiedValue("MOMMNAME", record.MotherGivenNames, 1);
             set => record.MotherGivenNames = Update_MiddleName(value, record.MotherGivenNames, MOMFNAME);
         }
 
@@ -3557,12 +3510,7 @@ namespace BFDR
         {
             get
             {
-                string[] names = record.MotherMaidenGivenNames;
-                if (names.Length > 0)
-                {
-                    return Truncate(names[0], 50).PadRight(50, ' ');
-                }
-                return new string(' ', 50);
+                return LeftJustifiedValue("MOMFMNME", record.MotherMaidenGivenNames);
             }
             set
             {
@@ -3579,12 +3527,7 @@ namespace BFDR
         {
             get
             {
-                string[] names = record.MotherMaidenGivenNames;
-                if (names.Length > 1)
-                {
-                    return Truncate(names[1], 50).PadRight(50, ' ');
-                }
-                return " ";
+                return LeftJustifiedValue("MOMMMID", record.MotherMaidenGivenNames, 1);
             }
             set
             {
@@ -3872,15 +3815,7 @@ namespace BFDR
         [IJEField(261, 3879, 50, "Father's Legal First Name", "DADFNAME", 1)]
         public string DADFNAME
         {
-            get
-            {
-                string[] names = record.FatherGivenNames;
-                if (names.Length > 0)
-                {
-                    return Truncate(names[0], 50).PadRight(50, ' ');
-                }
-                return new string(' ', 50);
-            }
+            get => LeftJustifiedValue("DADFNAME", record.FatherGivenNames);
             set => record.FatherGivenNames = Update_FirstName(value, record.FatherGivenNames);
         }
 
@@ -3888,15 +3823,7 @@ namespace BFDR
         [IJEField(262, 3929, 50, "Father's Legal Middle Name", "DADMNAME", 1)]
         public string DADMNAME
         {
-            get
-            {
-                string[] names = record.FatherGivenNames;
-                if (names.Length > 1)
-                {
-                    return Truncate(names[1], 50).PadRight(50, ' ');
-                }
-                return " ";
-            }
+            get => LeftJustifiedValue("DADMNAME", record.FatherGivenNames, 1);
             set => record.FatherGivenNames = Update_MiddleName(value, record.FatherGivenNames, DADFNAME);
         }
 
@@ -4347,15 +4274,7 @@ namespace BFDR
         {
             get
             {
-                var ethnicityLiteral = record.FatherEthnicityLiteral;
-                if (!String.IsNullOrWhiteSpace(ethnicityLiteral))
-                {
-                    return Truncate(ethnicityLiteral, 20).Trim();
-                }
-                else
-                {
-                    return "";
-                }
+                 return LeftJustified_Get("FETHNIC5", "FatherEthnicityLiteral");
             }
             set
             {

--- a/projects/VRDR.STU2.Convert/Program.cs
+++ b/projects/VRDR.STU2.Convert/Program.cs
@@ -36,7 +36,6 @@ namespace VRDR.CLI
             }
             return 0;
         }
-
         // CompareTwo: Perform a field by field comparison of d1 to d2
         private static int CompareTwo(DeathRecord d1, DeathRecord d2)
         {

--- a/projects/VRDR.STU2.Convert/Program.cs
+++ b/projects/VRDR.STU2.Convert/Program.cs
@@ -36,6 +36,7 @@ namespace VRDR.CLI
             }
             return 0;
         }
+
         // CompareTwo: Perform a field by field comparison of d1 to d2
         private static int CompareTwo(DeathRecord d1, DeathRecord d2)
         {

--- a/projects/VRDR/DeathRecord.xml
+++ b/projects/VRDR/DeathRecord.xml
@@ -3419,9 +3419,6 @@
         <member name="M:VRDR.IJEMortality.DateTime_Set(System.String,System.String,System.String,System.String,System.Boolean,System.Boolean)">
             <summary>Set a value on the DeathRecord whose type is some part of a DateTime.</summary>
         </member>
-        <member name="M:VRDR.IJEMortality.RightJustifiedZeroed_Get(System.String,System.String)">
-            <summary>Get a value on the DeathRecord whose IJE type is a right justified, zero filled string.</summary>
-        </member>
         <member name="M:VRDR.IJEMortality.Dictionary_Get(System.String,System.String,System.String)">
             <summary>Get a value on the DeathRecord whose property is a Dictionary type.</summary>
         </member>

--- a/projects/VRDR/IJEMortality.cs
+++ b/projects/VRDR/IJEMortality.cs
@@ -308,21 +308,6 @@ namespace VRDR
             }
         }
 
-        /// <summary>Get a value on the DeathRecord whose IJE type is a right justified, zero filled string.</summary>
-        private string RightJustifiedZeroed_Get(string ijeFieldName, string fhirFieldName)
-        {
-            IJEField info = FieldInfo(ijeFieldName);
-            string current = Convert.ToString(typeof(DeathRecord).GetProperty(fhirFieldName).GetValue(this.record));
-            if (current != null)
-            {
-                return Truncate(current, info.Length).PadLeft(info.Length, '0');
-            }
-            else
-            {
-                return new String('0', info.Length);
-            }
-        }
-
         /// <summary>Get a value on the DeathRecord whose property is a Dictionary type.</summary>
         private string Dictionary_Get(string ijeFieldName, string fhirFieldName, string key)
         {
@@ -595,12 +580,7 @@ namespace VRDR
         {
             get
             {
-                string[] names = record.GivenNames;
-                if (names.Length > 0)
-                {
-                    return Truncate(names[0], 50).PadRight(50, ' ');
-                }
-                return new string(' ', 50);
+                return LeftJustifiedValue("GNAME", record.GivenNames);
             }
             set
             {
@@ -617,12 +597,7 @@ namespace VRDR
         {
             get
             {
-                string[] names = record.GivenNames;
-                if (names.Length > 1)
-                {
-                    return Truncate(names[1], 1).PadRight(1, ' ');
-                }
-                return " ";
+                return LeftJustifiedValue("MNAME", record.GivenNames, 1);
             }
             set
             {
@@ -3031,12 +3006,7 @@ namespace VRDR
         {
             get
             {
-                string[] names = record.SpouseGivenNames;
-                if (names.Length > 0)
-                {
-                    return Truncate(names[0], 50).PadRight(50, ' ');
-                }
-                return new string(' ', 50);
+                return LeftJustifiedValue("SPOUSEF", record.SpouseGivenNames);
             }
             set
             {
@@ -3413,12 +3383,7 @@ namespace VRDR
         {
             get
             {
-                string[] names = record.GivenNames;
-                if (names.Length > 1)
-                {
-                    return Truncate(names[1], 50).PadRight(50, ' ');
-                }
-                return new string(' ', 50);
+                return LeftJustifiedValue("DMIDDLE", record.GivenNames, 1);
             }
             set
             {
@@ -3441,12 +3406,7 @@ namespace VRDR
         {
             get
             {
-                string[] names = record.FatherGivenNames;
-                if (names != null && names.Length > 0)
-                {
-                    return Truncate(names[0], 50).PadRight(50, ' ');
-                }
-                return new string(' ', 50);
+                return LeftJustifiedValue("DDADF", record.FatherGivenNames);
             }
             set
             {
@@ -3463,12 +3423,7 @@ namespace VRDR
         {
             get
             {
-                string[] names = record.FatherGivenNames;
-                if (names != null && names.Length > 1)
-                {
-                    return Truncate(names[1], 50).PadRight(50, ' ');
-                }
-                return new string(' ', 50);
+                return LeftJustifiedValue("DDADMID", record.FatherGivenNames, 1);
             }
             set
             {
@@ -3491,12 +3446,7 @@ namespace VRDR
         {
             get
             {
-                string[] names = record.MotherGivenNames;
-                if (names != null && names.Length > 0)
-                {
-                    return Truncate(names[0], 50).PadRight(50, ' ');
-                }
-                return new string(' ', 50);
+                return LeftJustifiedValue("DMOMF", record.MotherGivenNames);
             }
             set
             {
@@ -3513,12 +3463,7 @@ namespace VRDR
         {
             get
             {
-                string[] names = record.MotherGivenNames;
-                if (names != null && names.Length > 1)
-                {
-                    return Truncate(names[1], 50).PadRight(50, ' ');
-                }
-                return new string(' ', 50);
+                return LeftJustifiedValue("DMOMMID", record.MotherGivenNames, 1);
             }
             set
             {
@@ -4047,12 +3992,7 @@ namespace VRDR
         {
             get
             {
-                string[] names = record.SpouseGivenNames;
-                if (names != null && names.Length > 1)
-                {
-                    return Truncate(names[1], 50).PadRight(50, ' ');
-                }
-                return new string(' ', 50);
+                return LeftJustifiedValue("SPOUSEMIDNAME", record.SpouseGivenNames, 1);
             }
             set
             {
@@ -4463,12 +4403,7 @@ namespace VRDR
         {
             get
             {
-                string[] names = record.CertifierGivenNames;
-                if (names != null && names.Length > 0)
-                {
-                    return Truncate(names[0], 50).PadRight(50, ' ');
-                }
-                return new string(' ', 50);
+                return LeftJustifiedValue("CERTFIRST", record.CertifierGivenNames);
             }
             set
             {
@@ -4485,12 +4420,7 @@ namespace VRDR
         {
             get
             {
-                string[] names = record.CertifierGivenNames;
-                if (names != null && names.Length > 1)
-                {
-                    return Truncate(names[1], 50).PadRight(50, ' ');
-                }
-                return new string(' ', 50);
+                return LeftJustifiedValue("CERTMIDDLE", record.CertifierGivenNames, 1);
             }
             set
             {

--- a/projects/VitalRecord/IJE.cs
+++ b/projects/VitalRecord/IJE.cs
@@ -162,6 +162,17 @@ namespace VR
             NumericAllowingUnknown_Set(ijeFieldName, fhirFieldName, value);
         }
 
+        /// <summary>Get the value of the supplied array at position pos, correctly padded to the supplied IJE field length</summary>
+        protected string LeftJustifiedValue(string ijeFieldName, string[] values, int pos = 0)
+        {
+            IJEField info = FieldInfo(ijeFieldName);
+            if (values == null || values.Length <= pos)
+            {
+                return new string(' ', info.Length);
+            }
+            return Truncate(values[pos], info.Length).PadRight(info.Length, ' ');
+        }
+
         /// <summary>Get a value on the VitalRecord whose IJE type is a left justified string.</summary>
         protected string LeftJustified_Get(string ijeFieldName, string fhirFieldName)
         {
@@ -276,10 +287,26 @@ namespace VR
             }
         }
 
+        /// <summary>Get a value from the VitalRecord whose IJE type is a right justified, zero filled string.</summary>
+        protected string RightJustifiedZeroed_Get(string ijeFieldName, string fhirFieldName)
+        {
+            IJEField info = FieldInfo(ijeFieldName);
+            string current = Convert.ToString(Record.GetType().GetProperty(fhirFieldName).GetValue(Record));
+            if (current != null)
+            {
+                if (current.Length > info.Length)
+                {
+                    validationErrors.Add($"Error: FHIR field {fhirFieldName} contains string '{current}' too long for IJE field {ijeFieldName} of length {info.Length}");
+                    current = current.Substring(current.Length - info.Length);
+                }
+                return current.PadLeft(info.Length, '0');
+            }
+            return "".PadLeft(info.Length, '0');
+        }
+
         /// <summary>Set a value on the VitalRecord whose IJE type is a right justified, zero filled string.</summary>
         protected void RightJustifiedZeroed_Set(string ijeFieldName, string fhirFieldName, string value)
         {
-            IJEField info = FieldInfo(ijeFieldName);
             Record.GetType().GetProperty(fhirFieldName).SetValue(Record, value.TrimStart('0'));
         }
 

--- a/projects/VitalRecord/VitalRecord.xml
+++ b/projects/VitalRecord/VitalRecord.xml
@@ -258,6 +258,9 @@
             <summary>Set a value on the VitalRecord that is a numeric string with the option of being set to all 8s on the IJE side and absent on the
             FHIR side to represent'unknown'</summary>
         </member>
+        <member name="M:VR.IJE.LeftJustifiedValue(System.String,System.String[],System.Int32)">
+            <summary>Get the value of the supplied array at position pos, correctly padded to the supplied IJE field length</summary>
+        </member>
         <member name="M:VR.IJE.LeftJustified_Get(System.String,System.String)">
             <summary>Get a value on the VitalRecord whose IJE type is a left justified string.</summary>
         </member>
@@ -275,6 +278,9 @@
         </member>
         <member name="M:VR.IJE.TimeAllowingUnknown_Set(System.String,System.String,System.String)">
             <summary>Set a value on the DeathRecord that is a time with the option of being set to all 9s on the IJE side and null on the FHIR side to represent null</summary>
+        </member>
+        <member name="M:VR.IJE.RightJustifiedZeroed_Get(System.String,System.String)">
+            <summary>Get a value from the VitalRecord whose IJE type is a right justified, zero filled string.</summary>
         </member>
         <member name="M:VR.IJE.RightJustifiedZeroed_Set(System.String,System.String,System.String)">
             <summary>Set a value on the VitalRecord whose IJE type is a right justified, zero filled string.</summary>


### PR DESCRIPTION
This PR updates IJE properties whose getter could return strings that don't match the IJE field length, adding padding as necessary. A new helper method (LeftJustifiedValue) is used to consolidate handling of multivalued FHIR attributes such as given names. An existing VRDR helper is moved to the IJE base class for use in BFDR.

Fixes #NVSS-787