### PR TITLE
chore: add windows versions of run_tests scripts

### DIFF
--- a/projects/BFDR.Tests/run_tests.bat
+++ b/projects/BFDR.Tests/run_tests.bat
@@ -1,0 +1,81 @@
+@REM Make sure we can read and parse a JSON file
+dotnet run --project BFDR.CLI 2ije birth BFDR.Tests\fixtures\json\BasicBirthRecord.json > NUL || exit /b 127
+dotnet run --project BFDR.CLI 2ije fetaldeath BFDR.Tests\fixtures\json\BasicFetalDeathRecord.json > NUL || exit /b 127
+
+@REM Make sure we can read and parse an XML file
+dotnet run --project BFDR.CLI 2ijecontent birth BFDR.Tests\fixtures\json\BasicBirthRecord.json > NUL || exit /b 127
+dotnet run --project BFDR.CLI 2ijecontent fetaldeath BFDR.Tests\fixtures\json\BasicFetalDeathRecord.json > NUL || exit /b 127
+
+@REM Make sure we can pull all information out of a JSON file
+dotnet run --project BFDR.CLI description birth BFDR.Tests\fixtures\json\BasicBirthRecord.json > NUL || exit /b 127
+dotnet run --project BFDR.CLI description fetaldeath BFDR.Tests\fixtures\json\BasicFetalDeathRecord.json > NUL || exit /b 127
+
+@REM Make sure we can convert ije to json
+dotnet run --project BFDR.CLI ije2json birth BFDR.Tests\fixtures\ije\BasicBirthRecord.ije > NUL || exit /b 127
+dotnet run --project BFDR.CLI ije2json fetaldeath BFDR.Tests\fixtures\ije\FetalDeathRecord.ije > NUL || exit /b 127
+
+@REM Make sure we can convert ije to xml format
+dotnet run --project BFDR.CLI ije2xml birth BFDR.Tests\fixtures\ije\BasicBirthRecord.ije > NUL || exit /b 127
+dotnet run --project BFDR.CLI ije2xml fetaldeath BFDR.Tests\fixtures\ije\FetalDeathRecord.ije > NUL || exit /b 127
+
+@REM Make sure we can convert content of submission message in ije format
+dotnet run --project BFDR.CLI extract2ijecontent birth BFDR.Tests\fixtures\json\BirthRecordSubmissionMessage.json > NUL || exit /b 127
+dotnet run --project BFDR.CLI extract2ijecontent fetaldeath BFDR.Tests\fixtures\json\BasicFetalDeathRecordSubmissionMessage.json > NUL || exit /b 127
+
+@REM Make sure we can void a record
+dotnet run --project BFDR.CLI void birth BFDR.Tests\fixtures\json\BasicBirthRecord.json > NUL || exit /b 127
+dotnet run --project BFDR.CLI void birth BFDR.Tests\fixtures\json\BasicBirthRecord.json 1 > NUL || exit /b 127
+dotnet run --project BFDR.CLI void fetaldeath BFDR.Tests\fixtures\json\BasicFetalDeathRecord.json > NUL || exit /b 127
+dotnet run --project BFDR.CLI void fetaldeath BFDR.Tests\fixtures\json\BasicFetalDeathRecord.json 1 > NUL || exit /b 127
+
+@REM Make sure we can create an acknowledgement FHIR message for a submission FHIR message
+dotnet run --project BFDR.CLI ack birth BFDR.Tests\fixtures\json\BirthRecordSubmissionMessage.json > NUL || exit /b 127
+dotnet run --project BFDR.CLI ack birth BFDR.Tests\fixtures\json BFDR.Tests\fixtures\json\BirthRecordSubmissionMessage.json > NUL || exit /b 127
+dotnet run --project BFDR.CLI ack fetaldeath BFDR.Tests\fixtures\json\BasicFetalDeathRecordSubmissionMessage.json > NUL || exit /b 127
+dotnet run --project BFDR.CLI ack fetaldeath BFDR.Tests\fixtures\json BFDR.Tests\fixtures\json\BasicFetalDeathRecordSubmissionMessage.json > NUL || exit /b 127
+
+@REM Make sure we can read in and parse an ije record
+dotnet run --project BFDR.CLI ije birth BFDR.Tests\fixtures\ije\BasicBirthRecord.ije > NUL || exit /b 127
+dotnet run --project BFDR.CLI ije fetaldeath BFDR.Tests\fixtures\ije\FetalDeathRecord2.ije > NUL || exit /b 127
+
+@REM Make sure we can create a json record using IJE mapped fields
+dotnet run --project BFDR.CLI ijebuilder birth > NUL || exit /b 127
+dotnet run --project BFDR.CLI ijebuilder fetaldeath > NUL || exit /b 127
+
+@REM Make sure we can read in the FHIR JSON
+dotnet run --project BFDR.CLI json2xml birth BFDR.Tests\fixtures\json\BasicBirthRecord.json > NUL || exit /b 127
+dotnet run --project BFDR.CLI json2xml fetaldeath BFDR.Tests\fixtures\json\BasicFetalDeathRecord.json > NUL || exit /b 127
+
+@REM Make sure we can read in the FHIR xml
+dotnet run --project BFDR.CLI checkXml birth BFDR.Tests\fixtures\xml\BasicBirthRecord.xml > NUL || exit /b 127
+dotnet run --project BFDR.CLI checkXml fetaldeath BFDR.Tests\fixtures\xml\BasicFetalDeathRecord.xml > NUL || exit /b 127
+
+@REM Make sure we can read in the FHIR JSON
+dotnet run --project BFDR.CLI checkJson birth BFDR.Tests\fixtures\json\BasicBirthRecord.json > NUL || exit /b 127
+dotnet run --project BFDR.CLI checkJson fetaldeath BFDR.Tests\fixtures\json\BasicFetalDeathRecord.json > NUL || exit /b 127
+
+@REM Make sure we can convert xml to FHIR JSON
+dotnet run --project BFDR.CLI xml2json birth BFDR.Tests\fixtures\xml\BasicBirthRecord.xml > NUL || exit /b 127
+dotnet run --project BFDR.CLI xml2json fetaldeath BFDR.Tests\fixtures\xml\BasicFetalDeathRecord.xml > NUL || exit /b 127
+
+@REM Make sure we can convert xml to xml
+dotnet run --project BFDR.CLI xml2xml birth BFDR.Tests\fixtures\xml\BasicBirthRecord.xml > NUL || exit /b 127
+dotnet run --project BFDR.CLI xml2xml fetaldeath BFDR.Tests\fixtures\xml\BasicFetalDeathRecord.xml > NUL || exit /b 127
+
+@REM Make sure we can convert FHIR JSON to FHIR JSON
+dotnet run --project BFDR.CLI json2json birth BFDR.Tests\fixtures\json\BasicBirthRecord.json > NUL || exit /b 127
+dotnet run --project BFDR.CLI json2json fetaldeath BFDR.Tests\fixtures\json\BasicFetalDeathRecord.json > NUL || exit /b 127
+
+@REM Convert JSON files to IJE and back and make sure there's no data loss
+dotnet run --project BFDR.CLI roundtrip-ije birth BFDR.Tests\fixtures\json\BasicBirthRecord.json > NUL || exit /b 127
+dotnet run --project BFDR.CLI roundtrip-ije birth BFDR.Tests\fixtures\json\BasicBirthRecord2.json > NUL || exit /b 127
+dotnet run --project BFDR.CLI roundtrip-ije fetaldeath BFDR.Tests\fixtures\json\BasicFetalDeathRecord.json > NUL || exit /b 127
+
+@REM Convert JSON files to IJE and back and check every field individually
+dotnet run --project BFDR.CLI roundtrip-all birth BFDR.Tests\fixtures\json\BirthRecordZ.json || exit /b 127
+
+dotnet run --project BFDR.CLI roundtrip-all birth BFDR.Tests\fixtures\json\BirthRecordBabyGQuinn.json || exit /b 127
+dotnet run --project BFDR.CLI roundtrip-all birth BFDR.Tests\fixtures\json\BirthRecordBabyGQuinnJurisdiction.json || exit /b 127
+dotnet run --project BFDR.CLI roundtrip-all birth BFDR.Tests\fixtures\json\BirthRecordFakeWithRace.json || exit /b 127
+
+dotnet run --project BFDR.CLI roundtrip-all fetaldeath BFDR.Tests\fixtures\json\BasicFetalDeathRecord2.json || exit /b 127

