### PR TITLE
fix(bfdr): update changelog fileinformation

### DIFF
--- a/projects/BFDR/BFDR.csproj
+++ b/projects/BFDR/BFDR.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-preview.15</Version>
+    <Version>1.0.0-preview.16</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>BFDR</RootNamespace>
     <DocumentationFile>BFDR.xml</DocumentationFile>

--- a/projects/BFDR/CHANGELOG.md
+++ b/projects/BFDR/CHANGELOG.md
@@ -3,11 +3,12 @@
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
 <a name="1.0.0-preview.16"></a>
-## [1.0.0-preview.16]() (2026-01-14)
+## [1.0.0-preview.16]() (2026-01-21)
 
 ### Fixes
 * Fix resource condition by adding the missing profile information
 * Update connectathon record to include more realistic data
+* Fix issue related to BPLACE when value set is other
 
 <a name="1.0.0-preview.15"></a>
 ## [1.0.0-preview.15]() (2025-12-15)


### PR DESCRIPTION
Fixes:

- Add the prefix "FCOD_" to some of the fetal death initiating cause or condition codes 

- Add meta profile to the condition resource 

- Apply the correct code system when the fetal death initiating cause or condition starts with FCOD_

- Update the connect-a-thon record with realistic data

- Fix the issue related to the BPLACE when the value set entered is Other