### PR TITLE
fix(bfdr): fix issues with HFT and HIN mother height fields in IJE

### DIFF
--- a/projects/BFDR.Tests/IJEFetalDeath_Should.cs
+++ b/projects/BFDR.Tests/IJEFetalDeath_Should.cs
@@ -668,7 +668,41 @@ namespace BFDR.Tests
       Assert.Equal("89089090", record2.AttendantNPI);
       Assert.Equal("Test", record2.AttendantTitle["text"]);
       Assert.Equal("Test", record2.AttendantOtherHelper);
-
     }
-}
+
+    [Fact]
+    public void TestMotherHeightPropertiesSetter()
+    {
+      FetalDeathRecord record = new FetalDeathRecord();
+      IJEFetalDeath ije1 = new IJEFetalDeath(record);
+      // Height
+      Assert.Equal("99", ije1.HIN);
+      Assert.Equal("9", ije1.HFT);
+      ije1.HFT = "5";
+      Assert.Equal("5", ije1.HFT);
+      Assert.Equal("00", ije1.HIN);
+      ije1.HIN = "1";
+      Assert.Equal("5", ije1.HFT);
+      Assert.Equal("01", ije1.HIN);
+      ije1.HFT = "6";
+      Assert.Equal("6", ije1.HFT);
+      Assert.Equal("01", ije1.HIN);
+      ije1.HIN = "2";
+      Assert.Equal("6", ije1.HFT);
+      Assert.Equal("02", ije1.HIN);
+      ije1.HIN = "99";
+      Assert.Equal("99", ije1.HIN);
+      Assert.Equal("9", ije1.HFT);
+      // Edit Flag
+      Assert.Equal("", ije1.HGT_BYPASS);
+      ije1.HGT_BYPASS = "1";
+      Assert.Equal("1", ije1.HGT_BYPASS);
+      // FHIR translations
+      ije1.HFT = "5";
+      ije1.HIN = "3";
+      FetalDeathRecord record1 = new FetalDeathRecord(ije1.ToRecord().ToXML());
+      Assert.Equal(63, record1.MotherHeight);
+      Assert.Equal(VR.ValueSets.EditBypass01234.Edit_Failed_Data_Queried_And_Verified, record1.MotherHeightEditFlag["code"]);
+    }
+  }
 }

--- a/projects/BFDR.Tests/NatalityData_Should.cs
+++ b/projects/BFDR.Tests/NatalityData_Should.cs
@@ -1289,18 +1289,27 @@ namespace BFDR.Tests
       Assert.Equal("99", ije1.HIN);
       Assert.Equal("9", ije1.HFT);
       ije1.HFT = "5";
-      ije1.HIN = "7";
-      Assert.Equal("07", ije1.HIN);
       Assert.Equal("5", ije1.HFT);
-      ije1.HFT = "5";
-      ije1.HIN = "3";
+      Assert.Equal("00", ije1.HIN);
+      ije1.HIN = "1";
       Assert.Equal("5", ije1.HFT);
-      Assert.Equal("03", ije1.HIN);
+      Assert.Equal("01", ije1.HIN);
+      ije1.HFT = "6";
+      Assert.Equal("6", ije1.HFT);
+      Assert.Equal("01", ije1.HIN);
+      ije1.HIN = "2";
+      Assert.Equal("6", ije1.HFT);
+      Assert.Equal("02", ije1.HIN);
+      ije1.HIN = "99";
+      Assert.Equal("99", ije1.HIN);
+      Assert.Equal("9", ije1.HFT);
       // Edit Flag
       Assert.Equal("", ije1.HGT_BYPASS);
       ije1.HGT_BYPASS = "1";
       Assert.Equal("1", ije1.HGT_BYPASS);
       // FHIR translations
+      ije1.HFT = "5";
+      ije1.HIN = "3";
       BirthRecord record1 = new BirthRecord(ije1.ToRecord().ToXML());
       Assert.Equal(63, record1.MotherHeight);
       Assert.Equal(VR.ValueSets.EditBypass01234.Edit_Failed_Data_Queried_And_Verified, record1.MotherHeightEditFlag["code"]);

