### PR TITLE
fix(bfdr): fix gestational type and add test; add test for edit behavior

### DIFF
--- a/projects/BFDR.Tests/BirthRecord_Should.cs
+++ b/projects/BFDR.Tests/BirthRecord_Should.cs
@@ -938,6 +938,19 @@ namespace BFDR.Tests
       Assert.Equal("1988-09-05", rec.MotherDateOfBirth);
       rec.MotherDateOfBirth = "1990-08-29";
       Assert.Equal("1990-08-29", rec.MotherDateOfBirth);
+
+      // Make sure setter does not override edit flag
+      Dictionary<string, string> editDict = new();
+      editDict.Add("code", "abc");
+      editDict.Add("system", "example.com");
+      editDict.Add("display", "ABC");
+      editDict.Add("text", "A B C");
+      rec.MotherDateOfBirthEditFlag = editDict;
+      Assert.Equal(editDict, rec.MotherDateOfBirthEditFlag);
+      rec.MotherDateOfBirth = "1980-01-01";
+      Assert.Equal("1980-01-01", rec.MotherDateOfBirth);
+      Assert.Equal(editDict, rec.MotherDateOfBirthEditFlag);
+
       rec.MotherDateOfBirth = null;
       Assert.Equal(27, rec.MotherReportedAgeAtDelivery);
       rec.MotherReportedAgeAtDelivery = null;
@@ -3001,6 +3014,30 @@ namespace BFDR.Tests
       cc2.Add("display", "Edit Passed");
       Assert.Equal("0", birthRecord3.NumberOfPreviousCesareansEditFlagHelper);
       Assert.Equal(cc2, birthRecord3.NumberOfPreviousCesareansEditFlag);
+    }
+
+    [Fact]
+    public void TestGestationalAgeAtDeliveryIsQuantity()
+    {
+      BirthRecord birthRecord = new();
+
+      // Start by setting edit flag
+      Dictionary<string, string> editDict = new();
+      editDict.Add("code", "0off");
+      editDict.Add("system", "http://hl7.org/fhir/us/vr-common-library/CodeSystem/CodeSystem-vr-edit-flags");
+      editDict.Add("display", "Off");
+      birthRecord.GestationalAgeAtDeliveryEditFlag = editDict;
+      Assert.Equal(editDict, birthRecord.GestationalAgeAtDeliveryEditFlag);
+
+      // Set value as a Quantity
+      Dictionary<string, string> ageDict = new Dictionary<string, string>
+      {
+          { "value", "12.5" },
+          { "code", "d" }
+      };
+      birthRecord.GestationalAgeAtDelivery = ageDict;
+      Assert.Equal(ageDict["value"], birthRecord.GestationalAgeAtDelivery["value"]);
+      Assert.Equal("d", birthRecord.GestationalAgeAtDelivery["code"]);
     }
 
     [Fact]

--- a/projects/BFDR/NatalityRecord_submissionProperties.cs
+++ b/projects/BFDR/NatalityRecord_submissionProperties.cs
@@ -2183,6 +2183,7 @@ namespace BFDR
                 Date date = ConvertToDate(value);
                 if (date != null)
                 {
+                    // Need to keep any existing extension that could be there
                     date.Extension = this.Mother?.BirthDateElement?.Extension ?? date.Extension;
                     this.Mother.BirthDateElement = date;
                 }
@@ -2415,6 +2416,7 @@ namespace BFDR
                 Date date = ConvertToDate(value);
                 if (date != null)
                 {
+                    // Need to keep any existing extension that could be there
                     date.Extension = this.Father?.BirthDateElement?.Extension ?? date.Extension;
                     this.Father.BirthDateElement = date;
                 }
@@ -5851,7 +5853,7 @@ namespace BFDR
                 Observation obs = GetOrCreateObservation("11884-4", CodeSystems.LOINC, "Gestational age at delivery", BFDR.ProfileURL.ObservationGestationalAgeAtDelivery, GESTATIONAL_AGE, Mother.Id);
                 if (obs.Value == null)
                 {
-                    obs.Value = new CodeableConcept();
+                    obs.Value = new Quantity();
                 }
                 obs.Value?.Extension.RemoveAll(ext => ext.Url == VR.ExtensionURL.BypassEditFlag);
                 Extension editFlag = new Extension(VR.ExtensionURL.BypassEditFlag, DictToCodeableConcept(value));


### PR DESCRIPTION
Addresses both NVSS-802 and NVSS-803.

This PR:
- Adds a test for MotherDateOfBirth/MotherDateOfBirthEditFlag that ensures edit flag overwriting behavior is consistent with VRDR
- Adds some code comments explicitly calling out the fact that extensions (e.g. edit) are being retained
- Fixes GestationalAgeAtDeliveryEditFlag setting the value to a CodableConcept instead of a Quantity
- Adds a test for the GestationalAgeAtDeliveryEditFlag fix