### PR TITLE
docs(bfdr): add table of contents, move cli information

### DIFF
--- a/projects/BFDR.CLI/README.md
+++ b/projects/BFDR.CLI/README.md
@@ -1,0 +1,143 @@
+# bfdr-cli
+
+This project contains a small .NET (C#) command-line interface program that demonstrates usage of the BFDR project.
+
+## Usage: Birth Examples
+
+```bash
+# Prints CLI Help
+dotnet run --project BFDR.CLI help
+
+# Builds a fake birth record and print out the record as FHIR XML and JSON
+dotnet run --project BFDR.CLI fakerecord birth
+
+# Read in the FHIR XML or JSON birth record and print out as IJE
+dotnet run --project BFDR.CLI 2ije birth BFDR.CLI/1.xml
+
+# Read in the IJE birth record and print out as FHIR XML
+dotnet run --project BFDR.CLI ije2xml birth BFDR.CLI/1.MOR
+
+# Read in the IJE birth record and print out as FHIR JSON
+dotnet run --project BFDR.CLI ije2json birth BFDR.CLI/1.MOR
+
+# Read in the FHIR XML birth record and print out as FHIR JSON
+dotnet run --project BFDR.CLI xml2json birth BFDR.CLI/1.xml
+
+# Read in the FHIR JSON birth record and print out as FHIR XML
+dotnet run --project BFDR.CLI json2xml birth BFDR.CLI/1.json
+
+# Read in the FHIR JSON birth record, completely disassemble then reassemble, and print as FHIR JSON
+dotnet run --project BFDR.CLI json2json birth BFDR.CLI/1.json
+
+# Read in the FHIR XML birth record, completely disassemble then reassemble, and print as FHIR XML
+dotnet run --project BFDR.CLI xml2xml birth BFDR.CLI/1.xml
+
+# Read in the given FHIR xml (being permissive) and print out the same; useful for doing validation diffs
+dotnet run --project BFDR.CLI checkXml birth BFDR.CLI/1.xml
+
+# Read in the given FHIR json (being permissive) and print out the same; useful for doing validation diffs
+dotnet run --project BFDR.CLI checkJson birth BFDR.CLI/1.json
+
+# Read in and parse an IJE birth record and print out the values for every (supported) field
+dotnet run --project BFDR.CLI ije birth BFDR.CLI/1.MOR
+
+# Generate a verbose JSON description of the record (in the format used to drive Canary)
+dotnet run --project BFDR.CLI description birth BFDR.CLI/1.json
+
+# Dump content of a birth record in key/value IJE format
+dotnet run --project BFDR.CLI 2ijecontent birth BFDR.CLI/1.json
+
+# Convert a record to IJE and back to identify any conversion issues
+dotnet run --project BFDR.CLI roundtrip-ije birth BFDR.CLI/1.json
+
+# Convert a record to JSON and back to identify any conversion issues
+dotnet run --project BFDR.CLI roundtrip-all birth BFDR.CLI/1.json
+
+# Create a record using the provided IJE field name and value pairs
+dotnet run --project BFDR.CLI ijebuilder birth GNAME=Lazarus AGE=990
+
+# Compare an IJE record with a FHIR record by each IJE field
+dotnet run --project BFDR.CLI compare birth BFDR.CLI/1.MOR BFDR.CLI/1.json
+
+# Extract a FHIR record from a FHIR message
+dotnet run --project BFDR.CLI extract BFDR.CLI/1submit.json
+
+# Dump content of a submission message in key/value IJE format
+dotnet run --project BFDR.CLI extract2ijecontent birth BFDR.CLI/1submit.json
+
+# Create an acknowledgement FHIR message for a submission FHIR message
+dotnet run --project BFDR.CLI ack birth BFDR.CLI/1submit.json
+
+# Creates a void message for a Birth Record (1 argument: FHIR birth record; one optional argument: number of records to void)
+dotnet run --project BFDR.CLI void birth BFDR.Tests/fixtures/json/BirthRecord1.json
+```
+
+## Usage: Fetal Death Examples
+
+```bash
+# Prints CLI Help
+dotnet run --project BFDR.CLI help
+
+# Builds a fake fetaldeath record and print out the record as FHIR XML and JSON
+dotnet run --project BFDR.CLI fakerecord fetaldeath
+
+# Read in the FHIR XML or JSON fetaldeath record and print out as IJE
+dotnet run --project BFDR.CLI 2ije fetaldeath BFDR.CLI/1.xml
+
+# Read in the IJE fetaldeath record and print out as FHIR XML
+dotnet run --project BFDR.CLI ije2xml fetaldeath BFDR.CLI/1.MOR
+
+# Read in the IJE fetaldeath record and print out as FHIR JSON
+dotnet run --project BFDR.CLI ije2json fetaldeath BFDR.CLI/1.MOR
+
+# Read in the FHIR XML fetaldeath record and print out as FHIR JSON
+dotnet run --project BFDR.CLI xml2json fetaldeath BFDR.CLI/1.xml
+
+# Read in the FHIR JSON fetaldeath record and print out as FHIR XML
+dotnet run --project BFDR.CLI json2xml fetaldeath BFDR.CLI/1.json
+
+# Read in the FHIR JSON fetaldeath record, completely disassemble then reassemble, and print as FHIR JSON
+dotnet run --project BFDR.CLI json2json fetaldeath BFDR.CLI/1.json
+
+# Read in the FHIR XML fetaldeath record, completely disassemble then reassemble, and print as FHIR XML
+dotnet run --project BFDR.CLI xml2xml fetaldeath BFDR.CLI/1.xml
+
+# Read in the given FHIR xml (being permissive) and print out the same; useful for doing validation diffs
+dotnet run --project BFDR.CLI checkXml fetaldeath BFDR.CLI/1.xml
+
+# Read in the given FHIR json (being permissive) and print out the same; useful for doing validation diffs
+dotnet run --project BFDR.CLI checkJson fetaldeath BFDR.CLI/1.json
+
+# Read in and parse an IJE fetaldeath record and print out the values for every (supported) field
+dotnet run --project BFDR.CLI ije fetaldeath BFDR.CLI/1.MOR
+
+# Generate a verbose JSON description of the record (in the format used to drive Canary)
+dotnet run --project BFDR.CLI description fetaldeath BFDR.CLI/1.json
+
+# Dump content of a fetaldeath record in key/value IJE format
+dotnet run --project BFDR.CLI 2ijecontent fetaldeath BFDR.CLI/1.json
+
+# Convert a record to IJE and back to identify any conversion issues
+dotnet run --project BFDR.CLI roundtrip-ije fetaldeath BFDR.CLI/1.json
+
+# Convert a record to JSON and back to identify any conversion issues
+dotnet run --project BFDR.CLI roundtrip-all fetaldeath BFDR.CLI/1.json
+
+# Create a record using the provided IJE field name and value pairs
+dotnet run --project BFDR.CLI ijebuilder fetaldeath GNAME=Lazarus AGE=990
+
+# Compare an IJE record with a FHIR record by each IJE field
+dotnet run --project BFDR.CLI compare fetaldeath BFDR.CLI/1.MOR BFDR.CLI/1.json
+
+# Extract a FHIR record from a FHIR message
+dotnet run --project BFDR.CLI extract BFDR.CLI/1submit.json
+
+# Dump content of a submission message in key/value IJE format
+dotnet run --project BFDR.CLI extract2ijecontent fetaldeath BFDR.CLI/1submit.json
+
+# Create an acknowledgement FHIR message for a submission FHIR message
+dotnet run --project BFDR.CLI ack fetaldeath BFDR.CLI/1submit.json
+
+# Creates a void message for a fetaldeath Record (1 argument: FHIR fetaldeath record; one optional argument: number of records to void)
+dotnet run --project BFDR.CLI void fetaldeath BFDR.Tests/fixtures/json/FetalDeathRecord1.json
+```

--- a/projects/BFDR.CLI/README.md
+++ b/projects/BFDR.CLI/README.md
@@ -2,142 +2,77 @@
 
 This project contains a small .NET (C#) command-line interface program that demonstrates usage of the BFDR project.
 
-## Usage: Birth Examples
+## Usage
+
+These sample commands are run from the `projects` directory. The `[birth|fetaldeath]` argument should be substituted with one of `birth` or `fetaldeath`, indicating which record type should be used for the operation.
 
 ```bash
 # Prints CLI Help
 dotnet run --project BFDR.CLI help
 
-# Builds a fake birth record and print out the record as FHIR XML and JSON
-dotnet run --project BFDR.CLI fakerecord birth
+# Builds a fake birth/fetal death record and print out the record as FHIR XML and JSON
+dotnet run --project BFDR.CLI fakerecord [birth|fetaldeath]
 
-# Read in the FHIR XML or JSON birth record and print out as IJE
-dotnet run --project BFDR.CLI 2ije birth BFDR.CLI/1.xml
+# Read in the FHIR XML or JSON birth/fetal death record and print out as IJE
+dotnet run --project BFDR.CLI 2ije [birth|fetaldeath] BFDR.CLI/1.xml
 
-# Read in the IJE birth record and print out as FHIR XML
-dotnet run --project BFDR.CLI ije2xml birth BFDR.CLI/1.MOR
+# Read in the IJE birth/fetal death record and print out as FHIR XML
+dotnet run --project BFDR.CLI ije2xml [birth|fetaldeath] BFDR.CLI/1.MOR
 
-# Read in the IJE birth record and print out as FHIR JSON
-dotnet run --project BFDR.CLI ije2json birth BFDR.CLI/1.MOR
+# Read in the IJE birth/fetal death record and print out as FHIR JSON
+dotnet run --project BFDR.CLI ije2json [birth|fetaldeath] BFDR.CLI/1.MOR
 
-# Read in the FHIR XML birth record and print out as FHIR JSON
-dotnet run --project BFDR.CLI xml2json birth BFDR.CLI/1.xml
+# Read in the FHIR XML birth/fetal death record and print out as FHIR JSON
+dotnet run --project BFDR.CLI xml2json [birth|fetaldeath] BFDR.CLI/1.xml
 
-# Read in the FHIR JSON birth record and print out as FHIR XML
-dotnet run --project BFDR.CLI json2xml birth BFDR.CLI/1.json
+# Read in the FHIR JSON birth/fetal death record and print out as FHIR XML
+dotnet run --project BFDR.CLI json2xml [birth|fetaldeath] BFDR.CLI/1.json
 
-# Read in the FHIR JSON birth record, completely disassemble then reassemble, and print as FHIR JSON
-dotnet run --project BFDR.CLI json2json birth BFDR.CLI/1.json
+# Read in the FHIR JSON birth/fetal death record, completely disassemble then reassemble, and print as FHIR JSON
+dotnet run --project BFDR.CLI json2json [birth|fetaldeath] BFDR.CLI/1.json
 
-# Read in the FHIR XML birth record, completely disassemble then reassemble, and print as FHIR XML
-dotnet run --project BFDR.CLI xml2xml birth BFDR.CLI/1.xml
+# Read in the FHIR XML birth/fetal death record, completely disassemble then reassemble, and print as FHIR XML
+dotnet run --project BFDR.CLI xml2xml [birth|fetaldeath] BFDR.CLI/1.xml
 
 # Read in the given FHIR xml (being permissive) and print out the same; useful for doing validation diffs
-dotnet run --project BFDR.CLI checkXml birth BFDR.CLI/1.xml
+dotnet run --project BFDR.CLI checkXml [birth|fetaldeath] BFDR.CLI/1.xml
 
 # Read in the given FHIR json (being permissive) and print out the same; useful for doing validation diffs
-dotnet run --project BFDR.CLI checkJson birth BFDR.CLI/1.json
+dotnet run --project BFDR.CLI checkJson [birth|fetaldeath] BFDR.CLI/1.json
 
-# Read in and parse an IJE birth record and print out the values for every (supported) field
-dotnet run --project BFDR.CLI ije birth BFDR.CLI/1.MOR
+# Read in and parse an IJE birth/fetal death record and print out the values for every (supported) field
+dotnet run --project BFDR.CLI ije [birth|fetaldeath] BFDR.CLI/1.MOR
 
 # Generate a verbose JSON description of the record (in the format used to drive Canary)
-dotnet run --project BFDR.CLI description birth BFDR.CLI/1.json
+dotnet run --project BFDR.CLI description [birth|fetaldeath] BFDR.CLI/1.json
 
-# Dump content of a birth record in key/value IJE format
-dotnet run --project BFDR.CLI 2ijecontent birth BFDR.CLI/1.json
+# Dump content of a birth/fetal death record in key/value IJE format
+dotnet run --project BFDR.CLI 2ijecontent [birth|fetaldeath] BFDR.CLI/1.json
 
 # Convert a record to IJE and back to identify any conversion issues
-dotnet run --project BFDR.CLI roundtrip-ije birth BFDR.CLI/1.json
+dotnet run --project BFDR.CLI roundtrip-ije [birth|fetaldeath] BFDR.CLI/1.json
 
 # Convert a record to JSON and back to identify any conversion issues
-dotnet run --project BFDR.CLI roundtrip-all birth BFDR.CLI/1.json
+dotnet run --project BFDR.CLI roundtrip-all [birth|fetaldeath] BFDR.CLI/1.json
 
 # Create a record using the provided IJE field name and value pairs
-dotnet run --project BFDR.CLI ijebuilder birth GNAME=Lazarus AGE=990
+dotnet run --project BFDR.CLI ijebuilder [birth|fetaldeath] GNAME=Lazarus AGE=990
 
 # Compare an IJE record with a FHIR record by each IJE field
-dotnet run --project BFDR.CLI compare birth BFDR.CLI/1.MOR BFDR.CLI/1.json
+dotnet run --project BFDR.CLI compare [birth|fetaldeath] BFDR.CLI/1.MOR BFDR.CLI/1.json
 
 # Extract a FHIR record from a FHIR message
 dotnet run --project BFDR.CLI extract BFDR.CLI/1submit.json
 
 # Dump content of a submission message in key/value IJE format
-dotnet run --project BFDR.CLI extract2ijecontent birth BFDR.CLI/1submit.json
+dotnet run --project BFDR.CLI extract2ijecontent [birth|fetaldeath] BFDR.CLI/1submit.json
 
 # Create an acknowledgement FHIR message for a submission FHIR message
-dotnet run --project BFDR.CLI ack birth BFDR.CLI/1submit.json
+dotnet run --project BFDR.CLI ack [birth|fetaldeath] BFDR.CLI/1submit.json
 
-# Creates a void message for a Birth Record (1 argument: FHIR birth record; one optional argument: number of records to void)
+# Creates a void message for a birth Record (1 argument: FHIR birth record; one optional argument: number of records to void)
 dotnet run --project BFDR.CLI void birth BFDR.Tests/fixtures/json/BirthRecord1.json
-```
 
-## Usage: Fetal Death Examples
-
-```bash
-# Prints CLI Help
-dotnet run --project BFDR.CLI help
-
-# Builds a fake fetaldeath record and print out the record as FHIR XML and JSON
-dotnet run --project BFDR.CLI fakerecord fetaldeath
-
-# Read in the FHIR XML or JSON fetaldeath record and print out as IJE
-dotnet run --project BFDR.CLI 2ije fetaldeath BFDR.CLI/1.xml
-
-# Read in the IJE fetaldeath record and print out as FHIR XML
-dotnet run --project BFDR.CLI ije2xml fetaldeath BFDR.CLI/1.MOR
-
-# Read in the IJE fetaldeath record and print out as FHIR JSON
-dotnet run --project BFDR.CLI ije2json fetaldeath BFDR.CLI/1.MOR
-
-# Read in the FHIR XML fetaldeath record and print out as FHIR JSON
-dotnet run --project BFDR.CLI xml2json fetaldeath BFDR.CLI/1.xml
-
-# Read in the FHIR JSON fetaldeath record and print out as FHIR XML
-dotnet run --project BFDR.CLI json2xml fetaldeath BFDR.CLI/1.json
-
-# Read in the FHIR JSON fetaldeath record, completely disassemble then reassemble, and print as FHIR JSON
-dotnet run --project BFDR.CLI json2json fetaldeath BFDR.CLI/1.json
-
-# Read in the FHIR XML fetaldeath record, completely disassemble then reassemble, and print as FHIR XML
-dotnet run --project BFDR.CLI xml2xml fetaldeath BFDR.CLI/1.xml
-
-# Read in the given FHIR xml (being permissive) and print out the same; useful for doing validation diffs
-dotnet run --project BFDR.CLI checkXml fetaldeath BFDR.CLI/1.xml
-
-# Read in the given FHIR json (being permissive) and print out the same; useful for doing validation diffs
-dotnet run --project BFDR.CLI checkJson fetaldeath BFDR.CLI/1.json
-
-# Read in and parse an IJE fetaldeath record and print out the values for every (supported) field
-dotnet run --project BFDR.CLI ije fetaldeath BFDR.CLI/1.MOR
-
-# Generate a verbose JSON description of the record (in the format used to drive Canary)
-dotnet run --project BFDR.CLI description fetaldeath BFDR.CLI/1.json
-
-# Dump content of a fetaldeath record in key/value IJE format
-dotnet run --project BFDR.CLI 2ijecontent fetaldeath BFDR.CLI/1.json
-
-# Convert a record to IJE and back to identify any conversion issues
-dotnet run --project BFDR.CLI roundtrip-ije fetaldeath BFDR.CLI/1.json
-
-# Convert a record to JSON and back to identify any conversion issues
-dotnet run --project BFDR.CLI roundtrip-all fetaldeath BFDR.CLI/1.json
-
-# Create a record using the provided IJE field name and value pairs
-dotnet run --project BFDR.CLI ijebuilder fetaldeath GNAME=Lazarus AGE=990
-
-# Compare an IJE record with a FHIR record by each IJE field
-dotnet run --project BFDR.CLI compare fetaldeath BFDR.CLI/1.MOR BFDR.CLI/1.json
-
-# Extract a FHIR record from a FHIR message
-dotnet run --project BFDR.CLI extract BFDR.CLI/1submit.json
-
-# Dump content of a submission message in key/value IJE format
-dotnet run --project BFDR.CLI extract2ijecontent fetaldeath BFDR.CLI/1submit.json
-
-# Create an acknowledgement FHIR message for a submission FHIR message
-dotnet run --project BFDR.CLI ack fetaldeath BFDR.CLI/1submit.json
-
-# Creates a void message for a fetaldeath Record (1 argument: FHIR fetaldeath record; one optional argument: number of records to void)
+# Creates a void message for a fetal death Record (1 argument: FHIR fetal death record; one optional argument: number of records to void)
 dotnet run --project BFDR.CLI void fetaldeath BFDR.Tests/fixtures/json/FetalDeathRecord1.json
 ```

--- a/projects/BFDR/README.md
+++ b/projects/BFDR/README.md
@@ -6,9 +6,24 @@ This repository includes .NET (C#) code for
 - Producing and consuming FHIR messages for the exchange of BFDR documents.
 - Support for converting BFDR FHIR records to and from the Inter-Jurisdictional Exchange (IJE) Natality format, as well as companion microservice for performing conversions.
 
-## Documentation
+## Table of Contents
+
+- [Versions](#versions)
+- [Requirements](#requirements)
+  - [Development & CLI Requirements](#development--cli-requirements)
+  - [Library Usage](#library-usage)
+- [Project Organization](#project-organization)
+  - [BFDR](#bfdr)
+  - [BFDR.Messaging](#bfdrmessaging)
+  - [BFDR.Tests](#bfdrtests)
+  - [BFDR.CLI](#bfdrcli)
+- [Additional Notes For Library Developers](#additional-notes-for-library-developers)
+- [Contributing](#contributing)
+- [License](#license)
+- [Contact Information](#contact-information)
 
 ## Versions
+
 Interactions with NCHS are governed by the CI build version of the BFDR and Birth and Fetal Birth Records Messaging IGs, and should use the latest, supported releases of the BFDR .NET software and Canary.
 
 <table class="versionTable" border="3">
@@ -31,16 +46,18 @@ Interactions with NCHS are governed by the CI build version of the BFDR and Birt
 <td style="text-align: center;"><a href="">nuget</a> <a href=""> github</a></td>
 </tr>
 
-
 </tbody>
 </table>
 
 ## Requirements
 
 ### Development & CLI Requirements
-- This repository is built using .NET Core 6.0, download [here](https://dotnet.microsoft.com/download)
+
+- This repository is built using .NET Core 6.0, which you can download [here](https://dotnet.microsoft.com/download).
+
 ### Library Usage
-- The BFDR and BFDR.Messaging libraries target .NET Standard 2.0
+
+- The BFDR and BFDR.Messaging libraries target .NET Standard 2.0.
 - To check whether your .NET version supports a release, refer to [the .NET matrix](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support).
   - Note whether you are using .NET Core or .NET Framework - see [here](https://docs.microsoft.com/en-us/archive/msdn-magazine/2017/september/net-standard-demystifying-net-core-and-net-standard) for distinctions between the .NET implementation options.
   - Once you’ve determined your .NET implementation type and version, for example you are using .NET Framework 4.6.1, refer to the matrix to verify whether your .NET implementation supports the targeted .NET Standard version.
@@ -49,11 +66,13 @@ Interactions with NCHS are governed by the CI build version of the BFDR and Birt
 ## Project Organization
 
 ### BFDR
+
 This directory contains a FHIR Birth and Fetal Birth Record library for consuming and producing BFDR FHIR. This library also includes support for converting to and from the Inter-Jurisdictional Exchange (IJE) Natality format.
 
-#### Usage
+#### Including This Package
 
 This package will be published on NuGet, so including it is as easy as:
+
 ```xml
 <ItemGroup>
   ...
@@ -63,6 +82,7 @@ This package will be published on NuGet, so including it is as easy as:
 ```
 
 You can also include a locally downloaded copy of the library instead of the NuGet version by referencing `BFDR.csproj` in your project configuration, for example (taken from BFDR.CLI):
+
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
   ...
@@ -73,8 +93,10 @@ You can also include a locally downloaded copy of the library instead of the NuG
 </Project>
 ```
 
-#### Producing Example
-The following snippet is a quick example of producing a from-scratch FHIR BFDR record using this library, and then printing it out as a JSON string. 
+#### Usage: Producing Example
+
+The following snippet is a quick example of producing a from-scratch FHIR BFDR record using this library, and then printing it out as a JSON string.
+
 ```cs
 using BFDR;
 
@@ -98,8 +120,10 @@ birthRecord.StateLocalIdentifier1 = "123";
 Console.WriteLine(birthRecord.ToJSON());
 ```
 
-#### Consuming Example
+#### Usage: Consuming Example
+
 An example of consuming a BFDR FHIR document (in XML format) using this library, and printing some details from it:
+
 ```cs
 using BFDR;
 
@@ -113,46 +137,10 @@ BirthRecord birthRecord = new BirthRecord(xml);
 Console.WriteLine($"Child's Last Name: {birthRecord.ChildFamilyName}");
 ```
 
-#### Specifying that a date or time is explicitly unknown
-
-When specifying a date or time it is important to be able to differentiate between "we explicitly
-don't know the date, and we're telling you that we don't know it" and just not setting a date
-property at all. For this reason the date and time properties on the BirthRecord class support the
-special value of -1 (for properties that expect an integer) or "-1" (for properties that expect a
-string) in order to specify that the data is explicitly unknown. This is equivalent to using a value
-of "9999" in IJE.
-
-Example:
-
-```
-BirthRecord birthRecord = new BirthRecord();
-birthRecord.BirthYear = 2022;
-birthRecord.BirthMonth = 2;
-birthRecord.BirthDay = -1;
-birthRecord.BirthTime = "-1";
-```
-
-#### Names in FHIR
-
-FHIR manages names in a way that there is a fundamental incompatibility with IJE: in FHIR the
-"middle name" is stored as the second element in an array of given names. That means that it's not
-possible to set a middle name without first setting a first name. The library handles this by
-
-1. Requiring the entire given name (first name and any middle names) to be set all at once when
-using the BirthRecord class
-1. Raising an exception if a middle name is set before a first name when using the IJEBirth
-class
-1. Resetting the middle name if the first name is set again when using the IJEBirth class;
-setting the first name and then the middle name ensures no issues will occur.
-
-For the child's last name, if the family name, denoted as ChildFamilyName in FHIR, is missing or unknown,
-its corresponding KIDLNAME in IJE has value of "UNKNOWN". Vice versa, if its KIDLNAME in IJE is "UNKNOWN",
-its corresponding ChildFamilyName in FHIR has value of NULL. All other values have 1-to-1 mappings between
-FHIR's ChildFamilyName and IJE's KIDLNAME.
-
-#### FHIR BFDR record to/from IJE Natality format
+#### Usage: FHIR BFDR record to/from IJE Natality format
 
 An example of converting a BFDR FHIR Birth Record to an IJE string:
+
 ```cs
 using BFDR;
 
@@ -171,6 +159,7 @@ Console.WriteLine(ijeString);
 ```
 
 An example of converting an IJE string to a BFDR FHIR Birth Record:
+
 ```cs
 using BFDR;
 
@@ -184,13 +173,51 @@ BirthRecord birthRecord = ije.ToRecord();
 Console.WriteLine(birthRecord.ToJSON());
 ```
 
+#### Specifying that a date or time is explicitly unknown
+
+When specifying a date or time, it is important to be able to differentiate between "we explicitly
+don't know the date, and we're telling you that we don't know it" and just not setting a date
+property at all. For this reason, the date and time properties on the BirthRecord class support the
+special value of -1 (for properties that expect an integer) or "-1" (for properties that expect a
+string) in order to specify that the data is explicitly unknown. This is equivalent to using a value
+of "9999" in IJE.
+
+Example:
+
+```cs
+BirthRecord birthRecord = new BirthRecord();
+birthRecord.BirthYear = 2022;
+birthRecord.BirthMonth = 2;
+birthRecord.BirthDay = -1;
+birthRecord.BirthTime = "-1";
+```
+
+#### Names in FHIR
+
+FHIR manages names in a way that there is a fundamental incompatibility with IJE: in FHIR the
+"middle name" is stored as the second element in an array of given names. That means that it's not
+possible to set a middle name without first setting a first name. The library handles this by
+
+1. Requiring the entire given name (first name and any middle names) to be set all at once when
+   using the BirthRecord class
+1. Raising an exception if a middle name is set before a first name when using the IJEBirth
+   class
+1. Resetting the middle name if the first name is set again when using the IJEBirth class;
+   setting the first name and then the middle name ensures no issues will occur.
+
+For the child's last name, if the family name, denoted as ChildFamilyName in FHIR, is missing or unknown,
+its corresponding KIDLNAME in IJE has value of "UNKNOWN". Vice versa, if its KIDLNAME in IJE is "UNKNOWN",
+its corresponding ChildFamilyName in FHIR has value of NULL. All other values have 1-to-1 mappings between
+FHIR's ChildFamilyName and IJE's KIDLNAME.
+
 ### BFDR.Messaging
 
 This directory contains classes to create and parse FHIR messages used for Birth and Fetal Birth Reporting.
 
-#### Usage
+#### Including This Package
 
 This package is published on NuGet, so including it is as easy as:
+
 ```xml
 <ItemGroup>
   ...
@@ -219,7 +246,7 @@ You can also include a locally downloaded copy of the library instead of the NuG
 
 This directory contains unit and functional tests for the BFDR library as well as scripts for testing via the CLI and translation microservice.
 
-#### Usage
+#### Usage: Running The Tests
 
 The tests are automatically run by the repository GitHub workflows config, but can be run locally by executing the following command in the root project directory:
 
@@ -234,181 +261,44 @@ dotnet test
 ```
 
 ### BFDR.CLI
-This directory contains a sample command line interface app that uses the BFDR library to do a few different things.
 
-#### Birth CLI Examples 
+This directory contains a sample command line interface app that uses the BFDR library to do a few different things. For more details, consult the [BFDR.CLI README file](../BFDR.CLI/README.md).
 
-```bash
-# Prints CLI Help
-dotnet run --project BFDR.CLI help
+## Additional Notes For Library Developers
 
-# Builds a fake birth record and print out the record as FHIR XML and JSON
-dotnet run --project BFDR.CLI fakerecord birth
+Attributes (equivalent to Annotations in Java) are used in .NET to promote loose coupling via “declarative” programming, and add Metadata to the target program entity, namely .NET assembly, module, for global scope, and class, interface, struct, enum, constructor, delegate, field, property, method, parameter, return value, and event, for non-global scope. They can be either built-in or custom, and denoted by a pair (or pairs, for mutltiple attributes) of square brackets [...] preceding the target entity. As shown in [BFDR/NatalityRecord_submissionProperties.cs](../master/BFDR/NatalityRecord_submissionProperties.cs), the custom attributes [Property(...)] and [FHIRPath(...)] for each of the BirthRecord's properties, and [PropertyParam(...)] for many of its properties, add relevant sets of Metadata to their targets, based on their definitions and orders of formal parameters given in [BFDR/BirthRecord.cs](../master/BFDR/BirthRecord.cs). Consider the custom attribute [Property(...)] in this example:
 
-# Read in the FHIR XML or JSON birth record and print out as IJE
-dotnet run --project BFDR.CLI 2ije birth BFDR.CLI/1.xml
-
-# Read in the IJE birth record and print out as FHIR XML
-dotnet run --project BFDR.CLI ije2xml birth BFDR.CLI/1.MOR
-
-# Read in the IJE birth record and print out as FHIR JSON
-dotnet run --project BFDR.CLI ije2json birth BFDR.CLI/1.MOR
-
-# Read in the FHIR XML birth record and print out as FHIR JSON
-dotnet run --project BFDR.CLI xml2json birth BFDR.CLI/1.xml
-
-# Read in the FHIR JSON birth record and print out as FHIR XML
-dotnet run --project BFDR.CLI json2xml birth BFDR.CLI/1.json
-
-# Read in the FHIR JSON birth record, completely disassemble then reassemble, and print as FHIR JSON
-dotnet run --project BFDR.CLI json2json birth BFDR.CLI/1.json
-
-# Read in the FHIR XML birth record, completely disassemble then reassemble, and print as FHIR XML
-dotnet run --project BFDR.CLI xml2xml birth BFDR.CLI/1.xml
-
-# Read in the given FHIR xml (being permissive) and print out the same; useful for doing validation diffs
-dotnet run --project BFDR.CLI checkXml birth BFDR.CLI/1.xml
-
-# Read in the given FHIR json (being permissive) and print out the same; useful for doing validation diffs
-dotnet run --project BFDR.CLI checkJson birth BFDR.CLI/1.json
-
-# Read in and parse an IJE birth record and print out the values for every (supported) field
-dotnet run --project BFDR.CLI ije birth BFDR.CLI/1.MOR
-
-# Generate a verbose JSON description of the record (in the format used to drive Canary)
-dotnet run --project BFDR.CLI description birth BFDR.CLI/1.json
-
-# Dump content of a birth record in key/value IJE format
-dotnet run --project BFDR.CLI 2ijecontent birth BFDR.CLI/1.json
-
-# Convert a record to IJE and back to identify any conversion issues
-dotnet run --project BFDR.CLI roundtrip-ije birth BFDR.CLI/1.json
-
-# Convert a record to JSON and back to identify any conversion issues
-dotnet run --project BFDR.CLI roundtrip-all birth BFDR.CLI/1.json
-
-# Create a record using the provided IJE field name and value pairs
-dotnet run --project BFDR.CLI ijebuilder birth GNAME=Lazarus AGE=990
-
-# Compare an IJE record with a FHIR record by each IJE field
-dotnet run --project BFDR.CLI compare birth BFDR.CLI/1.MOR BFDR.CLI/1.json
-
-# Extract a FHIR record from a FHIR message
-dotnet run --project BFDR.CLI extract BFDR.CLI/1submit.json
-
-# Dump content of a submission message in key/value IJE format
-dotnet run --project BFDR.CLI extract2ijecontent birth BFDR.CLI/1submit.json
-
-# Create an acknowledgement FHIR message for a submission FHIR message
-dotnet run --project BFDR.CLI ack birth BFDR.CLI/1submit.json
-
-# Creates a void message for a Birth Record (1 argument: FHIR birth record; one optional argument: number of records to void)
-dotnet run --project BFDR.CLI void birth BFDR.Tests/fixtures/json/BirthRecord1.json
-```
-
-#### FetalDeath CLI Examples 
-
-```bash
-# Prints CLI Help
-dotnet run --project BFDR.CLI help
-
-# Builds a fake fetaldeath record and print out the record as FHIR XML and JSON
-dotnet run --project BFDR.CLI fakerecord fetaldeath
-
-# Read in the FHIR XML or JSON fetaldeath record and print out as IJE
-dotnet run --project BFDR.CLI 2ije fetaldeath BFDR.CLI/1.xml
-
-# Read in the IJE fetaldeath record and print out as FHIR XML
-dotnet run --project BFDR.CLI ije2xml fetaldeath BFDR.CLI/1.MOR
-
-# Read in the IJE fetaldeath record and print out as FHIR JSON
-dotnet run --project BFDR.CLI ije2json fetaldeath BFDR.CLI/1.MOR
-
-# Read in the FHIR XML fetaldeath record and print out as FHIR JSON
-dotnet run --project BFDR.CLI xml2json fetaldeath BFDR.CLI/1.xml
-
-# Read in the FHIR JSON fetaldeath record and print out as FHIR XML
-dotnet run --project BFDR.CLI json2xml fetaldeath BFDR.CLI/1.json
-
-# Read in the FHIR JSON fetaldeath record, completely disassemble then reassemble, and print as FHIR JSON
-dotnet run --project BFDR.CLI json2json fetaldeath BFDR.CLI/1.json
-
-# Read in the FHIR XML fetaldeath record, completely disassemble then reassemble, and print as FHIR XML
-dotnet run --project BFDR.CLI xml2xml fetaldeath BFDR.CLI/1.xml
-
-# Read in the given FHIR xml (being permissive) and print out the same; useful for doing validation diffs
-dotnet run --project BFDR.CLI checkXml fetaldeath BFDR.CLI/1.xml
-
-# Read in the given FHIR json (being permissive) and print out the same; useful for doing validation diffs
-dotnet run --project BFDR.CLI checkJson fetaldeath BFDR.CLI/1.json
-
-# Read in and parse an IJE fetaldeath record and print out the values for every (supported) field
-dotnet run --project BFDR.CLI ije fetaldeath BFDR.CLI/1.MOR
-
-# Generate a verbose JSON description of the record (in the format used to drive Canary)
-dotnet run --project BFDR.CLI description fetaldeath BFDR.CLI/1.json
-
-# Dump content of a fetaldeath record in key/value IJE format
-dotnet run --project BFDR.CLI 2ijecontent fetaldeath BFDR.CLI/1.json
-
-# Convert a record to IJE and back to identify any conversion issues
-dotnet run --project BFDR.CLI roundtrip-ije fetaldeath BFDR.CLI/1.json
-
-# Convert a record to JSON and back to identify any conversion issues
-dotnet run --project BFDR.CLI roundtrip-all fetaldeath BFDR.CLI/1.json
-
-# Create a record using the provided IJE field name and value pairs
-dotnet run --project BFDR.CLI ijebuilder fetaldeath GNAME=Lazarus AGE=990
-
-# Compare an IJE record with a FHIR record by each IJE field
-dotnet run --project BFDR.CLI compare fetaldeath BFDR.CLI/1.MOR BFDR.CLI/1.json
-
-# Extract a FHIR record from a FHIR message
-dotnet run --project BFDR.CLI extract BFDR.CLI/1submit.json
-
-# Dump content of a submission message in key/value IJE format
-dotnet run --project BFDR.CLI extract2ijecontent fetaldeath BFDR.CLI/1submit.json
-
-# Create an acknowledgement FHIR message for a submission FHIR message
-dotnet run --project BFDR.CLI ack fetaldeath BFDR.CLI/1submit.json
-
-# Creates a void message for a fetaldeath Record (1 argument: FHIR fetaldeath record; one optional argument: number of records to void)
-dotnet run --project BFDR.CLI void fetaldeath BFDR.Tests/fixtures/json/FetalDeathRecord1.json
-```
-
-#### For Library Developers
-
-Attributes (equivalent to Annotations in Java) are used in .NET to promote loose coupling via  “declarative” programming, and add Metadata to the target program entity, namely .NET assembly, module, for global scope, and class, interface, struct, enum, constructor, delegate, field, property, method, parameter, return value, and event, for non-global scope. They can be either built-in or custom, and denoted by pair or pair(s), for mutltiple attributes, of square brackets [...] surrounding the target entity. As shown in [BFDR/NatalityRecord_submissionProperties.cs](../master/BFDR/NatalityRecord_submissionProperties.cs), the custom attributes [Property(...)] and [FHIRPath(...)] for each of the BirthRecord's properties, and [PropertyParam(...)] for many of its properties, add relevant sets of Metadata to their targets, based on their definitions and orders of formal parameters given in [BFDR/BirthRecord.cs](../master/BFDR/BirthRecord.cs), where custom attribute [Property(...)], as in
-```
-        [Property("Birth Record Identifier", Property.Types.String, "Birth Certification", "Birth Record identifier.", true, IGURL.BirthCertificate, true, 4)]
-        [FHIRPath("Bundle", "identifier")]
-        public string BirthRecordIdentifier
+```cs
+[Property("Birth Record Identifier", Property.Types.String, "Birth Certification", "Birth Record identifier.", true, IGURL.BirthCertificate, true, 4)]
+[FHIRPath("Bundle", "identifier")]
+public string BirthRecordIdentifier
+{
+    get
+    {
+        if (Bundle != null && Bundle.Identifier != null)
         {
-            get
-            {
-                if (Bundle != null && Bundle.Identifier != null)
-                {
-                    return Bundle.Identifier.Value;
-                }
-                return null;
-            }
-            // The setter is private because the value is derived so should never be set directly
-            private set
-            {
-                if (String.IsNullOrWhiteSpace(value))
-                {
-                    return;
-                }
-                if (Bundle.Identifier == null)
-                {
-                    Bundle.Identifier = new Identifier();
-                }
-                Bundle.Identifier.Value = value;
-                Bundle.Identifier.System = "http://nchs.cdc.gov/bfdr_id";
-            }
+            return Bundle.Identifier.Value;
         }
+        return null;
+    }
+    // The setter is private because the value is derived so should never be set directly
+    private set
+    {
+        if (String.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+        if (Bundle.Identifier == null)
+        {
+            Bundle.Identifier = new Identifier();
+        }
+        Bundle.Identifier.Value = value;
+        Bundle.Identifier.System = "http://nchs.cdc.gov/bfdr_id";
+    }
+}
 ```
-for example, can be seen mapped to the following custom attribute class with the same name:
+
+Here, [Property(...)] is mapped to the following custom attribute class with the same name:
 
 `public class Property : System.Attribute`
 
@@ -416,16 +306,18 @@ and with the following constructor:
 
 `public Property(string name, Types type, string category, string description, bool serialize, string igurl, bool capturedInIJE, int priority = 4)`
 
-Similarly, custom attribute [FHIRPath( ... )] is mapped to custom attribute class FHIRPath with public constructor `FHIRPath(string path, string element)`
+Similarly,
 
-and custom attribute [PropertyParam( ... )] is mapped to custom attribute class PropertyParam with public constructor `PropertyParam(string key, string description)`
+- custom attribute [FHIRPath(...)] is mapped to custom attribute class `FHIRPath` with public constructor `FHIRPath(string path, string element)`
+- custom attribute [PropertyParam(...)] is mapped to custom attribute class `PropertyParam` with public constructor `PropertyParam(string key, string description)`
 
 Custom attribute classes are typically derived, either directly or indirectly, from built-in abstract class System.Attribute, just as illustrated here.
 
-The property values of these Metadata/attributes for BirthRecord are set and retrieved via setters and getters, respectively, based on individual sets of rules also as shown in [BFDR/NatalityRecord_submissionProperties.cs](../master/BFDR/NatalityRecord_submissionProperties.cs)
+The property values of these attributes for BirthRecord are set and retrieved via setters and getters, respectively, based on individual sets of rules also as shown in [BFDR/NatalityRecord_submissionProperties.cs](../master/BFDR/NatalityRecord_submissionProperties.cs)
 
-Snippet from [BFDR.CLI/Program.cs](../master/projects/BFDR.CLI/Program.cs#L479-L489) gives an example of how these custom attributes can be used:
-```
+A snippet from [BFDR.CLI/Program.cs](../master/projects/BFDR.CLI/Program.cs#L479-L489) gives an example of how these custom attributes can be used:
+
+```cs
 BirthRecord d = new BirthRecord(File.ReadAllText(args[1]));
 IJEBirth ije1 = new IJEBirth(d, false);
 // Loop over every property (these are the fields); Order by priority
@@ -436,23 +328,26 @@ foreach (PropertyInfo property in properties)
     IJEField info = property.GetCustomAttribute<IJEField>();
     // Grab the field value
     string field = Convert.ToString(property.GetValue(ije1, null));
-}   
+}
 ```
+
 Custom attributes are also used extensively in IJEField's properties, one of which is shown below as an example.
+
+```cs
+[IJEField(1, 1, 4, "Date of Birth--Year", "DOB_YR", 1)]
+public string DOB_YR
+{
+    get
+    {
+        return NumericAllowingUnknown_Get("DOB_YR", "BirthYear");
+    }
+    set
+    {
+        NumericAllowingUnknown_Set("DOB_YR", "BirthYear", value);
+    }
+}
 ```
-        [IJEField(1, 1, 4, "Date of Birth--Year", "DOB_YR", 1)]
-        public string DOB_YR
-        {
-            get
-            {
-                return NumericAllowingUnknown_Get("DOB_YR", "BirthYear");
-            }
-            set
-            {
-                NumericAllowingUnknown_Set("DOB_YR", "BirthYear", value);
-            }
-        }
-```
+
 which is mapped to the following custom attribute class with the same name:
 
 `public class IJEField : System.Attribute`
@@ -461,7 +356,6 @@ and with the following constructor:
 
 `public IJEField(int field, int location, int length, string contents, string name, int priority)` in the same file [BFDR/IJEBirth.cs](../master/BFDR/IJEBirth.cs)
 
-
 Official resources:<br/>
 https://learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/reflection-and-attributes/attribute-tutorial<br/>
 https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/attributes<br/>
@@ -469,7 +363,8 @@ https://learn.microsoft.com/en-us/dotnet/csharp/advanced-topics/reflection-and-a
 https://learn.microsoft.com/en-us/dotnet/standard/attributes/writing-custom-attributes<br/><br/>
 
 ## Contributing
-This repository follows [Semantic Versioning](https://semver.org/). Bug fixes and feature enhancements should be merged into the `master` branch via Pull Requests (PR), instead of directly committing to the `master` branch. Once a PR is merged, a new version of the library will be automatically published to NuGet.
+
+This repository follows [Semantic Versioning](https://semver.org/). Bug fixes and feature enhancements should be merged into the `master` branch via pull requests (PR), instead of directly committing to the `master` branch. Once a PR is merged, a new version of the library will be automatically published to NuGet.
 
 ```
 git pull origin master
@@ -478,15 +373,18 @@ git checkout -b <your-working-branch-name>
 <test-with-changes-from-master>
 git push -u origin <your-working-branch-name>
 ```
+
 Once the working branch is pushed to the respository, follow these steps:
 
 1. Create a new PR with the working branch as base, and master as head.
-1. The PR title and description should follow the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format. The PR title should be structured as  `<type>[optional scope]: <short-message>`, where a type can be:
-  - **feat:** introduces a new feature to the codebase (correlates with MINOR in Semantic Versioning).
-  - **fix:** patches a bug in the codebase (correlates with PATCH in Semantic Versioning).
-  - Other types such as `build`, `chore`, `ci`, `docs`, `style`, `refactor`, `perf`, `test`, and others are allowed as well (correlates with PATCH in Semantic Versioning).
-  
-  (The PR title needs to be concise and conform to the style guide for change tracking purposes. The PR description can include additional details about the changes associated with this PR.)
+1. The PR title and description should follow the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format. The PR title should be structured as `<type>[optional scope]: <short-message>`, where a type can be:
+
+- **feat:** introduces a new feature to the codebase (correlates with MINOR in Semantic Versioning).
+- **fix:** patches a bug in the codebase (correlates with PATCH in Semantic Versioning).
+- Other types such as `build`, `chore`, `ci`, `docs`, `style`, `refactor`, `perf`, `test`, and others are allowed as well (correlates with PATCH in Semantic Versioning).
+
+The PR title needs to be concise and conform to the style guide for change tracking purposes. The PR description can include additional details about the changes associated with this PR.
+
 1. Assign one or more reviewers to review your changes. At least one approved review is required before the PR can be merged.
 1. If the PR addresses an existing Issue, link the PR with the Issue to resolve it through the PR.
 1. Once the PR is approved by a reviewer, with all discussions resolved and all checks passed, click the Squash and Merge button. Avoid using "Create a merge commit." The PR title and description will automatically fill in the commit message boxes.
@@ -494,7 +392,6 @@ Once the working branch is pushed to the respository, follow these steps:
 #### Release Pull Request
 
 With each commit to the default branch, a release pull request will be automatically created/updated. This PR increments the package version and updates the CHANGELOG using a special branch named `actions/release`. You don't need to wait for this special PR to be merged into the default branch before merging additional pull requests. It consolidates subsequent commits to the default branch; only one instance of release pull request will be active.
-
 
 #### Publishing a Version
 
@@ -506,11 +403,11 @@ To create a new release of BFDR on NuGet:
 1. Update the CHANGELOG.md file with information on what is changing in the release
 1. Merge the above changes to master, causing the GitHub publishing workflow to fire
 1. Create a GitHub release
-    1. Go to the [Releases page](https://github.com/nightingaleproject/bfdr-dotnet/releases)
-    1. Click on "Draft a new release"
-    1. Enter the release version on the tag and release; this should be the same as in the Directory.Build.props file (e.g., v3.2.0-preview3)
-    1. Copy the information from the CHANGELOG.md file from this version into the release description
-    1. Do not check the "pre-release" button, even for preview releases, since those don't show up on the main GitHub page
+   1. Go to the [Releases page](https://github.com/nightingaleproject/bfdr-dotnet/releases)
+   1. Click on "Draft a new release"
+   1. Enter the release version on the tag and release; this should be the same as in the Directory.Build.props file (e.g., v3.2.0-preview3)
+   1. Copy the information from the CHANGELOG.md file from this version into the release description
+   1. Do not check the "pre-release" button, even for preview releases, since those don't show up on the main GitHub page
 
 ## License
 


### PR DESCRIPTION
Details about using BFDR.CLI are moved to a new README file in the BFDR.CLI directory.
Update some section headers to avoid repeating headers. Assorted minor text revisions.
The Return Coding Example is left blank in this change, as it is being added in a different branch.

Addresses Jira issue 779.