--- a/projects/VRDR.Tests/run_tests.bat
+++ b/projects/VRDR.Tests/run_tests.bat
@@ -1,0 +1,43 @@
+@REM Run the C# test suite
+dotnet test VRDR.Tests\VRDR.Tests.csproj || exit /b 127
+
+@REM Make sure we can read and parse a JSON file
+dotnet run --project VRDR.CLI json2json VRDR.CLI\1_wJurisdiction.json > NUL || exit /b 127
+
+@REM Make sure we can read and parse an XML file
+dotnet run --project VRDR.CLI xml2xml VRDR.CLI\1_wJurisdiction.xml > NUL || exit /b 127
+
+@REM Make sure we can pull all information out of a JSON file
+dotnet run --project VRDR.CLI description VRDR.CLI\1_wJurisdiction.json > NUL || exit /b 127
+
+@REM Make sure we can pull all information out of a XML file
+dotnet run --project VRDR.CLI description VRDR.CLI\1_wJurisdiction.xml > NUL || exit /b 127
+
+@REM Convert JSON files to IJE and back and make sure there's no data loss
+dotnet run --project VRDR.CLI roundtrip-ije VRDR.CLI\1.json || exit /b 127
+dotnet run --project VRDR.CLI roundtrip-ije VRDR.CLI\1_wJurisdiction.json || exit /b 127
+
+@REM Convert XML files to IJE and back and make sure there's no data loss
+dotnet run --project VRDR.CLI roundtrip-ije VRDR.CLI\1.xml || exit /b 127
+dotnet run --project VRDR.CLI roundtrip-ije VRDR.CLI\1_wJurisdiction.xml || exit /b 127
+
+@REM Convert JSON files to IJE and back and check every field individually
+dotnet run --project VRDR.CLI roundtrip-all VRDR.Tests\fixtures\json\Bundle-DeathCertificateDocument-Example2.json || exit /b 127
+dotnet run --project VRDR.CLI roundtrip-all VRDR.CLI\1_wJurisdiction.json || exit /b 127
+
+@REM Convert an XML file to IJE and back and check every field individually
+dotnet run --project VRDR.CLI roundtrip-all VRDR.CLI\1_wJurisdiction.xml || exit /b 127
+
+@REM Convert a JSON file to MRE and compare the results
+dotnet run --project VRDR.CLI json2mre VRDR.Tests\fixtures\json\Bundle-DemographicCodedContentBundle-Example1.json > example.mre || exit /b 127
+dotnet run --project VRDR.CLI compareMREtoJSON example.mre VRDR.Tests\fixtures\json\Bundle-DemographicCodedContentBundle-Example1.json || exit /b 127
+del example.mre
+
+@REM Convert a JSON file to TRX and compare the results
+dotnet run --project VRDR.CLI json2trx VRDR.Tests\fixtures\json\Bundle-CauseOfDeathCodedContentBundle-Example1.json > example.trx || exit /b 127
+dotnet run --project VRDR.CLI compareTRXtoJSON example.trx VRDR.Tests\fixtures\json\Bundle-CauseOfDeathCodedContentBundle-Example1.json || exit /b 127
+del example.trx
+
+@REM Convert an STU3 JSON file (with only features found in STU2) to STU2 and Back and Compare the STU2 JSON against the STU2 fixture.
+dotnet run --project VRDR.CLI rdtripstu3-to-stu2 VRDR.Tests\fixtures\json\DeathRecord1_STU3.json || exit /b 127
+dotnet run --project VRDR.CLI json-diff tempSTU2.json VRDR.Tests\fixtures\json\DeathRecord1_STU2.json || exit /b 127


### PR DESCRIPTION
The `run_tests.bat` scripts run all the same commands as the existing `run_tests.sh` scripts. There's no way to specify "exit when a command returns an error code" for an entire file in a batch script, so each command has a suffix that causes it to exit upon failure.

Addresses Jira issue 774.