--- a/projects/BFDR/IJEBirth.cs
+++ b/projects/BFDR/IJEBirth.cs
@@ -1949,31 +1949,24 @@ namespace BFDR
         {
             get
             {
-                // not using NumericAllowingUnknown_Get due to the length of the ije field (ft) being then imposed on FHIR field (in)
-                // string height_ft = NumericAllowingUnknown_Get("HFT", "MotherHeight");
-                IJEField info = FieldInfo("HFT");
-                int? value = (int?)Record.GetType().GetProperty("MotherHeight").GetValue(record);
-                if (value == -1 || value == null) return new String('9', info.Length); // Explicitly set to unknown
+                int? value = record.MotherHeight;
+                if (value == -1 || value == null) return new String('9', 1); // Explicitly set to unknown
                 var valueString = (value / 12).ToString();
-                return Truncate(valueString, info.Length).PadLeft(info.Length, '0');
+                return Truncate(valueString, 1);
             }
             set
             {
-                if (value != "9" && !string.IsNullOrWhiteSpace(value))
+                // Support explicitly setting to unknown; note that this sets both HIN and HFT to unknown
+                if (value == "9" || string.IsNullOrWhiteSpace(value))
                 {
-                    if (!string.IsNullOrWhiteSpace(HIN) && HIN != "-1")
-                    {
-                        record.MotherHeight = int.Parse(value) * 12 + int.Parse(HIN);
-                    }
-                    else
-                    {
-                        record.MotherHeight = int.Parse(value);
-                    }
-                    record.MotherHeight = int.Parse(value) * 12;
+                    record.MotherHeight = -1;
                 }
                 else
                 {
-                    record.MotherHeight = -1;
+                    // Set the value for feet without changing the value for inches (if set)
+                    int hin = HIN == "99" ? 0 : int.Parse(HIN);
+                    int totalInches = int.Parse(value) * 12 + hin;
+                    record.MotherHeight = totalInches;
                 }
             }
         }
@@ -1984,30 +1977,24 @@ namespace BFDR
         {
             get
             {
-                // not using NumericAllowingUnknown_Get due to the length of the ije field (%12 in) being then imposed on FHIR field (total in)
-                // string height_in = NumericAllowingUnknown_Get("HIN", "MotherHeight");
-                IJEField info = FieldInfo("HIN");
-                int? value = (int?)Record.GetType().GetProperty("MotherHeight").GetValue(record);
-                if (value == -1 || value == null) return new String('9', info.Length); // Explicitly set to unknown
+                int? value = record.MotherHeight;
+                if (value == -1 || value == null) return new String('9', 2); // Explicitly set to unknown
                 var valueString = (value % 12).ToString();
-                return Truncate(valueString, info.Length).PadLeft(info.Length, '0');
+                return Truncate(valueString, 2).PadLeft(2, '0');
             }
             set
             {
-                if (value != "99" && !string.IsNullOrWhiteSpace(value))
+                // Support explicitly setting to unknown; note that this sets both HIN and HFT to unknown
+                if (value == "99" || string.IsNullOrWhiteSpace(value))
                 {
-                    if (!string.IsNullOrWhiteSpace(HFT) && HFT != "-1")
-                    {
-                        record.MotherHeight = int.Parse(value) + (int.Parse(HFT) * 12);
-                    }
-                    else
-                    {
-                        record.MotherHeight = int.Parse(value);
-                    }
+                    record.MotherHeight = -1;
                 }
                 else
                 {
-                    record.MotherHeight = -1;
+                    // Set the value for inches without changing the value for feet (if set)
+                    int hft = HFT == "9" ? 0 : int.Parse(HFT);
+                    int totalInches = hft * 12 + int.Parse(value);
+                    record.MotherHeight = totalInches;
                 }
             }
         }

--- a/projects/BFDR/IJEFetalDeath.cs
+++ b/projects/BFDR/IJEFetalDeath.cs
@@ -1324,31 +1324,24 @@ namespace BFDR
         {
             get
             {
-                // not using NumericAllowingUnknown_Get due to the length of the ije field (ft) being then imposed on FHIR field (in)
-                // string height_ft = NumericAllowingUnknown_Get("HFT", "MotherHeight");
-                IJEField info = FieldInfo("HFT");
-                int? value = (int?)Record.GetType().GetProperty("MotherHeight").GetValue(record);
-                if (value == -1 || value == null) return new String('9', info.Length); // Explicitly set to unknown
+                int? value = record.MotherHeight;
+                if (value == -1 || value == null) return new String('9', 1); // Explicitly set to unknown
                 var valueString = (value / 12).ToString();
-                return Truncate(valueString, info.Length).PadLeft(info.Length, '0');
+                return Truncate(valueString, 1);
             }
             set
             {
-                if (value != "9" && !string.IsNullOrWhiteSpace(value))
+                // Support explicitly setting to unknown; note that this sets both HIN and HFT to unknown
+                if (value == "9" || string.IsNullOrWhiteSpace(value))
                 {
-                    if (!string.IsNullOrWhiteSpace(HIN) && HIN != "-1")
-                    {
-                        record.MotherHeight = int.Parse(value) * 12 + int.Parse(HIN);
-                    }
-                    else
-                    {
-                        record.MotherHeight = int.Parse(value);
-                    }
-                    record.MotherHeight = int.Parse(value) * 12;
+                    record.MotherHeight = -1;
                 }
                 else
                 {
-                    record.MotherHeight = -1;
+                    // Set the value for feet without changing the value for inches (if set)
+                    int hin = HIN == "99" ? 0 : int.Parse(HIN);
+                    int totalInches = int.Parse(value) * 12 + hin;
+                    record.MotherHeight = totalInches;
                 }
             }
         }
@@ -1359,30 +1352,24 @@ namespace BFDR
         {
             get
             {
-                // not using NumericAllowingUnknown_Get due to the length of the ije field (%12 in) being then imposed on FHIR field (total in)
-                // string height_in = NumericAllowingUnknown_Get("HIN", "MotherHeight");
-                IJEField info = FieldInfo("HIN");
-                int? value = (int?)Record.GetType().GetProperty("MotherHeight").GetValue(record);
-                if (value == -1 || value == null) return new String('9', info.Length); // Explicitly set to unknown
+                int? value = record.MotherHeight;
+                if (value == -1 || value == null) return new String('9', 2); // Explicitly set to unknown
                 var valueString = (value % 12).ToString();
-                return Truncate(valueString, info.Length).PadLeft(info.Length, '0');
+                return Truncate(valueString, 2).PadLeft(2, '0');
             }
             set
             {
-                if (value != "99" && !string.IsNullOrWhiteSpace(value))
+                // Support explicitly setting to unknown; note that this sets both HIN and HFT to unknown
+                if (value == "99" || string.IsNullOrWhiteSpace(value))
                 {
-                    if (!string.IsNullOrWhiteSpace(HFT) && HFT != "-1")
-                    {
-                        record.MotherHeight = int.Parse(value) + (int.Parse(HFT) * 12);
-                    }
-                    else
-                    {
-                        record.MotherHeight = int.Parse(value);
-                    }
+                    record.MotherHeight = -1;
                 }
                 else
                 {
-                    record.MotherHeight = -1;
+                    // Set the value for inches without changing the value for feet (if set)
+                    int hft = HFT == "9" ? 0 : int.Parse(HFT);
+                    int totalInches = hft * 12 + int.Parse(value);
+                    record.MotherHeight = totalInches;
                 }
             }
         }


### PR DESCRIPTION
This pull request fixes issues with how the mother height fields are handled in IJE for both birth and fetal death by

1) Simplifying logic by refactoring conditional checks and accessing the FHIR record property directory
2) Correctly allowing height in inches and feet to be set separately
3) Adding or updating tests for correct data handling